### PR TITLE
[ENH] extend package author attribution requirement in license to present

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 THE MIT License
 
-Copyright 2020 Jan Beitner
+Copyright (c) 2020 - present, the pytorch-forecasting developers
+Copyright (c) 2020 Jan Beitner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR extends the copyright to the present.

The package remains, of course, permissive license.
The impact is a required authorship attribution to "pytorch-forecasting developers" in any copied code.