### PR TITLE
[MNT]`black` doesn't have `extras` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ dev = [
   # jupyter notebook
   "ipykernel",
   "nbconvert",
-  "black[extras]",
+  "black[jupyter]",
   # documentatation
   "sphinx",
   "pydata-sphinx-theme",


### PR DESCRIPTION
This PR adds the correct dependency for `black` jupyter instead of `extras` as it doesn't have that.