### PR TITLE
[MNT] fix `pre-commit` failures on `main`

### DIFF
--- a/docs/source/tutorials/stallion.ipynb
+++ b/docs/source/tutorials/stallion.ipynb
@@ -979,7 +979,7 @@
     "    # reduce learning rate if no improvement in validation loss after x epochs\n",
     "    # reduce_on_plateau_patience=1000,\n",
     ")\n",
-    "print(f\"Number of parameters in network: {tft.size()/1e3:.1f}k\")"
+    "print(f\"Number of parameters in network: {tft.size() / 1e3:.1f}k\")"
    ]
   },
   {
@@ -1138,7 +1138,7 @@
     "    optimizer=\"Ranger\",\n",
     "    reduce_on_plateau_patience=4,\n",
     ")\n",
-    "print(f\"Number of parameters in network: {tft.size()/1e3:.1f}k\")"
+    "print(f\"Number of parameters in network: {tft.size() / 1e3:.1f}k\")"
    ]
   },
   {

--- a/examples/ar.py
+++ b/examples/ar.py
@@ -85,7 +85,7 @@ deepar = DeepAR.from_dataset(
     log_val_interval=3,
     # reduce_on_plateau_patience=3,
 )
-print(f"Number of parameters in network: {deepar.size()/1e3:.1f}k")
+print(f"Number of parameters in network: {deepar.size() / 1e3:.1f}k")
 
 # # find optimal learning rate
 # deepar.hparams.log_interval = -1

--- a/examples/nbeats.py
+++ b/examples/nbeats.py
@@ -65,7 +65,7 @@ trainer = pl.Trainer(
 net = NBeats.from_dataset(
     training, learning_rate=3e-2, log_interval=10, log_val_interval=1, log_gradient_flow=False, weight_decay=1e-2
 )
-print(f"Number of parameters in network: {net.size()/1e3:.1f}k")
+print(f"Number of parameters in network: {net.size() / 1e3:.1f}k")
 
 # # find optimal learning rate
 # # remove logging and artificial epoch size

--- a/examples/stallion.py
+++ b/examples/stallion.py
@@ -119,7 +119,7 @@ tft = TemporalFusionTransformer.from_dataset(
     log_val_interval=1,
     reduce_on_plateau_patience=3,
 )
-print(f"Number of parameters in network: {tft.size()/1e3:.1f}k")
+print(f"Number of parameters in network: {tft.size() / 1e3:.1f}k")
 
 # # find optimal learning rate
 # # remove logging and artificial epoch size

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -103,7 +103,7 @@ def check_for_nonfinite(tensor: torch.Tensor, names: Union[str, List[str]]) -> t
     for name, na in zip(names, nans):
         if na > 0:
             raise ValueError(
-                f"{na} ({na/tensor.size(0):.2%}) of {name} "
+                f"{na} ({na / tensor.size(0):.2%}) of {name} "
                 "values were found to be NA or infinite (even after encoding). NA values are not allowed "
                 "`allow_missing_timesteps` refers to missing rows, not to missing values. Possible strategies to "
                 f"fix the issue are (a) dropping the variable {name}, "


### PR DESCRIPTION
Cleaned up the offending items so `pre-commit` passes on main.

Fixes https://github.com/sktime/pytorch-forecasting/issues/1695

### Description

This quick fix sorts out the files causing `pre-commit` to fail on `main`, so it can run again.

### Checklist

- [x] Linked issues (if existing)
- [x] Amended changelog for large changes (and added myself there as contributor)
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
