### PR TITLE
[MNT] `ruff` linting - allow use of assert (S101)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ extend-ignore = [
   "C408", # Unnecessary dict call - rewrite as a literal.
   "C409", # Unnecessary list passed to tuple() - rewrite as a tuple literal.
   "F401", # unused imports
+  "S101", # use of assert
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
Currently, pre-commit trips over uses of assert which exist in non-test code across the code base.

This is often discouraged, but a de-facto part of the current code base, so for how we should simply skip the corresponding linting rule.