### PR TITLE
[MNT] CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# The file specifies framework level core developers for automated review requests
+
+* @benheid @fkiraly @fnhirwa @geetu040 @jdb78 @pranavvp16 @XinyuWuu @yarnabrina


### PR DESCRIPTION
This PR adds a CODEOWNERS file, which ensures that maintainers are pinged when a PR is opened.

I have included from among `sktime` and `pytorch-forecasting` maintainers those that have contributed to `pytorch-forecasting` more than occasionally - please let me know if you prefer not to be on this list.