### PR TITLE
[MNT] update linting: limit line length to 88, add `isort`

### DIFF
--- a/build_tools/changelog.py
+++ b/build_tools/changelog.py
@@ -62,7 +62,9 @@ def fetch_latest_release():  # noqa: D103
     """
     import httpx
 
-    response = httpx.get(f"{GITHUB_REPOS}/{OWNER}/{REPO}/releases/latest", headers=HEADERS)
+    response = httpx.get(
+        f"{GITHUB_REPOS}/{OWNER}/{REPO}/releases/latest", headers=HEADERS
+    )
 
     if response.status_code == 200:
         return response.json()
@@ -91,7 +93,9 @@ def fetch_pull_requests_since_last_release() -> list[dict]:
     all_pulls = []
     while not is_exhausted:
         pulls = fetch_merged_pull_requests(page=page)
-        all_pulls.extend([p for p in pulls if parser.parse(p["merged_at"]) > published_at])
+        all_pulls.extend(
+            [p for p in pulls if parser.parse(p["merged_at"]) > published_at]
+        )
         is_exhausted = any(parser.parse(p["updated_at"]) < published_at for p in pulls)
         page += 1
     return all_pulls
@@ -101,7 +105,9 @@ def github_compare_tags(tag_left: str, tag_right: str = "HEAD"):
     """Compare commit between two tags."""
     import httpx
 
-    response = httpx.get(f"{GITHUB_REPOS}/{OWNER}/{REPO}/compare/{tag_left}...{tag_right}")
+    response = httpx.get(
+        f"{GITHUB_REPOS}/{OWNER}/{REPO}/compare/{tag_left}...{tag_right}"
+    )
     if response.status_code == 200:
         return response.json()
     else:
@@ -135,7 +141,9 @@ def assign_prs(prs, categs: list[dict[str, list[str]]]):
     #             if any(l.startswith("module") for l in pr_labels):
     #                 print(i, pr_labels)
 
-    assigned["Other"] = list(set(range(len(prs))) - {i for _, j in assigned.items() for i in j})
+    assigned["Other"] = list(
+        set(range(len(prs))) - {i for _, j in assigned.items() for i in j}
+    )
 
     return assigned
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -145,7 +145,9 @@ html_theme_options = {
     "navbar_end": ["navbar-icon-links.html", "search-field.html"],
     "show_nav_level": 2,
     "header_links_before_dropdown": 10,
-    "external_links": [{"name": "GitHub", "url": "https://github.com/sktime/pytorch-forecasting"}],
+    "external_links": [
+        {"name": "GitHub", "url": "https://github.com/sktime/pytorch-forecasting"}
+    ],
 }
 
 html_sidebars = {

--- a/examples/ar.py
+++ b/examples/ar.py
@@ -51,14 +51,20 @@ validation = TimeSeriesDataSet.from_dataset(
     stop_randomization=True,
 )
 batch_size = 64
-train_dataloader = training.to_dataloader(train=True, batch_size=batch_size, num_workers=0)
-val_dataloader = validation.to_dataloader(train=False, batch_size=batch_size, num_workers=0)
+train_dataloader = training.to_dataloader(
+    train=True, batch_size=batch_size, num_workers=0
+)
+val_dataloader = validation.to_dataloader(
+    train=False, batch_size=batch_size, num_workers=0
+)
 
 # save datasets
 training.save("training.pkl")
 validation.save("validation.pkl")
 
-early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=1e-4, patience=5, verbose=False, mode="min")
+early_stop_callback = EarlyStopping(
+    monitor="val_loss", min_delta=1e-4, patience=5, verbose=False, mode="min"
+)
 lr_logger = LearningRateMonitor()
 
 trainer = pl.Trainer(

--- a/examples/nbeats.py
+++ b/examples/nbeats.py
@@ -42,13 +42,21 @@ training = TimeSeriesDataSet(
     add_target_scales=False,
 )
 
-validation = TimeSeriesDataSet.from_dataset(training, data, min_prediction_idx=training_cutoff)
+validation = TimeSeriesDataSet.from_dataset(
+    training, data, min_prediction_idx=training_cutoff
+)
 batch_size = 128
-train_dataloader = training.to_dataloader(train=True, batch_size=batch_size, num_workers=2)
-val_dataloader = validation.to_dataloader(train=False, batch_size=batch_size, num_workers=2)
+train_dataloader = training.to_dataloader(
+    train=True, batch_size=batch_size, num_workers=2
+)
+val_dataloader = validation.to_dataloader(
+    train=False, batch_size=batch_size, num_workers=2
+)
 
 
-early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=1e-4, patience=10, verbose=False, mode="min")
+early_stop_callback = EarlyStopping(
+    monitor="val_loss", min_delta=1e-4, patience=10, verbose=False, mode="min"
+)
 trainer = pl.Trainer(
     max_epochs=100,
     accelerator="auto",
@@ -63,7 +71,12 @@ trainer = pl.Trainer(
 
 
 net = NBeats.from_dataset(
-    training, learning_rate=3e-2, log_interval=10, log_val_interval=1, log_gradient_flow=False, weight_decay=1e-2
+    training,
+    learning_rate=3e-2,
+    log_interval=10,
+    log_val_interval=1,
+    log_gradient_flow=False,
+    weight_decay=1e-2,
 )
 print(f"Number of parameters in network: {net.size() / 1e3:.1f}k")
 

--- a/examples/stallion.py
+++ b/examples/stallion.py
@@ -7,10 +7,16 @@ from lightning.pytorch.loggers import TensorBoardLogger
 import numpy as np
 from pandas.core.common import SettingWithCopyWarning
 
-from pytorch_forecasting import GroupNormalizer, TemporalFusionTransformer, TimeSeriesDataSet
+from pytorch_forecasting import (
+    GroupNormalizer,
+    TemporalFusionTransformer,
+    TimeSeriesDataSet,
+)
 from pytorch_forecasting.data.examples import get_stallion_data
 from pytorch_forecasting.metrics import QuantileLoss
-from pytorch_forecasting.models.temporal_fusion_transformer.tuning import optimize_hyperparameters
+from pytorch_forecasting.models.temporal_fusion_transformer.tuning import (
+    optimize_hyperparameters,
+)
 
 warnings.simplefilter("error", category=SettingWithCopyWarning)
 
@@ -22,8 +28,12 @@ data["log_volume"] = np.log(data.volume + 1e-8)
 
 data["time_idx"] = data["date"].dt.year * 12 + data["date"].dt.month
 data["time_idx"] -= data["time_idx"].min()
-data["avg_volume_by_sku"] = data.groupby(["time_idx", "sku"], observed=True).volume.transform("mean")
-data["avg_volume_by_agency"] = data.groupby(["time_idx", "agency"], observed=True).volume.transform("mean")
+data["avg_volume_by_sku"] = data.groupby(
+    ["time_idx", "sku"], observed=True
+).volume.transform("mean")
+data["avg_volume_by_agency"] = data.groupby(
+    ["time_idx", "agency"], observed=True
+).volume.transform("mean")
 # data = data[lambda x: (x.sku == data.iloc[0]["sku"]) & (x.agency == data.iloc[0]["agency"])]
 special_days = [
     "easter_day",
@@ -39,7 +49,9 @@ special_days = [
     "beer_capital",
     "music_fest",
 ]
-data[special_days] = data[special_days].apply(lambda x: x.map({0: "", 1: x.name})).astype("category")
+data[special_days] = (
+    data[special_days].apply(lambda x: x.map({0: "", 1: x.name})).astype("category")
+)
 
 training_cutoff = data["time_idx"].max() - 6
 max_encoder_length = 36
@@ -50,14 +62,17 @@ training = TimeSeriesDataSet(
     time_idx="time_idx",
     target="volume",
     group_ids=["agency", "sku"],
-    min_encoder_length=max_encoder_length // 2,  # allow encoder lengths from 0 to max_prediction_length
+    min_encoder_length=max_encoder_length
+    // 2,  # allow encoder lengths from 0 to max_prediction_length
     max_encoder_length=max_encoder_length,
     min_prediction_length=1,
     max_prediction_length=max_prediction_length,
     static_categoricals=["agency", "sku"],
     static_reals=["avg_population_2017", "avg_yearly_household_income_2017"],
     time_varying_known_categoricals=["special_days", "month"],
-    variable_groups={"special_days": special_days},  # group of categorical variables can be treated as one variable
+    variable_groups={
+        "special_days": special_days
+    },  # group of categorical variables can be treated as one variable
     time_varying_known_reals=["time_idx", "price_regular", "discount_in_percent"],
     time_varying_unknown_categoricals=[],
     time_varying_unknown_reals=[
@@ -78,17 +93,25 @@ training = TimeSeriesDataSet(
 )
 
 
-validation = TimeSeriesDataSet.from_dataset(training, data, predict=True, stop_randomization=True)
+validation = TimeSeriesDataSet.from_dataset(
+    training, data, predict=True, stop_randomization=True
+)
 batch_size = 64
-train_dataloader = training.to_dataloader(train=True, batch_size=batch_size, num_workers=0)
-val_dataloader = validation.to_dataloader(train=False, batch_size=batch_size, num_workers=0)
+train_dataloader = training.to_dataloader(
+    train=True, batch_size=batch_size, num_workers=0
+)
+val_dataloader = validation.to_dataloader(
+    train=False, batch_size=batch_size, num_workers=0
+)
 
 
 # save datasets
 training.save("t raining.pkl")
 validation.save("validation.pkl")
 
-early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=1e-4, patience=10, verbose=False, mode="min")
+early_stop_callback = EarlyStopping(
+    monitor="val_loss", min_delta=1e-4, patience=10, verbose=False, mode="min"
+)
 lr_logger = LearningRateMonitor()
 logger = TensorBoardLogger(log_graph=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,63 +1,3 @@
-[tool.ruff]
-line-length = 120
-exclude = [
-  "docs/build/",
-  "node_modules/",
-  ".eggs/",
-  "versioneer.py",
-  "venv/",
-  ".venv/",
-  ".git/",
-  ".history/",
-]
-
-[tool.ruff.lint]
-select = ["E", "F", "W", "C4", "S"]
-extend-ignore = [
-  "E203", # space before : (needed for how black formats slicing)
-  "E402", # module level import not at top of file
-  "E731", # do not assign a lambda expression, use a def
-  "E741", # ignore not easy to read variables like i l I etc.
-  "C406", # Unnecessary list literal - rewrite as a dict literal.
-  "C408", # Unnecessary dict call - rewrite as a literal.
-  "C409", # Unnecessary list passed to tuple() - rewrite as a tuple literal.
-  "F401", # unused imports
-  "S101", # use of assert
-]
-
-[tool.ruff.lint.isort]
-known-first-party = ["pytorch_forecasting"]
-combine-as-imports = true
-force-sort-within-sections = true
-
-[tool.black]
-line-length = 120
-include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-  )/
-  | docs/build/
-  | node_modules/
-  | venve/
-  | .venv/
-)
-'''
-
-[tool.nbqa.mutate]
-ruff = 1
-black = 1
-
 [project]
 name = "pytorch-forecasting"
 readme = "README.md"         # Markdown files are supported
@@ -184,3 +124,67 @@ build-backend = "setuptools.build_meta"
 requires = [
   "setuptools>=70.0.0",
 ]
+
+[tool.ruff]
+line-length = 88
+exclude = [
+  "docs/build/",
+  "node_modules/",
+  ".eggs/",
+  "versioneer.py",
+  "venv/",
+  ".venv/",
+  ".git/",
+  ".history/",
+]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "C4", "S"]
+extend-select = [
+  "I", # isort
+  "C4", # https://pypi.org/project/flake8-comprehensions
+]
+extend-ignore = [
+  "E203", # space before : (needed for how black formats slicing)
+  "E402", # module level import not at top of file
+  "E731", # do not assign a lambda expression, use a def
+  "E741", # ignore not easy to read variables like i l I etc.
+  "C406", # Unnecessary list literal - rewrite as a dict literal.
+  "C408", # Unnecessary dict call - rewrite as a literal.
+  "C409", # Unnecessary list passed to tuple() - rewrite as a tuple literal.
+  "F401", # unused imports
+  "S101", # use of assert
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["pytorch_forecasting"]
+combine-as-imports = true
+force-sort-within-sections = true
+
+[tool.black]
+line-length = 88
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )/
+  | docs/build/
+  | node_modules/
+  | venve/
+  | .venv/
+)
+'''
+
+[tool.nbqa.mutate]
+ruff = 1
+black = 1

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -2,12 +2,12 @@
 Encoders for encoding categorical variables and scaling continuous data.
 """
 
-from typing import Any, Callable, Dict, Iterable, List, Tuple, Union, Optional
+from copy import deepcopy
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 import warnings
 
 import numpy as np
 import pandas as pd
-from copy import deepcopy
 from sklearn.base import BaseEstimator, TransformerMixin
 import torch
 from torch.distributions import constraints

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -11,7 +11,13 @@ from copy import deepcopy
 from sklearn.base import BaseEstimator, TransformerMixin
 import torch
 from torch.distributions import constraints
-from torch.distributions.transforms import ExpTransform, PowerTransform, SigmoidTransform, Transform, _clipped_sigmoid
+from torch.distributions.transforms import (
+    ExpTransform,
+    PowerTransform,
+    SigmoidTransform,
+    Transform,
+    _clipped_sigmoid,
+)
 import torch.nn.functional as F
 from torch.nn.utils import rnn
 
@@ -133,17 +139,46 @@ class TransformMixIn:
     # dict of PyTorch functions that transforms and inversely transforms values.
     # inverse entry required if "reverse" is not the "inverse" of "forward".
     TRANSFORMATIONS = {
-        "log": dict(forward=_clipped_log, reverse=torch.exp, inverse_torch=ExpTransform()),
-        "log1p": dict(forward=torch.log1p, reverse=torch.exp, inverse=torch.expm1, inverse_torch=Expm1Transform()),
-        "logit": dict(forward=_clipped_logit, reverse=_clipped_sigmoid, inverse_torch=SigmoidTransform()),
-        "count": dict(forward=_plus_one, reverse=F.softplus, inverse=_minus_one, inverse_torch=MinusOneTransform()),
-        "softplus": dict(forward=softplus_inv, reverse=F.softplus, inverse_torch=SoftplusTransform()),
-        "relu": dict(forward=_identity, reverse=F.relu, inverse=_identity, inverse_torch=ReLuTransform()),
-        "sqrt": dict(forward=torch.sqrt, reverse=_square, inverse_torch=PowerTransform(exponent=2.0)),
+        "log": dict(
+            forward=_clipped_log, reverse=torch.exp, inverse_torch=ExpTransform()
+        ),
+        "log1p": dict(
+            forward=torch.log1p,
+            reverse=torch.exp,
+            inverse=torch.expm1,
+            inverse_torch=Expm1Transform(),
+        ),
+        "logit": dict(
+            forward=_clipped_logit,
+            reverse=_clipped_sigmoid,
+            inverse_torch=SigmoidTransform(),
+        ),
+        "count": dict(
+            forward=_plus_one,
+            reverse=F.softplus,
+            inverse=_minus_one,
+            inverse_torch=MinusOneTransform(),
+        ),
+        "softplus": dict(
+            forward=softplus_inv, reverse=F.softplus, inverse_torch=SoftplusTransform()
+        ),
+        "relu": dict(
+            forward=_identity,
+            reverse=F.relu,
+            inverse=_identity,
+            inverse_torch=ReLuTransform(),
+        ),
+        "sqrt": dict(
+            forward=torch.sqrt,
+            reverse=_square,
+            inverse_torch=PowerTransform(exponent=2.0),
+        ),
     }
 
     @classmethod
-    def get_transform(cls, transformation: Union[str, Dict[str, Callable]]) -> Dict[str, Callable]:
+    def get_transform(
+        cls, transformation: Union[str, Dict[str, Callable]]
+    ) -> Dict[str, Callable]:
         """Return transformation functions.
 
         Args:
@@ -186,7 +221,9 @@ class TransformMixIn:
             y = np.asarray(y)
         return y
 
-    def inverse_preprocess(self, y: Union[pd.Series, np.ndarray, torch.Tensor]) -> Union[np.ndarray, torch.Tensor]:
+    def inverse_preprocess(
+        self, y: Union[pd.Series, np.ndarray, torch.Tensor]
+    ) -> Union[np.ndarray, torch.Tensor]:
         """
         Inverse preprocess re-scaled data (e.g. take exp).
 
@@ -207,7 +244,9 @@ class TransformMixIn:
         return y
 
 
-class NaNLabelEncoder(InitialParameterRepresenterMixIn, BaseEstimator, TransformerMixin, TransformMixIn):
+class NaNLabelEncoder(
+    InitialParameterRepresenterMixIn, BaseEstimator, TransformerMixin, TransformMixIn
+):
     """
     Labelencoder that can optionally always encode nan and unknown classes (in transform) as class ``0``
     """
@@ -251,7 +290,8 @@ class NaNLabelEncoder(InitialParameterRepresenterMixIn, BaseEstimator, Transform
             bool: True if series is numeric
         """
         return y.dtype.kind in "bcif" or (
-            isinstance(y.dtype, pd.CategoricalDtype) and y.cat.categories.dtype.kind in "bcif"
+            isinstance(y.dtype, pd.CategoricalDtype)
+            and y.cat.categories.dtype.kind in "bcif"
         )
 
     def fit(self, y: pd.Series, overwrite: bool = False):
@@ -292,7 +332,11 @@ class NaNLabelEncoder(InitialParameterRepresenterMixIn, BaseEstimator, Transform
         return self
 
     def transform(
-        self, y: Iterable, return_norm: bool = False, target_scale=None, ignore_na: bool = False
+        self,
+        y: Iterable,
+        return_norm: bool = False,
+        target_scale=None,
+        ignore_na: bool = False,
     ) -> Union[torch.Tensor, np.ndarray]:
         """
         Encode iterable with integers.
@@ -387,7 +431,9 @@ class NaNLabelEncoder(InitialParameterRepresenterMixIn, BaseEstimator, Transform
         return np.zeros(2, dtype=np.float64)
 
 
-class TorchNormalizer(InitialParameterRepresenterMixIn, BaseEstimator, TransformerMixin, TransformMixIn):
+class TorchNormalizer(
+    InitialParameterRepresenterMixIn, BaseEstimator, TransformerMixin, TransformMixIn
+):
     """
     Basic target transformer that can be fit also on torch tensors.
     """
@@ -425,11 +471,17 @@ class TorchNormalizer(InitialParameterRepresenterMixIn, BaseEstimator, Transform
                   can be defined to provide a torch distribution transform for inverse transformations.
         """
         self.method = method
-        assert method in ["standard", "robust", "identity"], f"method has invalid value {method}"
+        assert method in [
+            "standard",
+            "robust",
+            "identity",
+        ], f"method has invalid value {method}"
         self.center = center
         self.transformation = transformation
         self.method_kwargs = method_kwargs
-        self._method_kwargs = deepcopy(method_kwargs) if method_kwargs is not None else {}
+        self._method_kwargs = (
+            deepcopy(method_kwargs) if method_kwargs is not None else {}
+        )
 
     def get_parameters(self, *args, **kwargs) -> torch.Tensor:
         """
@@ -438,7 +490,9 @@ class TorchNormalizer(InitialParameterRepresenterMixIn, BaseEstimator, Transform
         Returns:
             torch.Tensor: First element is center of data and second is scale
         """
-        return torch.stack([torch.as_tensor(self.center_), torch.as_tensor(self.scale_)], dim=-1)
+        return torch.stack(
+            [torch.as_tensor(self.center_), torch.as_tensor(self.scale_)], dim=-1
+        )
 
     def fit(self, y: Union[pd.Series, np.ndarray, torch.Tensor]):
         """
@@ -455,7 +509,9 @@ class TorchNormalizer(InitialParameterRepresenterMixIn, BaseEstimator, Transform
         return self
 
     def _set_parameters(
-        self, y_center: Union[pd.Series, np.ndarray, torch.Tensor], y_scale: Union[pd.Series, np.ndarray, torch.Tensor]
+        self,
+        y_center: Union[pd.Series, np.ndarray, torch.Tensor],
+        y_scale: Union[pd.Series, np.ndarray, torch.Tensor],
     ):
         """
         Calculate parameters for scale and center based on input timeseries
@@ -498,17 +554,31 @@ class TorchNormalizer(InitialParameterRepresenterMixIn, BaseEstimator, Transform
 
         elif self.method == "robust":
             if isinstance(y_center, torch.Tensor):
-                self.center_ = y_center.quantile(self._method_kwargs.get("center", 0.5), dim=-1)
+                self.center_ = y_center.quantile(
+                    self._method_kwargs.get("center", 0.5), dim=-1
+                )
                 q_75 = y_scale.quantile(self._method_kwargs.get("upper", 0.75), dim=-1)
                 q_25 = y_scale.quantile(self._method_kwargs.get("lower", 0.25), dim=-1)
             elif isinstance(y_center, np.ndarray):
-                self.center_ = np.percentile(y_center, self._method_kwargs.get("center", 0.5) * 100, axis=-1)
-                q_75 = np.percentile(y_scale, self._method_kwargs.get("upper", 0.75) * 100, axis=-1)
-                q_25 = np.percentile(y_scale, self._method_kwargs.get("lower", 0.25) * 100, axis=-1)
+                self.center_ = np.percentile(
+                    y_center, self._method_kwargs.get("center", 0.5) * 100, axis=-1
+                )
+                q_75 = np.percentile(
+                    y_scale, self._method_kwargs.get("upper", 0.75) * 100, axis=-1
+                )
+                q_25 = np.percentile(
+                    y_scale, self._method_kwargs.get("lower", 0.25) * 100, axis=-1
+                )
             else:
-                self.center_ = np.percentile(y_center, self._method_kwargs.get("center", 0.5) * 100, axis=-1)
-                q_75 = np.percentile(y_scale, self._method_kwargs.get("upper", 0.75) * 100)
-                q_25 = np.percentile(y_scale, self._method_kwargs.get("lower", 0.25) * 100)
+                self.center_ = np.percentile(
+                    y_center, self._method_kwargs.get("center", 0.5) * 100, axis=-1
+                )
+                q_75 = np.percentile(
+                    y_scale, self._method_kwargs.get("upper", 0.75) * 100
+                )
+                q_25 = np.percentile(
+                    y_scale, self._method_kwargs.get("lower", 0.25) * 100
+                )
             self.scale_ = (q_75 - q_25) / 2.0 + eps
         if not self.center and self.method != "identity":
             self.scale_ = self.center_
@@ -529,7 +599,10 @@ class TorchNormalizer(InitialParameterRepresenterMixIn, BaseEstimator, Transform
         y: Union[pd.Series, np.ndarray, torch.Tensor],
         return_norm: bool = False,
         target_scale: torch.Tensor = None,
-    ) -> Union[Tuple[Union[np.ndarray, torch.Tensor], np.ndarray], Union[np.ndarray, torch.Tensor]]:
+    ) -> Union[
+        Tuple[Union[np.ndarray, torch.Tensor], np.ndarray],
+        Union[np.ndarray, torch.Tensor],
+    ]:
         """
         Rescale data.
 
@@ -658,7 +731,12 @@ class EncoderNormalizer(TorchNormalizer):
                   can be defined to provide a torch distribution transform for inverse transformations.
         """
         method_kwargs = deepcopy(method_kwargs) if method_kwargs is not None else {}
-        super().__init__(method=method, center=center, transformation=transformation, method_kwargs=method_kwargs)
+        super().__init__(
+            method=method,
+            center=center,
+            transformation=transformation,
+            method_kwargs=method_kwargs,
+        )
         self.max_length = max_length
 
     def fit(self, y: Union[pd.Series, np.ndarray, torch.Tensor]):
@@ -675,7 +753,9 @@ class EncoderNormalizer(TorchNormalizer):
         if self.max_length is None:
             y_center = y_scale = self.preprocess(y)
         elif isinstance(self.max_length, int):
-            y_center = y_scale = self.preprocess(self._slice(y, slice(-self.max_length, None)))
+            y_center = y_scale = self.preprocess(
+                self._slice(y, slice(-self.max_length, None))
+            )
         else:
             y = self.preprocess(self._slice(y, slice(-max(self.max_length), None)))
             if np.argmax(self.max_length) == 0:
@@ -771,7 +851,12 @@ class GroupNormalizer(TorchNormalizer):
         self._groups = list(groups) if groups is not None else []
         self.scale_by_group = scale_by_group
         method_kwargs = deepcopy(method_kwargs) if method_kwargs is not None else {}
-        super().__init__(method=method, center=center, transformation=transformation, method_kwargs=method_kwargs)
+        super().__init__(
+            method=method,
+            center=center,
+            transformation=transformation,
+            method_kwargs=method_kwargs,
+        )
 
     def fit(self, y: pd.Series, X: pd.DataFrame):
         """
@@ -787,9 +872,14 @@ class GroupNormalizer(TorchNormalizer):
         y = self.preprocess(y)
         eps = np.finfo(np.float16).eps
         if len(self._groups) == 0:
-            assert not self.scale_by_group, "No groups are defined, i.e. `scale_by_group=[]`"
+            assert (
+                not self.scale_by_group
+            ), "No groups are defined, i.e. `scale_by_group=[]`"
             if self.method == "standard":
-                self.norm_ = {"center": np.mean(y), "scale": np.std(y) + eps}  # center and scale
+                self.norm_ = {
+                    "center": np.mean(y),
+                    "scale": np.std(y) + eps,
+                }  # center and scale
             else:
                 quantiles = np.quantile(
                     y,
@@ -833,7 +923,8 @@ class GroupNormalizer(TorchNormalizer):
                     .assign(
                         center=lambda x: x[self._method_kwargs.get("center", 0.5)],
                         scale=lambda x: (
-                            x[self._method_kwargs.get("upper", 0.75)] - x[self._method_kwargs.get("lower", 0.25)]
+                            x[self._method_kwargs.get("upper", 0.75)]
+                            - x[self._method_kwargs.get("lower", 0.25)]
                         )
                         / 2.0
                         + eps,
@@ -848,8 +939,12 @@ class GroupNormalizer(TorchNormalizer):
                     norm["center"] = 0.0
                     return norm
 
-                self.norm_ = {g: swap_parameters(norm) for g, norm in self.norm_.items()}
-            self.missing_ = {group: scales.median().to_dict() for group, scales in self.norm_.items()}
+                self.norm_ = {
+                    g: swap_parameters(norm) for g, norm in self.norm_.items()
+                }
+            self.missing_ = {
+                group: scales.median().to_dict() for group, scales in self.norm_.items()
+            }
 
         else:
             if self.method == "standard":
@@ -876,7 +971,8 @@ class GroupNormalizer(TorchNormalizer):
                     .assign(
                         center=lambda x: x[self._method_kwargs.get("center", 0.5)],
                         scale=lambda x: (
-                            x[self._method_kwargs.get("upper", 0.75)] - x[self._method_kwargs.get("lower", 0.25)]
+                            x[self._method_kwargs.get("upper", 0.75)]
+                            - x[self._method_kwargs.get("lower", 0.25)]
                         )
                         / 2.0
                         + eps,
@@ -888,8 +984,17 @@ class GroupNormalizer(TorchNormalizer):
             self.missing_ = self.norm_.median().to_dict()
 
         if (
-            (self.scale_by_group and any((self.norm_[group]["scale"] < 1e-7).any() for group in self._groups))
-            or (not self.scale_by_group and isinstance(self.norm_["scale"], float) and self.norm_["scale"] < 1e-7)
+            (
+                self.scale_by_group
+                and any(
+                    (self.norm_[group]["scale"] < 1e-7).any() for group in self._groups
+                )
+            )
+            or (
+                not self.scale_by_group
+                and isinstance(self.norm_["scale"], float)
+                and self.norm_["scale"] < 1e-7
+            )
             or (
                 not self.scale_by_group
                 and not isinstance(self.norm_["scale"], float)
@@ -938,7 +1043,11 @@ class GroupNormalizer(TorchNormalizer):
         raise NotImplementedError()
 
     def transform(
-        self, y: pd.Series, X: pd.DataFrame = None, return_norm: bool = False, target_scale: torch.Tensor = None
+        self,
+        y: pd.Series,
+        X: pd.DataFrame = None,
+        return_norm: bool = False,
+        target_scale: torch.Tensor = None,
     ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
         """
         Scale input data.
@@ -961,7 +1070,9 @@ class GroupNormalizer(TorchNormalizer):
             target_scale = self.get_norm(X)
         return super().transform(y, return_norm=return_norm, target_scale=target_scale)
 
-    def get_parameters(self, groups: Union[torch.Tensor, list, tuple], group_names: List[str] = None) -> np.ndarray:
+    def get_parameters(
+        self, groups: Union[torch.Tensor, list, tuple], group_names: List[str] = None
+    ) -> np.ndarray:
         """
         Get fitted scaling parameters for a given group.
 
@@ -982,7 +1093,9 @@ class GroupNormalizer(TorchNormalizer):
         else:
             # filter group names
             group_names = [name for name in group_names if name in self._groups]
-        assert len(group_names) == len(self._groups), "Passed groups and fitted do not match"
+        assert len(group_names) == len(
+            self._groups
+        ), "Passed groups and fitted do not match"
 
         if len(self._groups) == 0:
             params = np.array([self.norm_["center"], self.norm_["scale"]])
@@ -992,7 +1105,9 @@ class GroupNormalizer(TorchNormalizer):
                 try:
                     norm = norm * self.norm_[group_name].loc[group].to_numpy()
                 except KeyError:
-                    norm = norm * np.asarray([self.missing_[group_name][name] for name in self.names])
+                    norm = norm * np.asarray(
+                        [self.missing_[group_name][name] for name in self.names]
+                    )
             norm = np.power(norm, 1.0 / len(self._groups))
             params = norm
         else:
@@ -1013,7 +1128,9 @@ class GroupNormalizer(TorchNormalizer):
             pd.DataFrame: dataframe with scaling parameterswhere each row corresponds to the input dataframe
         """
         if len(self._groups) == 0:
-            norm = np.asarray([self.norm_["center"], self.norm_["scale"]]).reshape(1, -1)
+            norm = np.asarray([self.norm_["center"], self.norm_["scale"]]).reshape(
+                1, -1
+            )
         elif self.scale_by_group:
             norm = [
                 np.prod(
@@ -1030,7 +1147,13 @@ class GroupNormalizer(TorchNormalizer):
             ]
             norm = np.power(np.stack(norm, axis=1), 1.0 / len(self._groups))
         else:
-            norm = X[self._groups].set_index(self._groups).join(self.norm_).fillna(self.missing_).to_numpy()
+            norm = (
+                X[self._groups]
+                .set_index(self._groups)
+                .join(self.norm_)
+                .fillna(self.missing_)
+                .to_numpy()
+            )
         return norm
 
 
@@ -1048,7 +1171,9 @@ class MultiNormalizer(TorchNormalizer):
         """
         self.normalizers = normalizers
 
-    def fit(self, y: Union[pd.DataFrame, np.ndarray, torch.Tensor], X: pd.DataFrame = None):
+    def fit(
+        self, y: Union[pd.DataFrame, np.ndarray, torch.Tensor], X: pd.DataFrame = None
+    ):
         """
         Fit transformer, i.e. determine center and scale of data
 
@@ -1097,7 +1222,10 @@ class MultiNormalizer(TorchNormalizer):
         X: pd.DataFrame = None,
         return_norm: bool = False,
         target_scale: List[torch.Tensor] = None,
-    ) -> Union[List[Tuple[Union[np.ndarray, torch.Tensor], np.ndarray]], List[Union[np.ndarray, torch.Tensor]]]:
+    ) -> Union[
+        List[Tuple[Union[np.ndarray, torch.Tensor], np.ndarray]],
+        List[Union[np.ndarray, torch.Tensor]],
+    ]:
         """
         Scale input data.
 
@@ -1122,9 +1250,13 @@ class MultiNormalizer(TorchNormalizer):
             else:
                 scale = None
             if isinstance(normalizer, GroupNormalizer):
-                r = normalizer.transform(y[idx], X, return_norm=return_norm, target_scale=scale)
+                r = normalizer.transform(
+                    y[idx], X, return_norm=return_norm, target_scale=scale
+                )
             else:
-                r = normalizer.transform(y[idx], return_norm=return_norm, target_scale=scale)
+                r = normalizer.transform(
+                    y[idx], return_norm=return_norm, target_scale=scale
+                )
             res.append(r)
 
         if return_norm:
@@ -1132,7 +1264,9 @@ class MultiNormalizer(TorchNormalizer):
         else:
             return res
 
-    def __call__(self, data: Dict[str, Union[List[torch.Tensor], torch.Tensor]]) -> List[torch.Tensor]:
+    def __call__(
+        self, data: Dict[str, Union[List[torch.Tensor], torch.Tensor]]
+    ) -> List[torch.Tensor]:
         """
         Inverse transformation but with network output as input.
 
@@ -1145,7 +1279,12 @@ class MultiNormalizer(TorchNormalizer):
             List[torch.Tensor]: list of de-scaled data
         """
         denormalized = [
-            normalizer(dict(prediction=data["prediction"][idx], target_scale=data["target_scale"][idx]))
+            normalizer(
+                dict(
+                    prediction=data["prediction"][idx],
+                    target_scale=data["target_scale"][idx],
+                )
+            )
             for idx, normalizer in enumerate(self.normalizers)
         ]
         return denormalized
@@ -1157,7 +1296,10 @@ class MultiNormalizer(TorchNormalizer):
         Returns:
             List[torch.Tensor]: First element is center of data and second is scale
         """
-        return [normalizer.get_parameters(*args, **kwargs) for normalizer in self.normalizers]
+        return [
+            normalizer.get_parameters(*args, **kwargs)
+            for normalizer in self.normalizers
+        ]
 
     def __getattr__(self, name: str):
         """

--- a/pytorch_forecasting/data/examples.py
+++ b/pytorch_forecasting/data/examples.py
@@ -92,9 +92,9 @@ def generate_ar_data(
 
     # generate series
     x = np.arange(timesteps)[None, :]
-    series = (x * linear_trends + x**2 * quadratic_trends) * trend + seasonalities * np.sin(
-        2 * np.pi * seasonality * x / timesteps
-    )
+    series = (
+        x * linear_trends + x**2 * quadratic_trends
+    ) * trend + seasonalities * np.sin(2 * np.pi * seasonality * x / timesteps)
     # add noise
     series = levels * series * (1 + noise * np.random.normal(size=series.shape))
     if exp:

--- a/pytorch_forecasting/data/samplers.py
+++ b/pytorch_forecasting/data/samplers.py
@@ -40,12 +40,20 @@ class GroupedSampler(Sampler):
         # Since collections.abc.Iterable does not check for `__getitem__`, which
         # is one way for an object to be an iterable, we don't do an `isinstance`
         # check here.
-        if not isinstance(batch_size, int) or isinstance(batch_size, bool) or batch_size <= 0:
+        if (
+            not isinstance(batch_size, int)
+            or isinstance(batch_size, bool)
+            or batch_size <= 0
+        ):
             raise ValueError(
-                "batch_size should be a positive integer value, " "but got batch_size={}".format(batch_size)
+                "batch_size should be a positive integer value, "
+                "but got batch_size={}".format(batch_size)
             )
         if not isinstance(drop_last, bool):
-            raise ValueError("drop_last should be a boolean value, but got " "drop_last={}".format(drop_last))
+            raise ValueError(
+                "drop_last should be a boolean value, but got "
+                "drop_last={}".format(drop_last)
+            )
         self.sampler = sampler
         self.batch_size = batch_size
         self.drop_last = drop_last
@@ -78,7 +86,9 @@ class GroupedSampler(Sampler):
             if self.drop_last:
                 self._group_sizes[name] = len(group) // self.batch_size
             else:
-                self._group_sizes[name] = (len(group) + self.batch_size - 1) // self.batch_size
+                self._group_sizes[name] = (
+                    len(group) + self.batch_size - 1
+                ) // self.batch_size
             if self._group_sizes[name] == 0:
                 self._group_sizes[name] = 1
                 warns.append(name)
@@ -90,9 +100,13 @@ class GroupedSampler(Sampler):
             )
         # create index from which can be sampled: index is equal to number of batches
         # associate index with prediction time
-        self._group_index = np.repeat(list(self._group_sizes.keys()), list(self._group_sizes.values()))
+        self._group_index = np.repeat(
+            list(self._group_sizes.keys()), list(self._group_sizes.values())
+        )
         # associate index with batch within prediction time group
-        self._sub_group_index = np.concatenate([np.arange(size) for size in self._group_sizes.values()])
+        self._sub_group_index = np.concatenate(
+            [np.arange(size) for size in self._group_sizes.values()]
+        )
 
     def __iter__(self):
         if self.shuffle:  # shuffle samples
@@ -127,7 +141,9 @@ class TimeSynchronizedBatchSampler(GroupedSampler):
         index = data_source.index
         # get groups, i.e. group all samples by first predict time
         last_time = data_source.data["time"][index["index_end"].to_numpy()].numpy()
-        decoder_lengths = data_source.calculate_decoder_length(last_time, index.sequence_length)
+        decoder_lengths = data_source.calculate_decoder_length(
+            last_time, index.sequence_length
+        )
         first_prediction_time = index.time + index.sequence_length - decoder_lengths + 1
         groups = pd.RangeIndex(0, len(index.index)).groupby(first_prediction_time)
         return groups

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -8,7 +8,7 @@ defines a class that is able to handle a wide variety of timeseries data problem
 from copy import copy as _copy, deepcopy
 from functools import lru_cache
 import inspect
-from typing import Any, Callable, Dict, List, Tuple, Union, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import warnings
 
 import numpy as np

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -34,7 +34,9 @@ from pytorch_forecasting.utils import repr_class
 from pytorch_forecasting.utils._dependencies import _check_matplotlib
 
 
-def _find_end_indices(diffs: np.ndarray, max_lengths: np.ndarray, min_length: int) -> Tuple[np.ndarray, np.ndarray]:
+def _find_end_indices(
+    diffs: np.ndarray, max_lengths: np.ndarray, min_length: int
+) -> Tuple[np.ndarray, np.ndarray]:
     """
     Identify end indices in series even if some values are missing.
 
@@ -82,7 +84,9 @@ except ImportError:
     pass
 
 
-def check_for_nonfinite(tensor: torch.Tensor, names: Union[str, List[str]]) -> torch.Tensor:
+def check_for_nonfinite(
+    tensor: torch.Tensor, names: Union[str, List[str]]
+) -> torch.Tensor:
     """
     Check if 2D tensor contains NAs or inifinite values.
 
@@ -192,15 +196,24 @@ class TimeSeriesDataSet(Dataset):
         time_varying_unknown_categoricals: Optional[List[str]] = None,
         time_varying_unknown_reals: Optional[List[str]] = None,
         variable_groups: Optional[Dict[str, List[int]]] = None,
-        constant_fill_strategy: Optional[Dict[str, Union[str, float, int, bool]]] = None,
+        constant_fill_strategy: Optional[
+            Dict[str, Union[str, float, int, bool]]
+        ] = None,
         allow_missing_timesteps: bool = False,
         lags: Optional[Dict[str, List[int]]] = None,
         add_relative_time_idx: bool = False,
         add_target_scales: bool = False,
         add_encoder_length: Union[bool, str] = "auto",
-        target_normalizer: Union[NORMALIZER, str, List[NORMALIZER], Tuple[NORMALIZER], None] = "auto",
+        target_normalizer: Union[
+            NORMALIZER, str, List[NORMALIZER], Tuple[NORMALIZER], None
+        ] = "auto",
         categorical_encoders: Optional[Dict[str, NaNLabelEncoder]] = None,
-        scalers: Optional[Dict[str, Union[StandardScaler, RobustScaler, TorchNormalizer, EncoderNormalizer]]] = None,
+        scalers: Optional[
+            Dict[
+                str,
+                Union[StandardScaler, RobustScaler, TorchNormalizer, EncoderNormalizer],
+            ]
+        ] = None,
         randomize_length: Union[None, Tuple[float, float], bool] = False,
         predict_mode: bool = False,
     ):
@@ -334,46 +347,68 @@ class TimeSeriesDataSet(Dataset):
         """
         super().__init__()
         self.max_encoder_length = max_encoder_length
-        assert isinstance(self.max_encoder_length, int), "max encoder length must be integer"
+        assert isinstance(
+            self.max_encoder_length, int
+        ), "max encoder length must be integer"
         if min_encoder_length is None:
             min_encoder_length = max_encoder_length
         self.min_encoder_length = min_encoder_length
         assert (
             self.min_encoder_length <= self.max_encoder_length
         ), "max encoder length has to be larger equals min encoder length"
-        assert isinstance(self.min_encoder_length, int), "min encoder length must be integer"
+        assert isinstance(
+            self.min_encoder_length, int
+        ), "min encoder length must be integer"
         self.max_prediction_length = max_prediction_length
-        assert isinstance(self.max_prediction_length, int), "max prediction length must be integer"
+        assert isinstance(
+            self.max_prediction_length, int
+        ), "max prediction length must be integer"
         if min_prediction_length is None:
             min_prediction_length = max_prediction_length
         self.min_prediction_length = min_prediction_length
         assert (
             self.min_prediction_length <= self.max_prediction_length
         ), "max prediction length has to be larger equals min prediction length"
-        assert self.min_prediction_length > 0, "min prediction length must be larger than 0"
-        assert isinstance(self.min_prediction_length, int), "min prediction length must be integer"
-        assert data[time_idx].dtype.kind == "i", "Timeseries index should be of type integer"
+        assert (
+            self.min_prediction_length > 0
+        ), "min prediction length must be larger than 0"
+        assert isinstance(
+            self.min_prediction_length, int
+        ), "min prediction length must be integer"
+        assert (
+            data[time_idx].dtype.kind == "i"
+        ), "Timeseries index should be of type integer"
         self.target = target
         self.weight = weight
         self.time_idx = time_idx
         self.group_ids = [] if group_ids is None else list(group_ids)
         self.static_categoricals = static_categoricals
-        self._static_categoricals = [] if static_categoricals is None else list(static_categoricals)
+        self._static_categoricals = (
+            [] if static_categoricals is None else list(static_categoricals)
+        )
         self.static_reals = static_reals
         self._static_reals = [] if static_reals is None else list(static_reals)
         self.time_varying_known_categoricals = time_varying_known_categoricals
         self._time_varying_known_categoricals = (
-            [] if time_varying_known_categoricals is None else list(time_varying_known_categoricals)
+            []
+            if time_varying_known_categoricals is None
+            else list(time_varying_known_categoricals)
         )
         self.time_varying_known_reals = time_varying_known_reals
-        self._time_varying_known_reals = [] if time_varying_known_reals is None else list(time_varying_known_reals)
+        self._time_varying_known_reals = (
+            [] if time_varying_known_reals is None else list(time_varying_known_reals)
+        )
         self.time_varying_unknown_categoricals = time_varying_unknown_categoricals
         self._time_varying_unknown_categoricals = (
-            [] if time_varying_unknown_categoricals is None else list(time_varying_unknown_categoricals)
+            []
+            if time_varying_unknown_categoricals is None
+            else list(time_varying_unknown_categoricals)
         )
         self.time_varying_unknown_reals = time_varying_unknown_reals
         self._time_varying_unknown_reals = (
-            [] if time_varying_unknown_reals is None else list(time_varying_unknown_reals)
+            []
+            if time_varying_unknown_reals is None
+            else list(time_varying_unknown_reals)
         )
         self.add_relative_time_idx = add_relative_time_idx
 
@@ -388,17 +423,23 @@ class TimeSeriesDataSet(Dataset):
             min_prediction_idx = data[self.time_idx].min()
         self.min_prediction_idx = min_prediction_idx
         self.constant_fill_strategy = constant_fill_strategy
-        self._constant_fill_strategy = {} if constant_fill_strategy is None else deepcopy(constant_fill_strategy)
+        self._constant_fill_strategy = (
+            {} if constant_fill_strategy is None else deepcopy(constant_fill_strategy)
+        )
         self.predict_mode = predict_mode
         self.allow_missing_timesteps = allow_missing_timesteps
         self.target_normalizer = target_normalizer
         self.categorical_encoders = categorical_encoders
-        self._categorical_encoders = {} if categorical_encoders is None else deepcopy(categorical_encoders)
+        self._categorical_encoders = (
+            {} if categorical_encoders is None else deepcopy(categorical_encoders)
+        )
         self.scalers = scalers
         self._scalers = {} if scalers is None else deepcopy(scalers)
         self.add_target_scales = add_target_scales
         self.variable_groups = variable_groups
-        self._variable_groups = {} if variable_groups is None else deepcopy(variable_groups)
+        self._variable_groups = (
+            {} if variable_groups is None else deepcopy(variable_groups)
+        )
         self.lags = lags
         self._lags = {} if lags is None else deepcopy(lags)
 
@@ -431,18 +472,28 @@ class TimeSeriesDataSet(Dataset):
             assert (
                 "relative_time_idx" not in data.columns
             ), "relative_time_idx is a protected column and must not be present in data"
-            if "relative_time_idx" not in self._time_varying_known_reals and "relative_time_idx" not in self.reals:
+            if (
+                "relative_time_idx" not in self._time_varying_known_reals
+                and "relative_time_idx" not in self.reals
+            ):
                 self._time_varying_known_reals.append("relative_time_idx")
-            data.loc[:, "relative_time_idx"] = 0.0  # dummy - real value will be set dynamically in __getitem__()
+            data.loc[:, "relative_time_idx"] = (
+                0.0  # dummy - real value will be set dynamically in __getitem__()
+            )
 
         # add decoder length to static real variables
         if self.add_encoder_length:
             assert (
                 "encoder_length" not in data.columns
             ), "encoder_length is a protected column and must not be present in data"
-            if "encoder_length" not in self._time_varying_known_reals and "encoder_length" not in self.reals:
+            if (
+                "encoder_length" not in self._time_varying_known_reals
+                and "encoder_length" not in self.reals
+            ):
                 self._static_reals.append("encoder_length")
-            data.loc[:, "encoder_length"] = 0  # dummy - real value will be set dynamically in __getitem__()
+            data.loc[:, "encoder_length"] = (
+                0  # dummy - real value will be set dynamically in __getitem__()
+            )
 
         # validate
         self._validate_data(data)
@@ -469,7 +520,9 @@ class TimeSeriesDataSet(Dataset):
                             self._time_varying_known_categoricals.append(lagged_name)
                 elif name in self._time_varying_unknown_reals:
                     for lagged_name, lag in lagged_names.items():
-                        if lag < self.max_prediction_length:  # keep in unknown as if lag is too small
+                        if (
+                            lag < self.max_prediction_length
+                        ):  # keep in unknown as if lag is too small
                             if lagged_name not in self._time_varying_unknown_reals:
                                 self._time_varying_unknown_reals.append(lagged_name)
                         else:
@@ -478,26 +531,40 @@ class TimeSeriesDataSet(Dataset):
                                 self._time_varying_known_reals.append(lagged_name)
                 elif name in self._time_varying_unknown_categoricals:
                     for lagged_name, lag in lagged_names.items():
-                        if lag < self.max_prediction_length:  # keep in unknown as if lag is too small
-                            if lagged_name not in self._time_varying_unknown_categoricals:
-                                self._time_varying_unknown_categoricals.append(lagged_name)
+                        if (
+                            lag < self.max_prediction_length
+                        ):  # keep in unknown as if lag is too small
+                            if (
+                                lagged_name
+                                not in self._time_varying_unknown_categoricals
+                            ):
+                                self._time_varying_unknown_categoricals.append(
+                                    lagged_name
+                                )
                         if lagged_name not in self._time_varying_known_categoricals:
                             # switch to known so that lag can be used in decoder directly
                             self._time_varying_known_categoricals.append(lagged_name)
                 else:
-                    raise KeyError(f"lagged variable {name} is not a known nor unknown time-varying variable")
+                    raise KeyError(
+                        f"lagged variable {name} is not a known nor unknown time-varying variable"
+                    )
 
         # filter data
         if min_prediction_idx is not None:
             # filtering for min_prediction_idx will be done on subsequence level ensuring
             # minimal decoder index is always >= min_prediction_idx
-            data = data[lambda x: x[self.time_idx] >= self.min_prediction_idx - self.max_encoder_length - self.max_lag]
+            data = data[
+                lambda x: x[self.time_idx]
+                >= self.min_prediction_idx - self.max_encoder_length - self.max_lag
+            ]
         data = data.sort_values(self.group_ids + [self.time_idx])
 
         # preprocess data
         data = self._preprocess_data(data)
         for target in self.target_names:
-            assert target not in self._scalers, "Target normalizer is separate and not in scalers."
+            assert (
+                target not in self._scalers
+            ), "Target normalizer is separate and not in scalers."
 
         # create index
         self.index = self._construct_index(data, predict_mode=self.predict_mode)
@@ -511,7 +578,11 @@ class TimeSeriesDataSet(Dataset):
         list of categorical variables that are unknown when making a
         forecast without observed history
         """
-        return [name for name, encoder in self._categorical_encoders.items() if encoder.add_nan]
+        return [
+            name
+            for name, encoder in self._categorical_encoders.items()
+            if encoder.add_nan
+        ]
 
     def _get_lagged_names(self, name: str) -> Dict[str, int]:
         """
@@ -546,7 +617,13 @@ class TimeSeriesDataSet(Dataset):
         """Subset of `lagged_variables` but only includes variables that are lagged targets."""
         vars = {}
         for name in self._lags:
-            vars.update({lag_name: name for lag_name in self._get_lagged_names(name) if name in self.target_names})
+            vars.update(
+                {
+                    lag_name: name
+                    for lag_name in self._get_lagged_names(name)
+                    if name in self.target_names
+                }
+            )
         return vars
 
     @property
@@ -590,7 +667,10 @@ class TimeSeriesDataSet(Dataset):
                 if data[target].dtype.kind != "f":  # category
                     normalizers.append(NaNLabelEncoder())
                     if self.add_target_scales:
-                        warnings.warn("Target scales will be only added for continous targets", UserWarning)
+                        warnings.warn(
+                            "Target scales will be only added for continous targets",
+                            UserWarning,
+                        )
                 else:
                     data_positive = (data[target] > 0).all()
                     if data_positive:
@@ -601,7 +681,9 @@ class TimeSeriesDataSet(Dataset):
                     else:
                         transformer = None
                     if self.max_encoder_length > 20 and self.min_encoder_length > 1:
-                        normalizers.append(EncoderNormalizer(transformation=transformer))
+                        normalizers.append(
+                            EncoderNormalizer(transformation=transformer)
+                        )
                     else:
                         normalizers.append(GroupNormalizer(transformation=transformer))
             if self.multi_target:
@@ -619,7 +701,9 @@ class TimeSeriesDataSet(Dataset):
         assert isinstance(
             self.target_normalizer, (TorchNormalizer, NaNLabelEncoder)
         ), f"target_normalizer has to be either None or of class TorchNormalizer but found {self.target_normalizer}"
-        assert not self.multi_target or isinstance(self.target_normalizer, MultiNormalizer), (
+        assert not self.multi_target or isinstance(
+            self.target_normalizer, MultiNormalizer
+        ), (
             "multiple targets / list of targets requires MultiNormalizer as target_normalizer "
             f"but found {self.target_normalizer}"
         )
@@ -656,7 +740,10 @@ class TimeSeriesDataSet(Dataset):
                 raise KeyError(f"variable {name} specified but not found in data")
             if not (
                 name in object_columns
-                or (name in category_columns and data[name].cat.categories.dtype.kind not in "bifc")
+                or (
+                    name in category_columns
+                    and data[name].cat.categories.dtype.kind not in "bifc"
+                )
             ):
                 raise ValueError(
                     f"Data type of category {name} was found to be numeric - use a string type / categorified string"
@@ -709,14 +796,22 @@ class TimeSeriesDataSet(Dataset):
                 name not in self._variable_groups
             ), f"lagged variables that are in {self._variable_groups} are not supported yet"
             for lagged_name, lag in self._get_lagged_names(name).items():
-                data[lagged_name] = data.groupby(self.group_ids, observed=True)[name].shift(lag)
+                data[lagged_name] = data.groupby(self.group_ids, observed=True)[
+                    name
+                ].shift(lag)
 
         # encode group ids - this encoding
         for name, group_name in self._group_ids_mapping.items():
             # use existing encoder - but a copy of it not too loose current encodings
-            encoder = deepcopy(self._categorical_encoders.get(group_name, NaNLabelEncoder()))
-            self._categorical_encoders[group_name] = encoder.fit(data[name].to_numpy().reshape(-1), overwrite=False)
-            data[group_name] = self.transform_values(name, data[name], inverse=False, group_id=True)
+            encoder = deepcopy(
+                self._categorical_encoders.get(group_name, NaNLabelEncoder())
+            )
+            self._categorical_encoders[group_name] = encoder.fit(
+                data[name].to_numpy().reshape(-1), overwrite=False
+            )
+            data[group_name] = self.transform_values(
+                name, data[name], inverse=False, group_id=True
+            )
 
         # encode categoricals first to ensure that group normalizer for relies on encoded categories
         if isinstance(
@@ -731,33 +826,45 @@ class TimeSeriesDataSet(Dataset):
             if name in self._variable_groups:  # fit groups
                 columns = self._variable_groups[name]
                 if name not in self._categorical_encoders:
-                    self._categorical_encoders[name] = NaNLabelEncoder().fit(data[columns].to_numpy().reshape(-1))
+                    self._categorical_encoders[name] = NaNLabelEncoder().fit(
+                        data[columns].to_numpy().reshape(-1)
+                    )
                 elif self._categorical_encoders[name] is not None:
                     try:
                         check_is_fitted(self._categorical_encoders[name])
                     except NotFittedError:
-                        self._categorical_encoders[name] = self._categorical_encoders[name].fit(
-                            data[columns].to_numpy().reshape(-1)
-                        )
+                        self._categorical_encoders[name] = self._categorical_encoders[
+                            name
+                        ].fit(data[columns].to_numpy().reshape(-1))
             else:
                 if name not in self._categorical_encoders:
                     self._categorical_encoders[name] = NaNLabelEncoder().fit(data[name])
-                elif self._categorical_encoders[name] is not None and name not in self.target_names:
+                elif (
+                    self._categorical_encoders[name] is not None
+                    and name not in self.target_names
+                ):
                     try:
                         check_is_fitted(self._categorical_encoders[name])
                     except NotFittedError:
-                        self._categorical_encoders[name] = self._categorical_encoders[name].fit(data[name])
+                        self._categorical_encoders[name] = self._categorical_encoders[
+                            name
+                        ].fit(data[name])
 
         # encode them
         for name in dict.fromkeys(group_ids_to_encode + self.flat_categoricals):
             # targets and its lagged versions are handled separetely
             if name not in self.target_names and name not in self.lagged_targets:
                 data[name] = self.transform_values(
-                    name, data[name], inverse=False, ignore_na=name in self.lagged_variables
+                    name,
+                    data[name],
+                    inverse=False,
+                    ignore_na=name in self.lagged_variables,
                 )
 
         # save special variables
-        assert "__time_idx__" not in data.columns, "__time_idx__ is a protected column and must not be present in data"
+        assert (
+            "__time_idx__" not in data.columns
+        ), "__time_idx__ is a protected column and must not be present in data"
         data["__time_idx__"] = data[self.time_idx]  # save unscaled
         for target in self.target_names:
             assert (
@@ -775,7 +882,9 @@ class TimeSeriesDataSet(Dataset):
             except NotFittedError:
                 if isinstance(self.target_normalizer, EncoderNormalizer):
                     self.target_normalizer.fit(data[self.target])
-                elif isinstance(self.target_normalizer, (GroupNormalizer, MultiNormalizer)):
+                elif isinstance(
+                    self.target_normalizer, (GroupNormalizer, MultiNormalizer)
+                ):
                     self.target_normalizer.fit(data[self.target], data)
                 else:
                     self.target_normalizer.fit(data[self.target])
@@ -786,19 +895,31 @@ class TimeSeriesDataSet(Dataset):
                 # transformation over the entire time range but by each group
                 common_init_args = [
                     name
-                    for name in inspect.signature(GroupNormalizer.__init__).parameters.keys()
-                    if name in inspect.signature(EncoderNormalizer.__init__).parameters.keys()
+                    for name in inspect.signature(
+                        GroupNormalizer.__init__
+                    ).parameters.keys()
+                    if name
+                    in inspect.signature(EncoderNormalizer.__init__).parameters.keys()
                     and name not in ["data", "self"]
                 ]
-                copy_kwargs = {name: getattr(self.target_normalizer, name) for name in common_init_args}
+                copy_kwargs = {
+                    name: getattr(self.target_normalizer, name)
+                    for name in common_init_args
+                }
                 normalizer = GroupNormalizer(groups=self.group_ids, **copy_kwargs)
-                data[self.target], scales = normalizer.fit_transform(data[self.target], data, return_norm=True)
+                data[self.target], scales = normalizer.fit_transform(
+                    data[self.target], data, return_norm=True
+                )
 
             elif isinstance(self.target_normalizer, GroupNormalizer):
-                data[self.target], scales = self.target_normalizer.transform(data[self.target], data, return_norm=True)
+                data[self.target], scales = self.target_normalizer.transform(
+                    data[self.target], data, return_norm=True
+                )
 
             elif isinstance(self.target_normalizer, MultiNormalizer):
-                transformed, scales = self.target_normalizer.transform(data[self.target], data, return_norm=True)
+                transformed, scales = self.target_normalizer.transform(
+                    data[self.target], data, return_norm=True
+                )
 
                 for idx, target in enumerate(self.target_names):
                     data[target] = transformed[idx]
@@ -814,20 +935,26 @@ class TimeSeriesDataSet(Dataset):
                 scales = None
 
             else:
-                data[self.target], scales = self.target_normalizer.transform(data[self.target], return_norm=True)
+                data[self.target], scales = self.target_normalizer.transform(
+                    data[self.target], return_norm=True
+                )
 
             # add target scales
             if self.add_target_scales:
                 if not isinstance(self.target_normalizer, MultiNormalizer):
                     scales = [scales]
                 for target_idx, target in enumerate(self.target_names):
-                    if not isinstance(self.target_normalizers[target_idx], NaNLabelEncoder):
+                    if not isinstance(
+                        self.target_normalizers[target_idx], NaNLabelEncoder
+                    ):
                         for scale_idx, name in enumerate(["center", "scale"]):
                             feature_name = f"{target}_{name}"
                             assert (
                                 feature_name not in data.columns
                             ), f"{feature_name} is a protected column and must not be present in data"
-                            data[feature_name] = scales[target_idx][:, scale_idx].squeeze()
+                            data[feature_name] = scales[target_idx][
+                                :, scale_idx
+                            ].squeeze()
                             if feature_name not in self.reals:
                                 self._static_reals.append(feature_name)
 
@@ -856,13 +983,17 @@ class TimeSeriesDataSet(Dataset):
                 and transformer is not None
                 and not isinstance(transformer, EncoderNormalizer)
             ):
-                data[name] = self.transform_values(name, data[name], data=data, inverse=False)
+                data[name] = self.transform_values(
+                    name, data[name], data=data, inverse=False
+                )
 
         # encode lagged categorical targets
         for name in self.lagged_targets:
             # normalizer only now available
             if name in self.flat_categoricals:
-                data[name] = self.transform_values(name, data[name], inverse=False, ignore_na=True)
+                data[name] = self.transform_values(
+                    name, data[name], inverse=False, ignore_na=True
+                )
 
         # encode constant values
         self.encoded_constant_fill_strategy = {}
@@ -894,7 +1025,9 @@ class TimeSeriesDataSet(Dataset):
         """
         if group_id:
             name = self._group_ids_mapping[name]
-        elif name in self.lagged_variables:  # recover transformer fitted on non-lagged variable
+        elif (
+            name in self.lagged_variables
+        ):  # recover transformer fitted on non-lagged variable
             name = self.lagged_variables[name]
 
         if name in self.flat_categoricals + self.group_ids + self._group_ids:
@@ -985,15 +1118,20 @@ class TimeSeriesDataSet(Dataset):
         """
 
         index = check_for_nonfinite(
-            torch.tensor(data[self._group_ids].to_numpy(np.int64), dtype=torch.int64), self.group_ids
+            torch.tensor(data[self._group_ids].to_numpy(np.int64), dtype=torch.int64),
+            self.group_ids,
         )
         time = check_for_nonfinite(
-            torch.tensor(data["__time_idx__"].to_numpy(np.int64), dtype=torch.int64), self.time_idx
+            torch.tensor(data["__time_idx__"].to_numpy(np.int64), dtype=torch.int64),
+            self.time_idx,
         )
 
         # categorical covariates
         categorical = check_for_nonfinite(
-            torch.tensor(data[self.flat_categoricals].to_numpy(np.int64), dtype=torch.int64), self.flat_categoricals
+            torch.tensor(
+                data[self.flat_categoricals].to_numpy(np.int64), dtype=torch.int64
+            ),
+            self.flat_categoricals,
         )
 
         # get weight
@@ -1012,7 +1150,10 @@ class TimeSeriesDataSet(Dataset):
         if isinstance(self.target_normalizer, NaNLabelEncoder):
             target = [
                 check_for_nonfinite(
-                    torch.tensor(data[f"__target__{self.target}"].to_numpy(dtype=np.int64), dtype=torch.long),
+                    torch.tensor(
+                        data[f"__target__{self.target}"].to_numpy(dtype=np.int64),
+                        dtype=torch.long,
+                    ),
                     self.target,
                 )
             ]
@@ -1022,9 +1163,13 @@ class TimeSeriesDataSet(Dataset):
                     check_for_nonfinite(
                         torch.tensor(
                             data[f"__target__{name}"].to_numpy(
-                                dtype=[np.float64, np.int64][data[name].dtype.kind in "bi"]
+                                dtype=[np.float64, np.int64][
+                                    data[name].dtype.kind in "bi"
+                                ]
                             ),
-                            dtype=[torch.float, torch.long][data[name].dtype.kind in "bi"],
+                            dtype=[torch.float, torch.long][
+                                data[name].dtype.kind in "bi"
+                            ],
                         ),
                         name,
                     )
@@ -1033,18 +1178,29 @@ class TimeSeriesDataSet(Dataset):
             else:
                 target = [
                     check_for_nonfinite(
-                        torch.tensor(data[f"__target__{self.target}"].to_numpy(dtype=np.float64), dtype=torch.float),
+                        torch.tensor(
+                            data[f"__target__{self.target}"].to_numpy(dtype=np.float64),
+                            dtype=torch.float,
+                        ),
                         self.target,
                     )
                 ]
 
         # continuous covariates
         continuous = check_for_nonfinite(
-            torch.tensor(data[self.reals].to_numpy(dtype=np.float64), dtype=torch.float), self.reals
+            torch.tensor(
+                data[self.reals].to_numpy(dtype=np.float64), dtype=torch.float
+            ),
+            self.reals,
         )
 
         tensors = dict(
-            reals=continuous, categoricals=categorical, groups=index, target=target, weight=weight, time=time
+            reals=continuous,
+            categoricals=categorical,
+            groups=index,
+            target=target,
+            weight=weight,
+            time=time,
         )
 
         return tensors
@@ -1058,7 +1214,9 @@ class TimeSeriesDataSet(Dataset):
             List[str]: list of variables
         """
         return (
-            self._static_categoricals + self._time_varying_known_categoricals + self._time_varying_unknown_categoricals
+            self._static_categoricals
+            + self._time_varying_known_categoricals
+            + self._time_varying_unknown_categoricals
         )
 
     @property
@@ -1098,7 +1256,11 @@ class TimeSeriesDataSet(Dataset):
         Returns:
             List[str]: list of variables
         """
-        return self._static_reals + self._time_varying_known_reals + self._time_varying_unknown_reals
+        return (
+            self._static_reals
+            + self._time_varying_known_reals
+            + self._time_varying_unknown_reals
+        )
 
     @property
     @lru_cache(None)
@@ -1156,7 +1318,12 @@ class TimeSeriesDataSet(Dataset):
 
     @classmethod
     def from_dataset(
-        cls, dataset, data: pd.DataFrame, stop_randomization: bool = False, predict: bool = False, **update_kwargs
+        cls,
+        dataset,
+        data: pd.DataFrame,
+        stop_randomization: bool = False,
+        predict: bool = False,
+        **update_kwargs,
     ):
         """
         Generate dataset with different underlying data but same variable encoders and scalers, etc.
@@ -1176,7 +1343,11 @@ class TimeSeriesDataSet(Dataset):
             TimeSeriesDataSet: new dataset
         """
         return cls.from_parameters(
-            dataset.get_parameters(), data, stop_randomization=stop_randomization, predict=predict, **update_kwargs
+            dataset.get_parameters(),
+            data,
+            stop_randomization=stop_randomization,
+            predict=predict,
+            **update_kwargs,
         )
 
     @classmethod
@@ -1209,7 +1380,8 @@ class TimeSeriesDataSet(Dataset):
                 stop_randomization = True
             elif not stop_randomization:
                 warnings.warn(
-                    "If predicting, no randomization should be possible - setting stop_randomization=True", UserWarning
+                    "If predicting, no randomization should be possible - setting stop_randomization=True",
+                    UserWarning,
                 )
                 stop_randomization = True
             parameters["min_prediction_length"] = parameters["max_prediction_length"]
@@ -1240,11 +1412,21 @@ class TimeSeriesDataSet(Dataset):
 
         df_index_first = g["__time_idx__"].transform("first").to_frame("time_first")
         df_index_last = g["__time_idx__"].transform("last").to_frame("time_last")
-        df_index_diff_to_next = -g["__time_idx__"].diff(-1).fillna(-1).astype(int).to_frame("time_diff_to_next")
-        df_index = pd.concat([df_index_first, df_index_last, df_index_diff_to_next], axis=1)
+        df_index_diff_to_next = (
+            -g["__time_idx__"]
+            .diff(-1)
+            .fillna(-1)
+            .astype(int)
+            .to_frame("time_diff_to_next")
+        )
+        df_index = pd.concat(
+            [df_index_first, df_index_last, df_index_diff_to_next], axis=1
+        )
         df_index["index_start"] = np.arange(len(df_index))
         df_index["time"] = data["__time_idx__"]
-        df_index["count"] = (df_index["time_last"] - df_index["time_first"]).astype(int) + 1
+        df_index["count"] = (df_index["time_last"] - df_index["time_first"]).astype(
+            int
+        ) + 1
         sequence_ids = g.ngroup()
         df_index["sequence_id"] = sequence_ids
 
@@ -1252,7 +1434,9 @@ class TimeSeriesDataSet(Dataset):
         max_sequence_length = self.max_prediction_length + self.max_encoder_length
 
         # calculate maximum index to include from current index_start
-        max_time = (df_index["time"] + max_sequence_length - 1).clip(upper=df_index["count"] + df_index.time_first - 1)
+        max_time = (df_index["time"] + max_sequence_length - 1).clip(
+            upper=df_index["count"] + df_index.time_first - 1
+        )
 
         # if there are missing timesteps, we cannot say directly what is the last timestep to include
         # therefore we iterate until it is found
@@ -1270,13 +1454,21 @@ class TimeSeriesDataSet(Dataset):
         # while the previous steps have ensured that we start a sequence on every time step, the missing_sequences
         # ensure that there is a sequence that finishes on every timestep
         if len(missing_sequences) > 0:
-            shortened_sequences = df_index.iloc[missing_sequences[:, 0]].assign(index_end=missing_sequences[:, 1])
+            shortened_sequences = df_index.iloc[missing_sequences[:, 0]].assign(
+                index_end=missing_sequences[:, 1]
+            )
 
             # concatenate shortened sequences
-            df_index = pd.concat([df_index, shortened_sequences], axis=0, ignore_index=True)
+            df_index = pd.concat(
+                [df_index, shortened_sequences], axis=0, ignore_index=True
+            )
 
         # filter out where encode and decode length are not satisfied
-        df_index["sequence_length"] = df_index["time"].iloc[df_index["index_end"]].to_numpy() - df_index["time"] + 1
+        df_index["sequence_length"] = (
+            df_index["time"].iloc[df_index["index_end"]].to_numpy()
+            - df_index["time"]
+            + 1
+        )
 
         # filter too short sequences
         df_index = df_index[
@@ -1284,24 +1476,35 @@ class TimeSeriesDataSet(Dataset):
             lambda x: (x.sequence_length >= min_sequence_length)
             &
             # prediction must be for after minimal prediction index + length of prediction
-            (x["sequence_length"] + x["time"] >= self.min_prediction_idx + self.min_prediction_length)
+            (
+                x["sequence_length"] + x["time"]
+                >= self.min_prediction_idx + self.min_prediction_length
+            )
         ]
 
-        if predict_mode:  # keep longest element per series (i.e. the first element that spans to the end of the series)
+        if (
+            predict_mode
+        ):  # keep longest element per series (i.e. the first element that spans to the end of the series)
             # filter all elements that are longer than the allowed maximum sequence length
             df_index = df_index[
                 lambda x: (x["time_last"] - x["time"] + 1 <= max_sequence_length)
                 & (x["sequence_length"] >= min_sequence_length)
             ]
             # choose longest sequence
-            df_index = df_index.loc[df_index.groupby("sequence_id").sequence_length.idxmax()]
+            df_index = df_index.loc[
+                df_index.groupby("sequence_id").sequence_length.idxmax()
+            ]
 
         # check that all groups/series have at least one entry in the index
         if not sequence_ids.isin(df_index.sequence_id).all():
-            missing_groups = data.loc[~sequence_ids.isin(df_index.sequence_id), self._group_ids].drop_duplicates()
+            missing_groups = data.loc[
+                ~sequence_ids.isin(df_index.sequence_id), self._group_ids
+            ].drop_duplicates()
             # decode values
             for name, id in self._group_ids_mapping.items():
-                missing_groups[id] = self.transform_values(name, missing_groups[id], inverse=True, group_id=True)
+                missing_groups[id] = self.transform_values(
+                    name, missing_groups[id], inverse=True, group_id=True
+                )
             warnings.warn(
                 "Min encoder length and/or min_prediction_idx and/or min prediction length and/or lags are "
                 "too large for "
@@ -1363,9 +1566,15 @@ class TimeSeriesDataSet(Dataset):
         index_last = self.index["index_end"].to_numpy()
         index = (
             # get group ids in order of index
-            pd.DataFrame(self.data["groups"][index_start].numpy(), columns=self.group_ids)
+            pd.DataFrame(
+                self.data["groups"][index_start].numpy(), columns=self.group_ids
+            )
             # to original values
-            .apply(lambda x: self.transform_values(name=x.name, values=x, group_id=True, inverse=True))
+            .apply(
+                lambda x: self.transform_values(
+                    name=x.name, values=x, group_id=True, inverse=True
+                )
+            )
             # add time index
             .assign(
                 time_idx_first=self.data["time"][index_start].numpy(),
@@ -1373,14 +1582,20 @@ class TimeSeriesDataSet(Dataset):
                 # prediction index is last time index - decoder length + 1
                 time_idx_first_prediction=lambda x: x.time_idx_last
                 - self.calculate_decoder_length(
-                    time_last=x.time_idx_last, sequence_length=x.time_idx_last - x.time_idx_first + 1
+                    time_last=x.time_idx_last,
+                    sequence_length=x.time_idx_last - x.time_idx_first + 1,
                 )
                 + 1,
             )
         )
         return index
 
-    def plot_randomization(self, betas: Tuple[float, float] = None, length: int = None, min_length: int = None):
+    def plot_randomization(
+        self,
+        betas: Tuple[float, float] = None,
+        length: int = None,
+        min_length: int = None,
+    ):
         """
         Plot expected randomized length distribution.
 
@@ -1421,7 +1636,10 @@ class TimeSeriesDataSet(Dataset):
         return self.index.shape[0]
 
     def set_overwrite_values(
-        self, values: Union[float, torch.Tensor], variable: str, target: Union[str, slice] = "decoder"
+        self,
+        values: Union[float, torch.Tensor],
+        variable: str,
+        target: Union[str, slice] = "decoder",
     ) -> None:
         """
         Convenience method to quickly overwrite values in decoder or encoder (or both) for a specific variable.
@@ -1433,26 +1651,40 @@ class TimeSeriesDataSet(Dataset):
                 a slice object which is directly used to overwrite indices, e.g. ``slice(-5, None)`` will overwrite
                 the last 5 values. Defaults to "decoder".
         """
-        values = torch.tensor(self.transform_values(variable, np.asarray(values).reshape(-1), inverse=False)).squeeze()
+        values = torch.tensor(
+            self.transform_values(
+                variable, np.asarray(values).reshape(-1), inverse=False
+            )
+        ).squeeze()
         assert target in [
             "all",
             "decoder",
             "encoder",
         ], f"target has be one of 'all', 'decoder' or 'encoder' but target={target} instead"
 
-        if variable in self._static_categoricals or variable in self._static_categoricals:
+        if (
+            variable in self._static_categoricals
+            or variable in self._static_categoricals
+        ):
             target = "all"
 
         if variable in self.target_names:
             raise NotImplementedError("Target variable is not supported")
         if self.weight is not None and self.weight == variable:
             raise NotImplementedError("Weight variable is not supported")
-        if isinstance(self._scalers.get(variable, self._categorical_encoders.get(variable)), TorchNormalizer):
-            raise NotImplementedError("TorchNormalizer (e.g. GroupNormalizer) is not supported")
+        if isinstance(
+            self._scalers.get(variable, self._categorical_encoders.get(variable)),
+            TorchNormalizer,
+        ):
+            raise NotImplementedError(
+                "TorchNormalizer (e.g. GroupNormalizer) is not supported"
+            )
 
         if self._overwrite_values is None:
             self._overwrite_values = {}
-        self._overwrite_values.update(dict(values=values, variable=variable, target=target))
+        self._overwrite_values.update(
+            dict(values=values, variable=variable, target=target)
+        )
 
     def reset_overwrite_values(self) -> None:
         """
@@ -1477,9 +1709,11 @@ class TimeSeriesDataSet(Dataset):
         """
         if isinstance(time_last, int):
             decoder_length = min(
-                time_last - (self.min_prediction_idx - 1),  # not going beyond min prediction idx
+                time_last
+                - (self.min_prediction_idx - 1),  # not going beyond min prediction idx
                 self.max_prediction_length,  # maximum prediction length
-                sequence_length - self.min_encoder_length,  # sequence length - min decoder length
+                sequence_length
+                - self.min_encoder_length,  # sequence length - min decoder length
             )
         else:
             decoder_length = np.min(
@@ -1504,14 +1738,21 @@ class TimeSeriesDataSet(Dataset):
         index = self.index.iloc[idx]
         # get index data
         data_cont = self.data["reals"][index.index_start : index.index_end + 1].clone()
-        data_cat = self.data["categoricals"][index.index_start : index.index_end + 1].clone()
+        data_cat = self.data["categoricals"][
+            index.index_start : index.index_end + 1
+        ].clone()
         time = self.data["time"][index.index_start : index.index_end + 1].clone()
-        target = [d[index.index_start : index.index_end + 1].clone() for d in self.data["target"]]
+        target = [
+            d[index.index_start : index.index_end + 1].clone()
+            for d in self.data["target"]
+        ]
         groups = self.data["groups"][index.index_start].clone()
         if self.data["weight"] is None:
             weight = None
         else:
-            weight = self.data["weight"][index.index_start : index.index_end + 1].clone()
+            weight = self.data["weight"][
+                index.index_start : index.index_end + 1
+            ].clone()
         # get target scale in the form of a list
         target_scale = self.target_normalizer.get_parameters(groups, self.group_ids)
         if not isinstance(self.target_normalizer, MultiNormalizer):
@@ -1520,10 +1761,16 @@ class TimeSeriesDataSet(Dataset):
         # fill in missing values (if not all time indices are specified
         sequence_length = len(time)
         if sequence_length < index.sequence_length:
-            assert self.allow_missing_timesteps, "allow_missing_timesteps should be True if sequences have gaps"
-            repetitions = torch.cat([time[1:] - time[:-1], torch.ones(1, dtype=time.dtype)])
+            assert (
+                self.allow_missing_timesteps
+            ), "allow_missing_timesteps should be True if sequences have gaps"
+            repetitions = torch.cat(
+                [time[1:] - time[:-1], torch.ones(1, dtype=time.dtype)]
+            )
             indices = torch.repeat_interleave(torch.arange(len(time)), repetitions)
-            repetition_indices = torch.cat([torch.tensor([False], dtype=torch.bool), indices[1:] == indices[:-1]])
+            repetition_indices = torch.cat(
+                [torch.tensor([False], dtype=torch.bool), indices[1:] == indices[:-1]]
+            )
 
             # select data
             data_cat = data_cat[indices]
@@ -1536,22 +1783,31 @@ class TimeSeriesDataSet(Dataset):
             if self.time_idx in self.reals:
                 time_idx = self.reals.index(self.time_idx)
                 data_cont[:, time_idx] = torch.linspace(
-                    data_cont[0, time_idx], data_cont[-1, time_idx], len(target[0]), dtype=data_cont.dtype
+                    data_cont[0, time_idx],
+                    data_cont[-1, time_idx],
+                    len(target[0]),
+                    dtype=data_cont.dtype,
                 )
 
             # make replacements to fill in categories
             for name, value in self.encoded_constant_fill_strategy.items():
                 if name in self.reals:
                     data_cont[repetition_indices, self.reals.index(name)] = value
-                elif name in [f"__target__{target_name}" for target_name in self.target_names]:
+                elif name in [
+                    f"__target__{target_name}" for target_name in self.target_names
+                ]:
                     target_pos = self.target_names.index(name[len("__target__") :])
                     target[target_pos][repetition_indices] = value
                 elif name in self.flat_categoricals:
-                    data_cat[repetition_indices, self.flat_categoricals.index(name)] = value
+                    data_cat[repetition_indices, self.flat_categoricals.index(name)] = (
+                        value
+                    )
                 elif name in self.target_names:  # target is just not an input value
                     pass
                 else:
-                    raise KeyError(f"Variable {name} is not known and thus cannot be filled in")
+                    raise KeyError(
+                        f"Variable {name} is not known and thus cannot be filled in"
+                    )
 
             sequence_length = len(target[0])
 
@@ -1565,12 +1821,16 @@ class TimeSeriesDataSet(Dataset):
         assert (
             decoder_length >= self.min_prediction_length
         ), "Decoder length should be at least minimum prediction length"
-        assert encoder_length >= self.min_encoder_length, "Encoder length should be at least minimum encoder length"
+        assert (
+            encoder_length >= self.min_encoder_length
+        ), "Encoder length should be at least minimum encoder length"
 
         if self.randomize_length is not None:  # randomization improves generalization
             # modify encode and decode lengths
             modifiable_encoder_length = encoder_length - self.min_encoder_length
-            encoder_length_probability = Beta(self.randomize_length[0], self.randomize_length[1]).sample()
+            encoder_length_probability = Beta(
+                self.randomize_length[0], self.randomize_length[1]
+            ).sample()
 
             # subsample a new/smaller encode length
             new_encoder_length = self.min_encoder_length + int(
@@ -1578,35 +1838,64 @@ class TimeSeriesDataSet(Dataset):
             )
 
             # extend decode length if possible
-            new_decoder_length = min(decoder_length + (encoder_length - new_encoder_length), self.max_prediction_length)
+            new_decoder_length = min(
+                decoder_length + (encoder_length - new_encoder_length),
+                self.max_prediction_length,
+            )
 
             # select subset of sequence of new sequence
             if new_encoder_length + new_decoder_length < len(target[0]):
-                data_cat = data_cat[encoder_length - new_encoder_length : encoder_length + new_decoder_length]
-                data_cont = data_cont[encoder_length - new_encoder_length : encoder_length + new_decoder_length]
-                target = [t[encoder_length - new_encoder_length : encoder_length + new_decoder_length] for t in target]
+                data_cat = data_cat[
+                    encoder_length
+                    - new_encoder_length : encoder_length
+                    + new_decoder_length
+                ]
+                data_cont = data_cont[
+                    encoder_length
+                    - new_encoder_length : encoder_length
+                    + new_decoder_length
+                ]
+                target = [
+                    t[
+                        encoder_length
+                        - new_encoder_length : encoder_length
+                        + new_decoder_length
+                    ]
+                    for t in target
+                ]
                 if weight is not None:
-                    weight = weight[encoder_length - new_encoder_length : encoder_length + new_decoder_length]
+                    weight = weight[
+                        encoder_length
+                        - new_encoder_length : encoder_length
+                        + new_decoder_length
+                    ]
                 encoder_length = new_encoder_length
                 decoder_length = new_decoder_length
 
             # switch some variables to nan if encode length is 0
             if encoder_length == 0 and len(self.dropout_categoricals) > 0:
-                data_cat[:, [self.flat_categoricals.index(c) for c in self.dropout_categoricals]] = (
-                    0  # zero is encoded nan
-                )
+                data_cat[
+                    :,
+                    [
+                        self.flat_categoricals.index(c)
+                        for c in self.dropout_categoricals
+                    ],
+                ] = 0  # zero is encoded nan
 
         assert decoder_length > 0, "Decoder length should be greater than 0"
         assert encoder_length >= 0, "Encoder length should be at least 0"
 
         if self.add_relative_time_idx:
             data_cont[:, self.reals.index("relative_time_idx")] = (
-                torch.arange(-encoder_length, decoder_length, dtype=data_cont.dtype) / self.max_encoder_length
+                torch.arange(-encoder_length, decoder_length, dtype=data_cont.dtype)
+                / self.max_encoder_length
             )
 
         if self.add_encoder_length:
             data_cont[:, self.reals.index("encoder_length")] = (
-                (encoder_length - 0.5 * self.max_encoder_length) / self.max_encoder_length * 2.0
+                (encoder_length - 0.5 * self.max_encoder_length)
+                / self.max_encoder_length
+                * 2.0
             )
 
         # rescale target
@@ -1619,14 +1908,20 @@ class TimeSeriesDataSet(Dataset):
                 single_target_scale = target_normalizer.get_parameters()
                 # modify input data
                 if target_name in self.reals:
-                    data_cont[:, self.reals.index(target_name)] = target_normalizer.transform(target[idx])
+                    data_cont[:, self.reals.index(target_name)] = (
+                        target_normalizer.transform(target[idx])
+                    )
                 if self.add_target_scales:
-                    data_cont[:, self.reals.index(f"{target_name}_center")] = self.transform_values(
-                        f"{target_name}_center", single_target_scale[0]
-                    )[0]
-                    data_cont[:, self.reals.index(f"{target_name}_scale")] = self.transform_values(
-                        f"{target_name}_scale", single_target_scale[1]
-                    )[0]
+                    data_cont[:, self.reals.index(f"{target_name}_center")] = (
+                        self.transform_values(
+                            f"{target_name}_center", single_target_scale[0]
+                        )[0]
+                    )
+                    data_cont[:, self.reals.index(f"{target_name}_scale")] = (
+                        self.transform_values(
+                            f"{target_name}_scale", single_target_scale[1]
+                        )[0]
+                    )
                 # scale needs to be numpy to be consistent with GroupNormalizer
                 target_scale[idx] = single_target_scale.numpy()
 
@@ -1713,29 +2008,55 @@ class TimeSeriesDataSet(Dataset):
         """
         # collate function for dataloader
         # lengths
-        encoder_lengths = torch.tensor([batch[0]["encoder_length"] for batch in batches], dtype=torch.long)
-        decoder_lengths = torch.tensor([batch[0]["decoder_length"] for batch in batches], dtype=torch.long)
+        encoder_lengths = torch.tensor(
+            [batch[0]["encoder_length"] for batch in batches], dtype=torch.long
+        )
+        decoder_lengths = torch.tensor(
+            [batch[0]["decoder_length"] for batch in batches], dtype=torch.long
+        )
 
         # ids
         decoder_time_idx_start = (
-            torch.tensor([batch[0]["encoder_time_idx_start"] for batch in batches], dtype=torch.long) + encoder_lengths
+            torch.tensor(
+                [batch[0]["encoder_time_idx_start"] for batch in batches],
+                dtype=torch.long,
+            )
+            + encoder_lengths
         )
-        decoder_time_idx = decoder_time_idx_start.unsqueeze(1) + torch.arange(decoder_lengths.max()).unsqueeze(0)
+        decoder_time_idx = decoder_time_idx_start.unsqueeze(1) + torch.arange(
+            decoder_lengths.max()
+        ).unsqueeze(0)
         groups = torch.stack([batch[0]["groups"] for batch in batches])
 
         # features
         encoder_cont = rnn.pad_sequence(
-            [batch[0]["x_cont"][:length] for length, batch in zip(encoder_lengths, batches)], batch_first=True
+            [
+                batch[0]["x_cont"][:length]
+                for length, batch in zip(encoder_lengths, batches)
+            ],
+            batch_first=True,
         )
         encoder_cat = rnn.pad_sequence(
-            [batch[0]["x_cat"][:length] for length, batch in zip(encoder_lengths, batches)], batch_first=True
+            [
+                batch[0]["x_cat"][:length]
+                for length, batch in zip(encoder_lengths, batches)
+            ],
+            batch_first=True,
         )
 
         decoder_cont = rnn.pad_sequence(
-            [batch[0]["x_cont"][length:] for length, batch in zip(encoder_lengths, batches)], batch_first=True
+            [
+                batch[0]["x_cont"][length:]
+                for length, batch in zip(encoder_lengths, batches)
+            ],
+            batch_first=True,
         )
         decoder_cat = rnn.pad_sequence(
-            [batch[0]["x_cat"][length:] for length, batch in zip(encoder_lengths, batches)], batch_first=True
+            [
+                batch[0]["x_cat"][length:]
+                for length, batch in zip(encoder_lengths, batches)
+            ],
+            batch_first=True,
         )
 
         # target scale
@@ -1744,34 +2065,54 @@ class TimeSeriesDataSet(Dataset):
         elif isinstance(batches[0][0]["target_scale"], (list, tuple)):
             target_scale = []
             for idx in range(len(batches[0][0]["target_scale"])):
-                if isinstance(batches[0][0]["target_scale"][idx], torch.Tensor):  # stack tensor
-                    scale = torch.stack([batch[0]["target_scale"][idx] for batch in batches])
+                if isinstance(
+                    batches[0][0]["target_scale"][idx], torch.Tensor
+                ):  # stack tensor
+                    scale = torch.stack(
+                        [batch[0]["target_scale"][idx] for batch in batches]
+                    )
                 else:
                     scale = torch.from_numpy(
-                        np.array([batch[0]["target_scale"][idx] for batch in batches], dtype=np.float32),
+                        np.array(
+                            [batch[0]["target_scale"][idx] for batch in batches],
+                            dtype=np.float32,
+                        ),
                     )
                 target_scale.append(scale)
         else:  # convert to tensor
             target_scale = torch.from_numpy(
-                np.array([batch[0]["target_scale"] for batch in batches], dtype=np.float32),
+                np.array(
+                    [batch[0]["target_scale"] for batch in batches], dtype=np.float32
+                ),
             )
 
         # target and weight
         if isinstance(batches[0][1][0], (tuple, list)):
             target = [
-                rnn.pad_sequence([batch[1][0][idx] for batch in batches], batch_first=True)
+                rnn.pad_sequence(
+                    [batch[1][0][idx] for batch in batches], batch_first=True
+                )
                 for idx in range(len(batches[0][1][0]))
             ]
             encoder_target = [
-                rnn.pad_sequence([batch[0]["encoder_target"][idx] for batch in batches], batch_first=True)
+                rnn.pad_sequence(
+                    [batch[0]["encoder_target"][idx] for batch in batches],
+                    batch_first=True,
+                )
                 for idx in range(len(batches[0][1][0]))
             ]
         else:
-            target = rnn.pad_sequence([batch[1][0] for batch in batches], batch_first=True)
-            encoder_target = rnn.pad_sequence([batch[0]["encoder_target"] for batch in batches], batch_first=True)
+            target = rnn.pad_sequence(
+                [batch[1][0] for batch in batches], batch_first=True
+            )
+            encoder_target = rnn.pad_sequence(
+                [batch[0]["encoder_target"] for batch in batches], batch_first=True
+            )
 
         if batches[0][1][1] is not None:
-            weight = rnn.pad_sequence([batch[1][1] for batch in batches], batch_first=True)
+            weight = rnn.pad_sequence(
+                [batch[1][1] for batch in batches], batch_first=True
+            )
         else:
             weight = None
 
@@ -1793,7 +2134,11 @@ class TimeSeriesDataSet(Dataset):
         )
 
     def to_dataloader(
-        self, train: bool = True, batch_size: int = 64, batch_sampler: Union[Sampler, str] = None, **kwargs
+        self,
+        train: bool = True,
+        batch_size: int = 64,
+        batch_sampler: Union[Sampler, str] = None,
+        **kwargs,
     ) -> DataLoader:
         """
         Get dataloader from dataset.
@@ -1883,7 +2228,9 @@ class TimeSeriesDataSet(Dataset):
                         drop_last=kwargs["drop_last"],
                     )
                 else:
-                    raise ValueError(f"batch_sampler {sampler} unknown - see docstring for valid batch_sampler")
+                    raise ValueError(
+                        f"batch_sampler {sampler} unknown - see docstring for valid batch_sampler"
+                    )
             del kwargs["batch_size"]
             del kwargs["shuffle"]
             del kwargs["drop_last"]
@@ -1904,9 +2251,15 @@ class TimeSeriesDataSet(Dataset):
         for id in self.group_ids:
             index_data[id] = x["groups"][:, self.group_ids.index(id)].cpu()
             # decode if possible
-            index_data[id] = self.transform_values(id, index_data[id], inverse=True, group_id=True)
+            index_data[id] = self.transform_values(
+                id, index_data[id], inverse=True, group_id=True
+            )
         index = pd.DataFrame(index_data)
         return index
 
     def __repr__(self) -> str:
-        return repr_class(self, attributes=self.get_parameters(), extra_attributes=dict(length=len(self)))
+        return repr_class(
+            self,
+            attributes=self.get_parameters(),
+            extra_attributes=dict(length=len(self)),
+        )

--- a/pytorch_forecasting/metrics/__init__.py
+++ b/pytorch_forecasting/metrics/__init__.py
@@ -19,7 +19,16 @@ from pytorch_forecasting.metrics.distributions import (
     NegativeBinomialDistributionLoss,
     NormalDistributionLoss,
 )
-from pytorch_forecasting.metrics.point import MAE, MAPE, MASE, RMSE, SMAPE, CrossEntropy, PoissonLoss, TweedieLoss
+from pytorch_forecasting.metrics.point import (
+    MAE,
+    MAPE,
+    MASE,
+    RMSE,
+    SMAPE,
+    CrossEntropy,
+    PoissonLoss,
+    TweedieLoss,
+)
 from pytorch_forecasting.metrics.quantile import QuantileLoss
 
 __all__ = [

--- a/pytorch_forecasting/metrics/_mqf2_utils.py
+++ b/pytorch_forecasting/metrics/_mqf2_utils.py
@@ -4,7 +4,12 @@ from typing import List, Optional, Tuple
 
 from cpflows.flows import DeepConvexFlow, SequentialFlow
 import torch
-from torch.distributions import AffineTransform, Distribution, Normal, TransformedDistribution
+from torch.distributions import (
+    AffineTransform,
+    Distribution,
+    Normal,
+    TransformedDistribution,
+)
 import torch.nn.functional as F
 
 
@@ -67,14 +72,19 @@ class DeepConvexNet(DeepConvexFlow):
         self.is_energy_score = is_energy_score
         self.estimate_logdet = estimate_logdet
 
-    def get_potential(self, x: torch.Tensor, context: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def get_potential(
+        self, x: torch.Tensor, context: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
         n = x.size(0)
         output = self.picnn(x, context)
 
         if self.is_energy_score:
             return output
         else:
-            return F.softplus(self.w1) * output + F.softplus(self.w0) * (x.view(n, -1) ** 2).sum(1, keepdim=True) / 2
+            return (
+                F.softplus(self.w1) * output
+                + F.softplus(self.w0) * (x.view(n, -1) ** 2).sum(1, keepdim=True) / 2
+            )
 
     def forward_transform(
         self,
@@ -84,7 +94,9 @@ class DeepConvexNet(DeepConvexFlow):
         extra: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if self.estimate_logdet:
-            return self.forward_transform_stochastic(x, logdet, context=context, extra=extra)
+            return self.forward_transform_stochastic(
+                x, logdet, context=context, extra=extra
+            )
         else:
             return self.forward_transform_bruteforce(x, logdet, context=context)
 
@@ -106,7 +118,9 @@ class SequentialNet(SequentialFlow):
         super().__init__(networks)
         self.networks = self.flows
 
-    def forward(self, x: torch.Tensor, context: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, context: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
         for network in self.networks:
             if isinstance(network, DeepConvexNet):
                 x = network.forward(x, context=context)
@@ -139,7 +153,9 @@ class SequentialNet(SequentialFlow):
         standard_normal = Normal(zero, one)
 
         samples = self.forward(
-            standard_normal.sample([num_samples * dimension]).view(num_samples, dimension),
+            standard_normal.sample([num_samples * dimension]).view(
+                num_samples, dimension
+            ),
             context=hidden_state,
         )
 
@@ -184,7 +200,9 @@ class SequentialNet(SequentialFlow):
 
         # (numel_batch * dimension * es_num_samples x hidden_size)
 
-        hidden_state_repeat = hidden_state.repeat_interleave(repeats=es_num_samples, dim=0)
+        hidden_state_repeat = hidden_state.repeat_interleave(
+            repeats=es_num_samples, dim=0
+        )
 
         w = self.es_sample(hidden_state_repeat, dimension)
         w_prime = self.es_sample(hidden_state_repeat, dimension)
@@ -280,7 +298,9 @@ class MQF2Distribution(Distribution):
 
         super().__init__(batch_shape=self.batch_shape, validate_args=validate_args)
 
-        self.context_length = self.hidden_state.shape[-2] if len(self.hidden_state.shape) > 2 else 1
+        self.context_length = (
+            self.hidden_state.shape[-2] if len(self.hidden_state.shape) > 2 else 1
+        )
         self.numel_batch = self.get_numel(self.batch_shape)
 
         # mean zero and std one
@@ -338,7 +358,9 @@ class MQF2Distribution(Distribution):
         z = torch.clamp(z, min=-self.threshold_input, max=self.threshold_input)
         z = self.stack_sliding_view(z)
 
-        loss = self.picnn.logp(z, self.hidden_state.reshape(-1, self.hidden_state.shape[-1]))
+        loss = self.picnn.logp(
+            z, self.hidden_state.reshape(-1, self.hidden_state.shape[-1])
+        )
 
         return loss
 
@@ -369,9 +391,13 @@ class MQF2Distribution(Distribution):
         beta = self.beta
 
         z = self.stack_sliding_view(z)
-        reshaped_hidden_state = self.hidden_state.reshape(-1, self.hidden_state.shape[-1])
+        reshaped_hidden_state = self.hidden_state.reshape(
+            -1, self.hidden_state.shape[-1]
+        )
 
-        loss = self.picnn.energy_score(z, reshaped_hidden_state, es_num_samples=es_num_samples, beta=beta)
+        loss = self.picnn.energy_score(
+            z, reshaped_hidden_state, es_num_samples=es_num_samples, beta=beta
+        )
 
         return loss
 
@@ -395,7 +421,9 @@ class MQF2Distribution(Distribution):
         num_samples_per_batch = MQF2Distribution.get_numel(sample_shape)
         num_samples = num_samples_per_batch * numel_batch
 
-        hidden_state_repeat = self.hidden_state.repeat_interleave(repeats=num_samples_per_batch, dim=0)
+        hidden_state_repeat = self.hidden_state.repeat_interleave(
+            repeats=num_samples_per_batch, dim=0
+        )
 
         alpha = torch.rand(
             (num_samples, prediction_length),
@@ -413,7 +441,9 @@ class MQF2Distribution(Distribution):
         )
         return samples
 
-    def quantile(self, alpha: torch.Tensor, hidden_state: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def quantile(
+        self, alpha: torch.Tensor, hidden_state: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
         """
         Generates the predicted paths associated with the quantile levels alpha
 
@@ -514,11 +544,13 @@ class TransformedMQF2Distribution(TransformedDistribution):
 
         return loss * (repeated_scale**beta)
 
-    def quantile(self, alpha: torch.Tensor, hidden_state: Optional[torch.Tensor] = None) -> torch.Tensor:
+    def quantile(
+        self, alpha: torch.Tensor, hidden_state: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
         result = self.base_dist.quantile(alpha, hidden_state=hidden_state)
-        result = result.reshape(self.base_dist.hidden_state.size(0), -1, self.base_dist.prediction_length).transpose(
-            0, 1
-        )
+        result = result.reshape(
+            self.base_dist.hidden_state.size(0), -1, self.base_dist.prediction_length
+        ).transpose(0, 1)
         for transform in self.transforms:
             # transform separate for each prediction horizon
             result = transform(result)

--- a/pytorch_forecasting/metrics/point.py
+++ b/pytorch_forecasting/metrics/point.py
@@ -32,9 +32,16 @@ class PoissonLoss(MultiHorizonMetric):
     The result is the model prediction.
     """
 
-    def loss(self, y_pred: Dict[str, torch.Tensor], target: torch.Tensor) -> torch.Tensor:
+    def loss(
+        self, y_pred: Dict[str, torch.Tensor], target: torch.Tensor
+    ) -> torch.Tensor:
         return F.poisson_nll_loss(
-            super().to_prediction(y_pred), target, log_input=True, full=False, eps=1e-6, reduction="none"
+            super().to_prediction(y_pred),
+            target,
+            log_input=True,
+            full=False,
+            eps=1e-6,
+            reduction="none",
         )
 
     def to_prediction(self, out: Dict[str, torch.Tensor]):
@@ -50,7 +57,12 @@ class PoissonLoss(MultiHorizonMetric):
         predictions = self.to_prediction(out)
         return (
             torch.stack(
-                [torch.tensor(scipy.stats.poisson(predictions.detach().cpu().numpy()).ppf(q)) for q in quantiles],
+                [
+                    torch.tensor(
+                        scipy.stats.poisson(predictions.detach().cpu().numpy()).ppf(q)
+                    )
+                    for q in quantiles
+                ],
                 dim=-1,
             )
             .type(predictions.dtype)
@@ -101,9 +113,9 @@ class CrossEntropy(MultiHorizonMetric):
     """
 
     def loss(self, y_pred, target):
-        loss = F.cross_entropy(y_pred.view(-1, y_pred.size(-1)), target.view(-1), reduction="none").view(
-            -1, target.size(-1)
-        )
+        loss = F.cross_entropy(
+            y_pred.view(-1, y_pred.size(-1)), target.view(-1), reduction="none"
+        ).view(-1, target.size(-1))
         return loss
 
     def to_prediction(self, y_pred: torch.Tensor) -> torch.Tensor:
@@ -120,7 +132,9 @@ class CrossEntropy(MultiHorizonMetric):
         """
         return y_pred.argmax(dim=-1)
 
-    def to_quantiles(self, y_pred: torch.Tensor, quantiles: List[float] = None) -> torch.Tensor:
+    def to_quantiles(
+        self, y_pred: torch.Tensor, quantiles: List[float] = None
+    ) -> torch.Tensor:
         """
         Convert network prediction into a quantile prediction.
 
@@ -189,7 +203,12 @@ class MASE(MultiHorizonMetric):
         if isinstance(target, rnn.PackedSequence):
             target, lengths = unpack_sequence(target)
         else:
-            lengths = torch.full((target.size(0),), fill_value=target.size(1), dtype=torch.long, device=target.device)
+            lengths = torch.full(
+                (target.size(0),),
+                fill_value=target.size(1),
+                dtype=torch.long,
+                device=target.device,
+            )
 
         # determine lengths for encoder
         if encoder_lengths is None:
@@ -199,7 +218,9 @@ class MASE(MultiHorizonMetric):
         assert not target.requires_grad
 
         # calculate loss with "none" reduction
-        scaling = self.calculate_scaling(target, lengths, encoder_target, encoder_lengths)
+        scaling = self.calculate_scaling(
+            target, lengths, encoder_target, encoder_lengths
+        )
         losses = self.loss(y_pred, target, scaling)
 
         # weight samples
@@ -217,19 +238,28 @@ class MASE(MultiHorizonMetric):
         eps = 1e-6
         batch_size = target.size(0)
         total_lengths = lengths + encoder_lengths
-        assert (total_lengths > 1).all(), "Need at least 2 target values to be able to calculate MASE"
+        assert (
+            total_lengths > 1
+        ).all(), "Need at least 2 target values to be able to calculate MASE"
         max_length = target.size(1) + encoder_target.size(1)
-        if (total_lengths != max_length).any():  # if decoder or encoder targets have sequences of different lengths
+        if (
+            total_lengths != max_length
+        ).any():  # if decoder or encoder targets have sequences of different lengths
             targets = torch.cat(
                 [
                     encoder_target,
-                    torch.zeros(batch_size, target.size(1), device=target.device, dtype=encoder_target.dtype),
+                    torch.zeros(
+                        batch_size,
+                        target.size(1),
+                        device=target.device,
+                        dtype=encoder_target.dtype,
+                    ),
                 ],
                 dim=1,
             )
-            target_index = torch.arange(target.size(1), device=target.device, dtype=torch.long).unsqueeze(0).expand(
-                batch_size, -1
-            ) + encoder_lengths.unsqueeze(-1)
+            target_index = torch.arange(
+                target.size(1), device=target.device, dtype=torch.long
+            ).unsqueeze(0).expand(batch_size, -1) + encoder_lengths.unsqueeze(-1)
             targets.scatter_(dim=1, src=target, index=target_index)
         else:
             targets = torch.cat([encoder_target, target], dim=1)
@@ -242,7 +272,9 @@ class MASE(MultiHorizonMetric):
         zero_correction_indices = total_lengths[not_maximum_length] - 1
         if len(zero_correction_indices) > 0:
             diffs[
-                torch.arange(batch_size, dtype=torch.long, device=diffs.device)[not_maximum_length],
+                torch.arange(batch_size, dtype=torch.long, device=diffs.device)[
+                    not_maximum_length
+                ],
                 zero_correction_indices,
             ] = 0.0
 

--- a/pytorch_forecasting/models/__init__.py
+++ b/pytorch_forecasting/models/__init__.py
@@ -15,7 +15,9 @@ from pytorch_forecasting.models.nbeats import NBeats
 from pytorch_forecasting.models.nhits import NHiTS
 from pytorch_forecasting.models.nn import GRU, LSTM, MultiEmbedding, get_rnn
 from pytorch_forecasting.models.rnn import RecurrentNetwork
-from pytorch_forecasting.models.temporal_fusion_transformer import TemporalFusionTransformer
+from pytorch_forecasting.models.temporal_fusion_transformer import (
+    TemporalFusionTransformer,
+)
 
 __all__ = [
     "NBeats",

--- a/pytorch_forecasting/models/baseline.py
+++ b/pytorch_forecasting/models/baseline.py
@@ -59,11 +59,18 @@ class Baseline(BaseModel):
         return self.to_network_output(prediction=prediction)
 
     def forward_one_target(
-        self, encoder_lengths: torch.Tensor, decoder_lengths: torch.Tensor, encoder_target: torch.Tensor
+        self,
+        encoder_lengths: torch.Tensor,
+        decoder_lengths: torch.Tensor,
+        encoder_target: torch.Tensor,
     ):
         max_prediction_length = decoder_lengths.max()
-        assert encoder_lengths.min() > 0, "Encoder lengths of at least 1 required to obtain last value"
-        last_values = encoder_target[torch.arange(encoder_target.size(0)), encoder_lengths - 1]
+        assert (
+            encoder_lengths.min() > 0
+        ), "Encoder lengths of at least 1 required to obtain last value"
+        last_values = encoder_target[
+            torch.arange(encoder_target.size(0)), encoder_lengths - 1
+        ]
         prediction = last_values[:, None].expand(-1, max_prediction_length)
         return prediction
 

--- a/pytorch_forecasting/models/mlp/_decodermlp.py
+++ b/pytorch_forecasting/models/mlp/_decodermlp.py
@@ -9,7 +9,15 @@ import torch
 from torch import nn
 
 from pytorch_forecasting.data import TimeSeriesDataSet
-from pytorch_forecasting.metrics import MAE, MAPE, MASE, RMSE, SMAPE, MultiHorizonMetric, QuantileLoss
+from pytorch_forecasting.metrics import (
+    MAE,
+    MAPE,
+    MASE,
+    RMSE,
+    SMAPE,
+    MultiHorizonMetric,
+    QuantileLoss,
+)
 from pytorch_forecasting.models.base_model import BaseModelWithCovariates
 from pytorch_forecasting.models.mlp.submodules import FullyConnectedModule
 from pytorch_forecasting.models.nn.embeddings import MultiEmbedding
@@ -148,15 +156,20 @@ class DecoderMLP(BaseModelWithCovariates):
             if name in self.decoder_variables + self.static_variables
         ]
 
-    def forward(self, x: Dict[str, torch.Tensor], n_samples: int = None) -> Dict[str, torch.Tensor]:
+    def forward(
+        self, x: Dict[str, torch.Tensor], n_samples: int = None
+    ) -> Dict[str, torch.Tensor]:
         """
         Forward network
         """
         # x is a batch generated based on the TimeSeriesDataset
         batch_size = x["decoder_lengths"].size(0)
-        embeddings = self.input_embeddings(x["decoder_cat"])  # returns dictionary with embedding tensors
+        embeddings = self.input_embeddings(
+            x["decoder_cat"]
+        )  # returns dictionary with embedding tensors
         network_input = torch.cat(
-            [x["decoder_cont"][..., self.decoder_reals_positions]] + list(embeddings.values()),
+            [x["decoder_cont"][..., self.decoder_reals_positions]]
+            + list(embeddings.values()),
             dim=-1,
         )
         prediction = self.mlp(network_input.view(-1, self.mlp.input_size)).view(
@@ -174,6 +187,8 @@ class DecoderMLP(BaseModelWithCovariates):
 
     @classmethod
     def from_dataset(cls, dataset: TimeSeriesDataSet, **kwargs):
-        new_kwargs = cls.deduce_default_output_parameters(dataset, kwargs, QuantileLoss())
+        new_kwargs = cls.deduce_default_output_parameters(
+            dataset, kwargs, QuantileLoss()
+        )
         kwargs.update(new_kwargs)
         return super().from_dataset(dataset, **kwargs)

--- a/pytorch_forecasting/models/mlp/_decodermlp.py
+++ b/pytorch_forecasting/models/mlp/_decodermlp.py
@@ -2,7 +2,7 @@
 Simple models based on fully connected networks
 """
 
-from typing import Dict, List, Tuple, Union, Optional
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch

--- a/pytorch_forecasting/models/mlp/submodules.py
+++ b/pytorch_forecasting/models/mlp/submodules.py
@@ -34,7 +34,9 @@ class FullyConnectedModule(nn.Module):
             module_list.append(nn.LayerNorm(hidden_size))
         # hidden layers
         for _ in range(n_hidden_layers):
-            module_list.extend([nn.Linear(hidden_size, hidden_size), activation_class()])
+            module_list.extend(
+                [nn.Linear(hidden_size, hidden_size), activation_class()]
+            )
             if dropout is not None:
                 module_list.append(nn.Dropout(dropout))
             if norm:

--- a/pytorch_forecasting/models/nbeats/__init__.py
+++ b/pytorch_forecasting/models/nbeats/__init__.py
@@ -1,6 +1,10 @@
 """N-Beats model for timeseries forecasting without covariates."""
 
 from pytorch_forecasting.models.nbeats._nbeats import NBeats
-from pytorch_forecasting.models.nbeats.sub_modules import NBEATSGenericBlock, NBEATSSeasonalBlock, NBEATSTrendBlock
+from pytorch_forecasting.models.nbeats.sub_modules import (
+    NBEATSGenericBlock,
+    NBEATSSeasonalBlock,
+    NBEATSTrendBlock,
+)
 
 __all__ = ["NBeats", "NBEATSGenericBlock", "NBEATSSeasonalBlock", "NBEATSTrendBlock"]

--- a/pytorch_forecasting/models/nbeats/sub_modules.py
+++ b/pytorch_forecasting/models/nbeats/sub_modules.py
@@ -18,7 +18,9 @@ def linear(input_size, output_size, bias=True, dropout: int = None):
         return lin
 
 
-def linspace(backcast_length: int, forecast_length: int, centered: bool = False) -> Tuple[np.ndarray, np.ndarray]:
+def linspace(
+    backcast_length: int, forecast_length: int, centered: bool = False
+) -> Tuple[np.ndarray, np.ndarray]:
     if centered:
         norm = max(backcast_length, forecast_length)
         start = -backcast_length
@@ -27,7 +29,9 @@ def linspace(backcast_length: int, forecast_length: int, centered: bool = False)
         norm = backcast_length + forecast_length
         start = 0
         stop = backcast_length + forecast_length - 1
-    lin_space = np.linspace(start / norm, stop / norm, backcast_length + forecast_length, dtype=np.float32)
+    lin_space = np.linspace(
+        start / norm, stop / norm, backcast_length + forecast_length, dtype=np.float32
+    )
     b_ls = lin_space[:backcast_length]
     f_ls = lin_space[backcast_length:]
     return b_ls, f_ls
@@ -97,22 +101,44 @@ class NBEATSSeasonalBlock(NBEATSBlock):
             dropout=dropout,
         )
 
-        backcast_linspace, forecast_linspace = linspace(backcast_length, forecast_length, centered=False)
+        backcast_linspace, forecast_linspace = linspace(
+            backcast_length, forecast_length, centered=False
+        )
 
-        p1, p2 = (thetas_dim // 2, thetas_dim // 2) if thetas_dim % 2 == 0 else (thetas_dim // 2, thetas_dim // 2 + 1)
+        p1, p2 = (
+            (thetas_dim // 2, thetas_dim // 2)
+            if thetas_dim % 2 == 0
+            else (thetas_dim // 2, thetas_dim // 2 + 1)
+        )
         s1_b = torch.tensor(
-            [np.cos(2 * np.pi * i * backcast_linspace) for i in self.get_frequencies(p1)], dtype=torch.float32
+            [
+                np.cos(2 * np.pi * i * backcast_linspace)
+                for i in self.get_frequencies(p1)
+            ],
+            dtype=torch.float32,
         )  # H/2-1
         s2_b = torch.tensor(
-            [np.sin(2 * np.pi * i * backcast_linspace) for i in self.get_frequencies(p2)], dtype=torch.float32
+            [
+                np.sin(2 * np.pi * i * backcast_linspace)
+                for i in self.get_frequencies(p2)
+            ],
+            dtype=torch.float32,
         )
         self.register_buffer("S_backcast", torch.cat([s1_b, s2_b]))
 
         s1_f = torch.tensor(
-            [np.cos(2 * np.pi * i * forecast_linspace) for i in self.get_frequencies(p1)], dtype=torch.float32
+            [
+                np.cos(2 * np.pi * i * forecast_linspace)
+                for i in self.get_frequencies(p1)
+            ],
+            dtype=torch.float32,
         )  # H/2-1
         s2_f = torch.tensor(
-            [np.sin(2 * np.pi * i * forecast_linspace) for i in self.get_frequencies(p2)], dtype=torch.float32
+            [
+                np.sin(2 * np.pi * i * forecast_linspace)
+                for i in self.get_frequencies(p2)
+            ],
+            dtype=torch.float32,
         )
         self.register_buffer("S_forecast", torch.cat([s1_f, s2_f]))
 
@@ -126,7 +152,9 @@ class NBEATSSeasonalBlock(NBEATSBlock):
         return backcast, forecast
 
     def get_frequencies(self, n):
-        return np.linspace(0, (self.backcast_length + self.forecast_length) / self.min_period, n)
+        return np.linspace(
+            0, (self.backcast_length + self.forecast_length) / self.min_period, n
+        )
 
 
 class NBEATSTrendBlock(NBEATSBlock):
@@ -149,13 +177,21 @@ class NBEATSTrendBlock(NBEATSBlock):
             dropout=dropout,
         )
 
-        backcast_linspace, forecast_linspace = linspace(backcast_length, forecast_length, centered=True)
-        norm = np.sqrt(forecast_length / thetas_dim)  # ensure range of predictions is comparable to input
+        backcast_linspace, forecast_linspace = linspace(
+            backcast_length, forecast_length, centered=True
+        )
+        norm = np.sqrt(
+            forecast_length / thetas_dim
+        )  # ensure range of predictions is comparable to input
 
-        coefficients = torch.tensor([backcast_linspace**i for i in range(thetas_dim)], dtype=torch.float32)
+        coefficients = torch.tensor(
+            [backcast_linspace**i for i in range(thetas_dim)], dtype=torch.float32
+        )
         self.register_buffer("T_backcast", coefficients * norm)
 
-        coefficients = torch.tensor([forecast_linspace**i for i in range(thetas_dim)], dtype=torch.float32)
+        coefficients = torch.tensor(
+            [forecast_linspace**i for i in range(thetas_dim)], dtype=torch.float32
+        )
         self.register_buffer("T_forecast", coefficients * norm)
 
     def forward(self, x) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/pytorch_forecasting/models/nhits/sub_modules.py
+++ b/pytorch_forecasting/models/nhits/sub_modules.py
@@ -10,7 +10,11 @@ import torch.nn.functional as F
 class StaticFeaturesEncoder(nn.Module):
     def __init__(self, in_features, out_features):
         super().__init__()
-        layers = [nn.Dropout(p=0.5), nn.Linear(in_features=in_features, out_features=out_features), nn.ReLU()]
+        layers = [
+            nn.Dropout(p=0.5),
+            nn.Linear(in_features=in_features, out_features=out_features),
+            nn.ReLU(),
+        ]
         self.encoder = nn.Sequential(*layers)
 
     def forward(self, x):
@@ -21,7 +25,9 @@ class StaticFeaturesEncoder(nn.Module):
 class IdentityBasis(nn.Module):
     def __init__(self, backcast_size: int, forecast_size: int, interpolation_mode: str):
         super().__init__()
-        assert (interpolation_mode in ["linear", "nearest"]) or ("cubic" in interpolation_mode)
+        assert (interpolation_mode in ["linear", "nearest"]) or (
+            "cubic" in interpolation_mode
+        )
         self.forecast_size = forecast_size
         self.backcast_size = backcast_size
         self.interpolation_mode = interpolation_mode
@@ -38,7 +44,9 @@ class IdentityBasis(nn.Module):
 
         if self.interpolation_mode == "nearest":
             knots = knots[:, None, :]
-            forecast = F.interpolate(knots, size=self.forecast_size, mode=self.interpolation_mode)
+            forecast = F.interpolate(
+                knots, size=self.forecast_size, mode=self.interpolation_mode
+            )
             forecast = forecast[:, 0, :]
         elif self.interpolation_mode == "linear":
             knots = knots[:, None, :]
@@ -53,9 +61,13 @@ class IdentityBasis(nn.Module):
             n_batches = int(np.ceil(len(knots) / batch_size))
             for i in range(n_batches):
                 forecast_i = F.interpolate(
-                    knots[i * batch_size : (i + 1) * batch_size], size=self.forecast_size, mode="bicubic"
+                    knots[i * batch_size : (i + 1) * batch_size],
+                    size=self.forecast_size,
+                    mode="bicubic",
                 )  # , align_corners=True)
-                forecast[i * batch_size : (i + 1) * batch_size] += forecast_i[:, 0, 0, :]
+                forecast[i * batch_size : (i + 1) * batch_size] += forecast_i[
+                    :, 0, 0, :
+                ]
 
         return backcast, forecast
 
@@ -137,17 +149,32 @@ class NHiTSBlock(nn.Module):
         activ = getattr(nn, activation)()
 
         if pooling_mode == "max":
-            self.pooling_layer = nn.MaxPool1d(kernel_size=self.pooling_sizes, stride=self.pooling_sizes, ceil_mode=True)
+            self.pooling_layer = nn.MaxPool1d(
+                kernel_size=self.pooling_sizes,
+                stride=self.pooling_sizes,
+                ceil_mode=True,
+            )
         elif pooling_mode == "average":
-            self.pooling_layer = nn.AvgPool1d(kernel_size=self.pooling_sizes, stride=self.pooling_sizes, ceil_mode=True)
+            self.pooling_layer = nn.AvgPool1d(
+                kernel_size=self.pooling_sizes,
+                stride=self.pooling_sizes,
+                ceil_mode=True,
+            )
 
         hidden_layers = []
         for i in range(n_layers):
-            hidden_layers.append(nn.Linear(in_features=self.hidden_size[i], out_features=self.hidden_size[i + 1]))
+            hidden_layers.append(
+                nn.Linear(
+                    in_features=self.hidden_size[i],
+                    out_features=self.hidden_size[i + 1],
+                )
+            )
             hidden_layers.append(activ)
 
             if self.batch_normalization:
-                hidden_layers.append(nn.BatchNorm1d(num_features=self.hidden_size[i + 1]))
+                hidden_layers.append(
+                    nn.BatchNorm1d(num_features=self.hidden_size[i + 1])
+                )
 
             if self.dropout > 0:
                 hidden_layers.append(nn.Dropout(p=self.dropout))
@@ -155,19 +182,26 @@ class NHiTSBlock(nn.Module):
         output_layer = [
             nn.Linear(
                 in_features=self.hidden_size[-1],
-                out_features=context_length * len(output_size) + n_theta * sum(output_size),
+                out_features=context_length * len(output_size)
+                + n_theta * sum(output_size),
             )
         ]
         layers = hidden_layers + output_layer
 
         # static_size is computed with data, static_hidden_size is provided by user, if 0 no statics are used
         if (self.static_size > 0) and (self.static_hidden_size > 0):
-            self.static_encoder = StaticFeaturesEncoder(in_features=static_size, out_features=static_hidden_size)
+            self.static_encoder = StaticFeaturesEncoder(
+                in_features=static_size, out_features=static_hidden_size
+            )
         self.layers = nn.Sequential(*layers)
         self.basis = basis
 
     def forward(
-        self, encoder_y: torch.Tensor, encoder_x_t: torch.Tensor, decoder_x_t: torch.Tensor, x_s: torch.Tensor
+        self,
+        encoder_y: torch.Tensor,
+        encoder_x_t: torch.Tensor,
+        decoder_x_t: torch.Tensor,
+        x_s: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         batch_size = len(encoder_y)
 
@@ -201,11 +235,21 @@ class NHiTSBlock(nn.Module):
 
         # Compute local projection weights and projection
         theta = self.layers(encoder_y)
-        backcast_theta = theta[:, : self.context_length * len(self.output_size)].reshape(-1, self.context_length)
-        forecast_theta = theta[:, self.context_length * len(self.output_size) :].reshape(-1, self.n_theta)
-        backcast, forecast = self.basis(backcast_theta, forecast_theta, encoder_x_t, decoder_x_t)
-        backcast = backcast.reshape(-1, len(self.output_size), self.context_length).transpose(1, 2)
-        forecast = forecast.reshape(-1, sum(self.output_size), self.prediction_length).transpose(1, 2)
+        backcast_theta = theta[
+            :, : self.context_length * len(self.output_size)
+        ].reshape(-1, self.context_length)
+        forecast_theta = theta[
+            :, self.context_length * len(self.output_size) :
+        ].reshape(-1, self.n_theta)
+        backcast, forecast = self.basis(
+            backcast_theta, forecast_theta, encoder_x_t, decoder_x_t
+        )
+        backcast = backcast.reshape(
+            -1, len(self.output_size), self.context_length
+        ).transpose(1, 2)
+        forecast = forecast.reshape(
+            -1, sum(self.output_size), self.prediction_length
+        ).transpose(1, 2)
 
         return backcast, forecast
 
@@ -343,15 +387,17 @@ class NHiTS(nn.Module):
         decoder_x_t,
         x_s,
     ):
-        residuals = (
-            encoder_y  # .flip(dims=(1,))  # todo: check if flip is required or should be rather replaced by scatter
-        )
+        residuals = encoder_y  # .flip(dims=(1,))  # todo: check if flip is required or should be rather replaced by scatter
         # encoder_x_t = encoder_x_t.flip(dims=(-1,))
         # encoder_mask = encoder_mask.flip(dims=(-1,))
         encoder_mask = encoder_mask.unsqueeze(-1)
 
-        level = encoder_y[:, -1:].repeat(1, self.prediction_length, 1)  # Level with Naive1
-        forecast_level = level.repeat_interleave(torch.tensor(self.output_size, device=level.device), dim=2)
+        level = encoder_y[:, -1:].repeat(
+            1, self.prediction_length, 1
+        )  # Level with Naive1
+        forecast_level = level.repeat_interleave(
+            torch.tensor(self.output_size, device=level.device), dim=2
+        )
 
         # level with last available observation
         if self.naive_level:
@@ -367,7 +413,10 @@ class NHiTS(nn.Module):
         # forecast by block
         for block in self.blocks:
             block_backcast, block_forecast = block(
-                encoder_y=residuals, encoder_x_t=encoder_x_t, decoder_x_t=decoder_x_t, x_s=x_s
+                encoder_y=residuals,
+                encoder_x_t=encoder_x_t,
+                decoder_x_t=decoder_x_t,
+                x_s=x_s,
             )
             residuals = (residuals - block_backcast) * encoder_mask
 

--- a/pytorch_forecasting/models/nn/__init__.py
+++ b/pytorch_forecasting/models/nn/__init__.py
@@ -2,4 +2,11 @@ from pytorch_forecasting.models.nn.embeddings import MultiEmbedding
 from pytorch_forecasting.models.nn.rnn import GRU, LSTM, HiddenState, get_rnn
 from pytorch_forecasting.utils import TupleOutputMixIn
 
-__all__ = ["MultiEmbedding", "get_rnn", "LSTM", "GRU", "HiddenState", "TupleOutputMixIn"]
+__all__ = [
+    "MultiEmbedding",
+    "get_rnn",
+    "LSTM",
+    "GRU",
+    "HiddenState",
+    "TupleOutputMixIn",
+]

--- a/pytorch_forecasting/models/nn/embeddings.py
+++ b/pytorch_forecasting/models/nn/embeddings.py
@@ -16,13 +16,17 @@ class TimeDistributedEmbeddingBag(nn.EmbeddingBag):
             return super().forward(x)
 
         # Squash samples and timesteps into a single axis
-        x_reshape = x.contiguous().view(-1, x.size(-1))  # (samples * timesteps, input_size)
+        x_reshape = x.contiguous().view(
+            -1, x.size(-1)
+        )  # (samples * timesteps, input_size)
 
         y = super().forward(x_reshape)
 
         # We have to reshape Y
         if self.batch_first:
-            y = y.contiguous().view(x.size(0), -1, y.size(-1))  # (samples, timesteps, output_size)
+            y = y.contiguous().view(
+                x.size(0), -1, y.size(-1)
+            )  # (samples, timesteps, output_size)
         else:
             y = y.view(-1, x.size(1), y.size(-1))  # (timesteps, samples, output_size)
         return y
@@ -33,7 +37,9 @@ class MultiEmbedding(nn.Module):
 
     def __init__(
         self,
-        embedding_sizes: Union[Dict[str, Tuple[int, int]], Dict[str, int], List[int], List[Tuple[int, int]]],
+        embedding_sizes: Union[
+            Dict[str, Tuple[int, int]], Dict[str, int], List[int], List[Tuple[int, int]]
+        ],
         x_categoricals: List[str] = None,
         categorical_groups: Optional[Dict[str, List[str]]] = None,
         embedding_paddings: Optional[List[str]] = None,
@@ -79,7 +85,9 @@ class MultiEmbedding(nn.Module):
             self.concat_output = False  # return dictionary of embeddings
             # conduct input data checks
             assert x_categoricals is not None, "x_categoricals must be provided."
-            categorical_group_variables = [name for names in categorical_groups.values() for name in names]
+            categorical_group_variables = [
+                name for names in categorical_groups.values() for name in names
+            ]
             if len(categorical_groups) > 0:
                 assert all(
                     name in embedding_sizes for name in categorical_groups
@@ -91,7 +99,9 @@ class MultiEmbedding(nn.Module):
                     name in x_categoricals for name in categorical_group_variables
                 ), "group variables in categorical_groups must be in x_categoricals."
             assert all(
-                name in embedding_sizes for name in embedding_sizes if name not in categorical_group_variables
+                name in embedding_sizes
+                for name in embedding_sizes
+                if name not in categorical_group_variables
             ), (
                 "all variables in embedding_sizes must be in x_categoricals - but only if"
                 "not already in categorical_groups."
@@ -101,7 +111,9 @@ class MultiEmbedding(nn.Module):
                 x_categoricals is None and len(categorical_groups) == 0
             ), "If embedding_sizes is not a dictionary, categorical_groups and x_categoricals must be empty."
             # number embeddings based on order
-            embedding_sizes = {str(name): size for name, size in enumerate(embedding_sizes)}
+            embedding_sizes = {
+                str(name): size for name, size in enumerate(embedding_sizes)
+            }
             x_categoricals = list(embedding_sizes.keys())
             self.concat_output = True
 
@@ -128,7 +140,10 @@ class MultiEmbedding(nn.Module):
             self.embedding_sizes[name][1] = embedding_size
             if name in self.categorical_groups:  # embedding bag if related embeddings
                 self.embeddings[name] = TimeDistributedEmbeddingBag(
-                    self.embedding_sizes[name][0], embedding_size, mode="sum", batch_first=True
+                    self.embedding_sizes[name][0],
+                    embedding_size,
+                    mode="sum",
+                    batch_first=True,
                 )
             else:
                 if name in self.embedding_paddings:
@@ -185,7 +200,10 @@ class MultiEmbedding(nn.Module):
                 input_vectors[name] = emb(
                     x[
                         ...,
-                        [self.x_categoricals.index(cat_name) for cat_name in self.categorical_groups[name]],
+                        [
+                            self.x_categoricals.index(cat_name)
+                            for cat_name in self.categorical_groups[name]
+                        ],
                     ]
                 )
             else:

--- a/pytorch_forecasting/models/nn/embeddings.py
+++ b/pytorch_forecasting/models/nn/embeddings.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple, Union, Optional
+from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn

--- a/pytorch_forecasting/models/nn/rnn.py
+++ b/pytorch_forecasting/models/nn/rnn.py
@@ -21,7 +21,10 @@ class RNN(ABC, nn.RNNBase):
 
     @abstractmethod
     def handle_no_encoding(
-        self, hidden_state: HiddenState, no_encoding: torch.BoolTensor, initial_hidden_state: HiddenState
+        self,
+        hidden_state: HiddenState,
+        no_encoding: torch.BoolTensor,
+        initial_hidden_state: HiddenState,
     ) -> HiddenState:
         """
         Mask the hidden_state where there is no encoding.
@@ -50,7 +53,9 @@ class RNN(ABC, nn.RNNBase):
         pass
 
     @abstractmethod
-    def repeat_interleave(self, hidden_state: HiddenState, n_samples: int) -> HiddenState:
+    def repeat_interleave(
+        self, hidden_state: HiddenState, n_samples: int
+    ) -> HiddenState:
         """
         Duplicate the hidden_state n_samples times.
 
@@ -89,7 +94,9 @@ class RNN(ABC, nn.RNNBase):
                 Output is packed sequence if input has been a packed sequence.
         """
         if isinstance(x, rnn.PackedSequence) or lengths is None:
-            assert lengths is None, "cannot combine x of type PackedSequence with lengths argument"
+            assert (
+                lengths is None
+            ), "cannot combine x of type PackedSequence with lengths argument"
             return super().forward(x, hx=hx)
         else:
             min_length = lengths.min()
@@ -99,15 +106,30 @@ class RNN(ABC, nn.RNNBase):
             if max_length == 0:
                 hidden_state = self.init_hidden_state(x)
                 if self.batch_first:
-                    out = torch.zeros(lengths.size(0), x.size(1), self.hidden_size, dtype=x.dtype, device=x.device)
+                    out = torch.zeros(
+                        lengths.size(0),
+                        x.size(1),
+                        self.hidden_size,
+                        dtype=x.dtype,
+                        device=x.device,
+                    )
                 else:
-                    out = torch.zeros(x.size(0), lengths.size(0), self.hidden_size, dtype=x.dtype, device=x.device)
+                    out = torch.zeros(
+                        x.size(0),
+                        lengths.size(0),
+                        self.hidden_size,
+                        dtype=x.dtype,
+                        device=x.device,
+                    )
                 return out, hidden_state
             else:
                 pack_lengths = lengths.where(lengths > 0, torch.ones_like(lengths))
                 packed_out, hidden_state = super().forward(
                     rnn.pack_padded_sequence(
-                        x, pack_lengths.cpu(), enforce_sorted=enforce_sorted, batch_first=self.batch_first
+                        x,
+                        pack_lengths.cpu(),
+                        enforce_sorted=enforce_sorted,
+                        batch_first=self.batch_first,
                     ),
                     hx=hx,
                 )
@@ -121,10 +143,14 @@ class RNN(ABC, nn.RNNBase):
                     else:
                         initial_hidden_state = hx
                     # propagate initial hidden state when sequence length was 0
-                    hidden_state = self.handle_no_encoding(hidden_state, no_encoding, initial_hidden_state)
+                    hidden_state = self.handle_no_encoding(
+                        hidden_state, no_encoding, initial_hidden_state
+                    )
 
                 # return unpacked sequence
-                out, _ = rnn.pad_packed_sequence(packed_out, batch_first=self.batch_first)
+                out, _ = rnn.pad_packed_sequence(
+                    packed_out, batch_first=self.batch_first
+                )
                 return out, hidden_state
 
 
@@ -132,7 +158,10 @@ class LSTM(RNN, nn.LSTM):
     """LSTM that can handle zero-length sequences"""
 
     def handle_no_encoding(
-        self, hidden_state: HiddenState, no_encoding: torch.BoolTensor, initial_hidden_state: HiddenState
+        self,
+        hidden_state: HiddenState,
+        no_encoding: torch.BoolTensor,
+        initial_hidden_state: HiddenState,
     ) -> HiddenState:
         hidden, cell = hidden_state
         hidden = hidden.masked_scatter(no_encoding, initial_hidden_state[0])
@@ -157,7 +186,9 @@ class LSTM(RNN, nn.LSTM):
         )
         return hidden, cell
 
-    def repeat_interleave(self, hidden_state: HiddenState, n_samples: int) -> HiddenState:
+    def repeat_interleave(
+        self, hidden_state: HiddenState, n_samples: int
+    ) -> HiddenState:
         hidden, cell = hidden_state
         hidden = hidden.repeat_interleave(n_samples, 1)
         cell = cell.repeat_interleave(n_samples, 1)
@@ -168,7 +199,10 @@ class GRU(RNN, nn.GRU):
     """GRU that can handle zero-length sequences"""
 
     def handle_no_encoding(
-        self, hidden_state: HiddenState, no_encoding: torch.BoolTensor, initial_hidden_state: HiddenState
+        self,
+        hidden_state: HiddenState,
+        no_encoding: torch.BoolTensor,
+        initial_hidden_state: HiddenState,
     ) -> HiddenState:
         return hidden_state.masked_scatter(no_encoding, initial_hidden_state)
 
@@ -185,7 +219,9 @@ class GRU(RNN, nn.GRU):
         )
         return hidden
 
-    def repeat_interleave(self, hidden_state: HiddenState, n_samples: int) -> HiddenState:
+    def repeat_interleave(
+        self, hidden_state: HiddenState, n_samples: int
+    ) -> HiddenState:
         return hidden_state.repeat_interleave(n_samples, 1)
 
 
@@ -206,5 +242,7 @@ def get_rnn(cell_type: Union[Type[RNN], str]) -> Type[RNN]:
     elif cell_type == "GRU":
         rnn = GRU
     else:
-        raise ValueError(f"RNN type {cell_type} is not supported. supported: [LSTM, GRU]")
+        raise ValueError(
+            f"RNN type {cell_type} is not supported. supported: [LSTM, GRU]"
+        )
     return rnn

--- a/pytorch_forecasting/models/rnn/_rnn.py
+++ b/pytorch_forecasting/models/rnn/_rnn.py
@@ -3,7 +3,7 @@ Simple recurrent model - either with LSTM or GRU cells.
 """
 
 from copy import copy
-from typing import Dict, List, Tuple, Union, Optional
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch

--- a/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/__init__.py
@@ -1,6 +1,8 @@
 """Temporal fusion transformer for forecasting timeseries."""
 
-from pytorch_forecasting.models.temporal_fusion_transformer._tft import TemporalFusionTransformer
+from pytorch_forecasting.models.temporal_fusion_transformer._tft import (
+    TemporalFusionTransformer,
+)
 from pytorch_forecasting.models.temporal_fusion_transformer.sub_modules import (
     AddNorm,
     GateAddNorm,

--- a/pytorch_forecasting/models/temporal_fusion_transformer/_tft.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/_tft.py
@@ -3,7 +3,7 @@ The temporal fusion transformer is a powerful predictive model for forecasting t
 """
 
 from copy import copy
-from typing import Dict, List, Tuple, Union, Optional
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch

--- a/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
@@ -2,9 +2,9 @@
 Implementation of ``nn.Modules`` for temporal fusion transformer.
 """
 
+from copy import deepcopy
 import math
 from typing import Dict, Tuple
-from copy import deepcopy
 
 import torch
 import torch.nn as nn

--- a/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
@@ -22,20 +22,26 @@ class TimeDistributed(nn.Module):
             return self.module(x)
 
         # Squash samples and timesteps into a single axis
-        x_reshape = x.contiguous().view(-1, x.size(-1))  # (samples * timesteps, input_size)
+        x_reshape = x.contiguous().view(
+            -1, x.size(-1)
+        )  # (samples * timesteps, input_size)
 
         y = self.module(x_reshape)
 
         # We have to reshape Y
         if self.batch_first:
-            y = y.contiguous().view(x.size(0), -1, y.size(-1))  # (samples, timesteps, output_size)
+            y = y.contiguous().view(
+                x.size(0), -1, y.size(-1)
+            )  # (samples, timesteps, output_size)
         else:
             y = y.view(-1, x.size(1), y.size(-1))  # (timesteps, samples, output_size)
         return y
 
 
 class TimeDistributedInterpolation(nn.Module):
-    def __init__(self, output_size: int, batch_first: bool = False, trainable: bool = False):
+    def __init__(
+        self, output_size: int, batch_first: bool = False, trainable: bool = False
+    ):
         super().__init__()
         self.output_size = output_size
         self.batch_first = batch_first
@@ -45,7 +51,9 @@ class TimeDistributedInterpolation(nn.Module):
             self.gate = nn.Sigmoid()
 
     def interpolate(self, x):
-        upsampled = F.interpolate(x.unsqueeze(1), self.output_size, mode="linear", align_corners=True).squeeze(1)
+        upsampled = F.interpolate(
+            x.unsqueeze(1), self.output_size, mode="linear", align_corners=True
+        ).squeeze(1)
         if self.trainable:
             upsampled = upsampled * self.gate(self.mask.unsqueeze(0)) * 2.0
         return upsampled
@@ -55,13 +63,17 @@ class TimeDistributedInterpolation(nn.Module):
             return self.interpolate(x)
 
         # Squash samples and timesteps into a single axis
-        x_reshape = x.contiguous().view(-1, x.size(-1))  # (samples * timesteps, input_size)
+        x_reshape = x.contiguous().view(
+            -1, x.size(-1)
+        )  # (samples * timesteps, input_size)
 
         y = self.interpolate(x_reshape)
 
         # We have to reshape Y
         if self.batch_first:
-            y = y.contiguous().view(x.size(0), -1, y.size(-1))  # (samples, timesteps, output_size)
+            y = y.contiguous().view(
+                x.size(0), -1, y.size(-1)
+            )  # (samples, timesteps, output_size)
         else:
             y = y.view(-1, x.size(1), y.size(-1))  # (timesteps, samples, output_size)
 
@@ -99,7 +111,9 @@ class GatedLinearUnit(nn.Module):
 
 
 class ResampleNorm(nn.Module):
-    def __init__(self, input_size: int, output_size: int = None, trainable_add: bool = True):
+    def __init__(
+        self, input_size: int, output_size: int = None, trainable_add: bool = True
+    ):
         super().__init__()
 
         self.input_size = input_size
@@ -107,7 +121,9 @@ class ResampleNorm(nn.Module):
         self.output_size = output_size or input_size
 
         if self.input_size != self.output_size:
-            self.resample = TimeDistributedInterpolation(self.output_size, batch_first=True, trainable=False)
+            self.resample = TimeDistributedInterpolation(
+                self.output_size, batch_first=True, trainable=False
+            )
 
         if self.trainable_add:
             self.mask = nn.Parameter(torch.zeros(self.output_size, dtype=torch.float))
@@ -126,7 +142,9 @@ class ResampleNorm(nn.Module):
 
 
 class AddNorm(nn.Module):
-    def __init__(self, input_size: int, skip_size: int = None, trainable_add: bool = True):
+    def __init__(
+        self, input_size: int, skip_size: int = None, trainable_add: bool = True
+    ):
         super().__init__()
 
         self.input_size = input_size
@@ -134,7 +152,9 @@ class AddNorm(nn.Module):
         self.skip_size = skip_size or input_size
 
         if self.input_size != self.skip_size:
-            self.resample = TimeDistributedInterpolation(self.input_size, batch_first=True, trainable=False)
+            self.resample = TimeDistributedInterpolation(
+                self.input_size, batch_first=True, trainable=False
+            )
 
         if self.trainable_add:
             self.mask = nn.Parameter(torch.zeros(self.input_size, dtype=torch.float))
@@ -168,8 +188,12 @@ class GateAddNorm(nn.Module):
         self.skip_size = skip_size or self.hidden_size
         self.dropout = dropout
 
-        self.glu = GatedLinearUnit(self.input_size, hidden_size=self.hidden_size, dropout=self.dropout)
-        self.add_norm = AddNorm(self.hidden_size, skip_size=self.skip_size, trainable_add=trainable_add)
+        self.glu = GatedLinearUnit(
+            self.input_size, hidden_size=self.hidden_size, dropout=self.dropout
+        )
+        self.add_norm = AddNorm(
+            self.hidden_size, skip_size=self.skip_size, trainable_add=trainable_add
+        )
 
     def forward(self, x, skip):
         output = self.glu(x)
@@ -225,7 +249,9 @@ class GatedResidualNetwork(nn.Module):
             if "bias" in name:
                 torch.nn.init.zeros_(p)
             elif "fc1" in name or "fc2" in name:
-                torch.nn.init.kaiming_normal_(p, a=0, mode="fan_in", nonlinearity="leaky_relu")
+                torch.nn.init.kaiming_normal_(
+                    p, a=0, mode="fan_in", nonlinearity="leaky_relu"
+                )
             elif "context" in name:
                 torch.nn.init.xavier_uniform_(p)
 
@@ -265,7 +291,9 @@ class VariableSelectionNetwork(nn.Module):
         self.hidden_size = hidden_size
         self.input_sizes = input_sizes
         self.input_embedding_flags = input_embedding_flags
-        self._input_embedding_flags = {} if input_embedding_flags is None else deepcopy(input_embedding_flags)
+        self._input_embedding_flags = (
+            {} if input_embedding_flags is None else deepcopy(input_embedding_flags)
+        )
         self.dropout = dropout
         self.context_size = context_size
 
@@ -295,7 +323,9 @@ class VariableSelectionNetwork(nn.Module):
             if name in single_variable_grns:
                 self.single_variable_grns[name] = single_variable_grns[name]
             elif self._input_embedding_flags.get(name, False):
-                self.single_variable_grns[name] = ResampleNorm(input_size, self.hidden_size)
+                self.single_variable_grns[name] = ResampleNorm(
+                    input_size, self.hidden_size
+                )
             else:
                 self.single_variable_grns[name] = GatedResidualNetwork(
                     input_size,
@@ -314,7 +344,10 @@ class VariableSelectionNetwork(nn.Module):
 
     @property
     def input_size_total(self):
-        return sum(size if name in self._input_embedding_flags else size for name, size in self.input_sizes.items())
+        return sum(
+            size if name in self._input_embedding_flags else size
+            for name, size in self.input_sizes.items()
+        )
 
     @property
     def num_inputs(self):
@@ -346,18 +379,26 @@ class VariableSelectionNetwork(nn.Module):
             variable_embedding = x[name]
             if name in self.prescalers:
                 variable_embedding = self.prescalers[name](variable_embedding)
-            outputs = self.single_variable_grns[name](variable_embedding)  # fast forward if only one variable
+            outputs = self.single_variable_grns[name](
+                variable_embedding
+            )  # fast forward if only one variable
             if outputs.ndim == 3:  # -> batch size, time, hidden size, n_variables
-                sparse_weights = torch.ones(outputs.size(0), outputs.size(1), 1, 1, device=outputs.device)  #
+                sparse_weights = torch.ones(
+                    outputs.size(0), outputs.size(1), 1, 1, device=outputs.device
+                )  #
             else:  # ndim == 2 -> batch size, hidden size, n_variables
-                sparse_weights = torch.ones(outputs.size(0), 1, 1, device=outputs.device)
+                sparse_weights = torch.ones(
+                    outputs.size(0), 1, 1, device=outputs.device
+                )
         return outputs, sparse_weights
 
 
 class PositionalEncoder(torch.nn.Module):
     def __init__(self, d_model, max_seq_len=160):
         super().__init__()
-        assert d_model % 2 == 0, "model dimension has to be multiple of 2 (encode sin(pos) and cos(pos))"
+        assert (
+            d_model % 2 == 0
+        ), "model dimension has to be multiple of 2 (encode sin(pos) and cos(pos))"
         self.d_model = d_model
         pe = torch.zeros(max_seq_len, d_model)
         for pos in range(max_seq_len):
@@ -390,7 +431,9 @@ class ScaledDotProductAttention(nn.Module):
         attn = torch.bmm(q, k.permute(0, 2, 1))  # query-key overlap
 
         if self.scale:
-            dimension = torch.as_tensor(k.size(-1), dtype=attn.dtype, device=attn.device).sqrt()
+            dimension = torch.as_tensor(
+                k.size(-1), dtype=attn.dtype, device=attn.device
+            ).sqrt()
             attn = attn / dimension
 
         if mask is not None:
@@ -413,8 +456,12 @@ class InterpretableMultiHeadAttention(nn.Module):
         self.dropout = nn.Dropout(p=dropout)
 
         self.v_layer = nn.Linear(self.d_model, self.d_v)
-        self.q_layers = nn.ModuleList([nn.Linear(self.d_model, self.d_q) for _ in range(self.n_head)])
-        self.k_layers = nn.ModuleList([nn.Linear(self.d_model, self.d_k) for _ in range(self.n_head)])
+        self.q_layers = nn.ModuleList(
+            [nn.Linear(self.d_model, self.d_q) for _ in range(self.n_head)]
+        )
+        self.k_layers = nn.ModuleList(
+            [nn.Linear(self.d_model, self.d_k) for _ in range(self.n_head)]
+        )
         self.attention = ScaledDotProductAttention()
         self.w_h = nn.Linear(self.d_v, self.d_model, bias=False)
 

--- a/pytorch_forecasting/utils/_dependencies.py
+++ b/pytorch_forecasting/utils/_dependencies.py
@@ -57,6 +57,8 @@ def _check_matplotlib(ref="This feature", raise_error=True):
     pkgs = _get_installed_packages()
 
     if raise_error and "matplotlib" not in pkgs:
-        raise ImportError(f"{ref} requires matplotlib. Please install matplotlib with `pip install matplotlib`.")
+        raise ImportError(
+            f"{ref} requires matplotlib. Please install matplotlib with `pip install matplotlib`."
+        )
 
     return "matplotlib" in pkgs

--- a/pytorch_forecasting/utils/_utils.py
+++ b/pytorch_forecasting/utils/_utils.py
@@ -42,7 +42,11 @@ def integer_histogram(
 
 
 def groupby_apply(
-    keys: torch.Tensor, values: torch.Tensor, bins: int = 95, reduction: str = "mean", return_histogram: bool = False
+    keys: torch.Tensor,
+    values: torch.Tensor,
+    bins: int = 95,
+    reduction: str = "mean",
+    return_histogram: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Groupby apply for torch tensors
@@ -64,16 +68,24 @@ def groupby_apply(
     else:
         raise ValueError(f"Unknown reduction '{reduction}'")
     uniques, counts = keys.unique(return_counts=True)
-    groups = torch.stack([reduce(item) for item in torch.split_with_sizes(values, tuple(counts))])
-    reduced = torch.zeros(bins, dtype=values.dtype, device=values.device).scatter(dim=0, index=uniques, src=groups)
+    groups = torch.stack(
+        [reduce(item) for item in torch.split_with_sizes(values, tuple(counts))]
+    )
+    reduced = torch.zeros(bins, dtype=values.dtype, device=values.device).scatter(
+        dim=0, index=uniques, src=groups
+    )
     if return_histogram:
-        hist = torch.zeros(bins, dtype=torch.long, device=values.device).scatter(dim=0, index=uniques, src=counts)
+        hist = torch.zeros(bins, dtype=torch.long, device=values.device).scatter(
+            dim=0, index=uniques, src=counts
+        )
         return reduced, hist
     else:
         return reduced
 
 
-def profile(function: Callable, profile_fname: str, filter: str = "", period=0.0001, **kwargs):
+def profile(
+    function: Callable, profile_fname: str, filter: str = "", period=0.0001, **kwargs
+):
     """
     Profile a given function with ``vmprof``.
 
@@ -119,7 +131,9 @@ def get_embedding_size(n: int, max_size: int = 100) -> int:
         return 1
 
 
-def create_mask(size: int, lengths: torch.LongTensor, inverse: bool = False) -> torch.BoolTensor:
+def create_mask(
+    size: int, lengths: torch.LongTensor, inverse: bool = False
+) -> torch.BoolTensor:
     """
     Create boolean masks of shape len(lenghts) x size.
 
@@ -135,9 +149,13 @@ def create_mask(size: int, lengths: torch.LongTensor, inverse: bool = False) -> 
     """
 
     if inverse:  # return where values are
-        return torch.arange(size, device=lengths.device).unsqueeze(0) < lengths.unsqueeze(-1)
+        return torch.arange(size, device=lengths.device).unsqueeze(
+            0
+        ) < lengths.unsqueeze(-1)
     else:  # return where no values are
-        return torch.arange(size, device=lengths.device).unsqueeze(0) >= lengths.unsqueeze(-1)
+        return torch.arange(size, device=lengths.device).unsqueeze(
+            0
+        ) >= lengths.unsqueeze(-1)
 
 
 _NEXT_FAST_LEN = {}
@@ -206,12 +224,16 @@ def autocorrelation(input, dim=0):
 
     # truncate and normalize the result, then transpose back to original shape
     autocorr = autocorr[..., :N]
-    autocorr = autocorr / torch.tensor(range(N, 0, -1), dtype=input.dtype, device=input.device)
+    autocorr = autocorr / torch.tensor(
+        range(N, 0, -1), dtype=input.dtype, device=input.device
+    )
     autocorr = autocorr / autocorr[..., :1]
     return autocorr.transpose(dim, -1)
 
 
-def unpack_sequence(sequence: Union[torch.Tensor, rnn.PackedSequence]) -> Tuple[torch.Tensor, torch.Tensor]:
+def unpack_sequence(
+    sequence: Union[torch.Tensor, rnn.PackedSequence]
+) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Unpack RNN sequence.
 
@@ -227,7 +249,9 @@ def unpack_sequence(sequence: Union[torch.Tensor, rnn.PackedSequence]) -> Tuple[
         # batch sizes reside on the CPU by default -> we need to bring them to GPU
         lengths = lengths.to(sequence.device)
     else:
-        lengths = torch.ones(sequence.size(0), device=sequence.device, dtype=torch.long) * sequence.size(1)
+        lengths = torch.ones(
+            sequence.size(0), device=sequence.device, dtype=torch.long
+        ) * sequence.size(1)
     return sequence, lengths
 
 
@@ -250,14 +274,18 @@ def concat_sequences(
         return torch.cat(sequences, dim=1)
     elif isinstance(sequences[0], (tuple, list)):
         return tuple(
-            concat_sequences([sequences[ii][i] for ii in range(len(sequences))]) for i in range(len(sequences[0]))
+            concat_sequences([sequences[ii][i] for ii in range(len(sequences))])
+            for i in range(len(sequences[0]))
         )
     else:
         raise ValueError("Unsupported sequence type")
 
 
 def padded_stack(
-    tensors: List[torch.Tensor], side: str = "right", mode: str = "constant", value: Union[int, float] = 0
+    tensors: List[torch.Tensor],
+    side: str = "right",
+    mode: str = "constant",
+    value: Union[int, float] = 0,
 ) -> torch.Tensor:
     """
     Stack tensors along first dimension and pad them along last dimension to ensure their size is equal.
@@ -283,7 +311,11 @@ def padded_stack(
 
     out = torch.stack(
         [
-            F.pad(x, make_padding(full_size - x.size(-1)), mode=mode, value=value) if full_size - x.size(-1) > 0 else x
+            (
+                F.pad(x, make_padding(full_size - x.size(-1)), mode=mode, value=value)
+                if full_size - x.size(-1) > 0
+                else x
+            )
             for x in tensors
         ],
         dim=0,
@@ -485,7 +517,9 @@ def detach(
         return x
 
 
-def masked_op(tensor: torch.Tensor, op: str = "mean", dim: int = 0, mask: torch.Tensor = None) -> torch.Tensor:
+def masked_op(
+    tensor: torch.Tensor, op: str = "mean", dim: int = 0, mask: torch.Tensor = None
+) -> torch.Tensor:
     """Calculate operation on masked tensor.
 
     Args:
@@ -531,14 +565,21 @@ def repr_class(
         extra_attributes = {}
     # get attributes
     if isinstance(attributes, (tuple, list)):
-        attributes = {name: getattr(obj, name) for name in attributes if hasattr(obj, name)}
+        attributes = {
+            name: getattr(obj, name) for name in attributes if hasattr(obj, name)
+        }
     attributes_strings = [f"{name}={repr(value)}" for name, value in attributes.items()]
     # get header
     header_name = obj.__class__.__name__
     # add extra attributes
     if len(extra_attributes) > 0:
-        extra_attributes_strings = [f"{name}={repr(value)}" for name, value in extra_attributes.items()]
-        if len(header_name) + 2 + len(", ".join(extra_attributes_strings)) > max_characters_before_break:
+        extra_attributes_strings = [
+            f"{name}={repr(value)}" for name, value in extra_attributes.items()
+        ]
+        if (
+            len(header_name) + 2 + len(", ".join(extra_attributes_strings))
+            > max_characters_before_break
+        ):
             header = f"{header_name}[\n\t" + ",\n\t".join(attributes_strings) + "\n]("
         else:
             header = f"{header_name}[{', '.join(extra_attributes_strings)}]("
@@ -547,7 +588,10 @@ def repr_class(
 
     # create final representation
     attributes_string = ", ".join(attributes_strings)
-    if len(attributes_string) + len(header.split("\n")[-1]) + 1 > max_characters_before_break:
+    if (
+        len(attributes_string) + len(header.split("\n")[-1]) + 1
+        > max_characters_before_break
+    ):
         attributes_string = "\n\t" + ",\n\t".join(attributes_strings) + "\n"
     return f"{header}{attributes_string})"
 
@@ -565,4 +609,10 @@ class InitialParameterRepresenterMixIn:
             return "\t" + repr(self.hparams).replace("\n", "\n\t")
         else:
             attributes = list(inspect.signature(self.__class__).parameters.keys())
-            return ", ".join([f"{name}={repr(getattr(self, name))}" for name in attributes if hasattr(self, name)])
+            return ", ".join(
+                [
+                    f"{name}={repr(getattr(self, name))}"
+                    for name in attributes
+                    if hasattr(self, name)
+                ]
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,9 @@ def test_data():
         "beer_capital",
         "music_fest",
     ]
-    data[special_days] = data[special_days].apply(lambda x: x.map({0: "", 1: x.name})).astype("category")
+    data[special_days] = (
+        data[special_days].apply(lambda x: x.map({0: "", 1: x.name})).astype("category")
+    )
 
     data = data[lambda x: x.time_idx < 10]  # downsample
     return data

--- a/tests/test_data/test_encoders.py
+++ b/tests/test_data/test_encoders.py
@@ -37,9 +37,15 @@ def test_NaNLabelEncoder(data, allow_nan):
         with pytest.raises(KeyError):
             encoder.transform(transform_data)
     else:
-        assert encoder.transform(transform_data)[0] == 0, "First value should be translated to 0 if nan"
-        assert encoder.transform(transform_data)[-1] == 0, "Last value should be translated to 0 if nan"
-        assert encoder.transform(fit_data)[0] > 0, "First value should not be 0 if not nan"
+        assert (
+            encoder.transform(transform_data)[0] == 0
+        ), "First value should be translated to 0 if nan"
+        assert (
+            encoder.transform(transform_data)[-1] == 0
+        ), "Last value should be translated to 0 if nan"
+        assert (
+            encoder.transform(fit_data)[0] > 0
+        ), "First value should not be 0 if not nan"
 
 
 def test_NaNLabelEncoder_add():
@@ -80,11 +86,16 @@ def test_EncoderNormalizer(kwargs):
 
     if kwargs.get("transformation") in ["relu", "softplus", "log1p"]:
         assert (
-            normalizer.inverse_transform(torch.as_tensor(normalizer.fit_transform(data))) >= 0
+            normalizer.inverse_transform(
+                torch.as_tensor(normalizer.fit_transform(data))
+            )
+            >= 0
         ).all(), "Inverse transform should yield only positive values"
     else:
         assert torch.isclose(
-            normalizer.inverse_transform(torch.as_tensor(normalizer.fit_transform(data))),
+            normalizer.inverse_transform(
+                torch.as_tensor(normalizer.fit_transform(data))
+            ),
             torch.as_tensor(data),
             atol=1e-5,
         ).all(), "Inverse transform should reverse transform"
@@ -107,7 +118,9 @@ def test_EncoderNormalizer(kwargs):
 )
 def test_GroupNormalizer(kwargs, groups):
     data = pd.DataFrame(dict(a=[1, 1, 2, 2, 3], b=[1.1, 1.1, 1.0, 0.0, 1.1]))
-    defaults = dict(method="standard", transformation=None, center=True, scale_by_group=False)
+    defaults = dict(
+        method="standard", transformation=None, center=True, scale_by_group=False
+    )
     defaults.update(kwargs)
     kwargs = defaults
     kwargs["groups"] = groups
@@ -122,7 +135,9 @@ def test_GroupNormalizer(kwargs, groups):
     )
 
     if kwargs.get("transformation") in ["relu", "softplus", "log1p", "log"]:
-        assert (normalizer(test_data) >= 0).all(), "Inverse transform should yield only positive values"
+        assert (
+            normalizer(test_data) >= 0
+        ).all(), "Inverse transform should yield only positive values"
     else:
         assert torch.isclose(
             normalizer(test_data), torch.tensor(data.b.iloc[0]), atol=1e-5
@@ -136,7 +151,11 @@ def test_EncoderNormalizer_with_limited_history():
 
 
 def test_MultiNormalizer_fitted():
-    data = pd.DataFrame(dict(a=[1, 1, 2, 2, 3], b=[1.1, 1.1, 1.0, 5.0, 1.1], c=[1.1, 1.1, 1.0, 5.0, 1.1]))
+    data = pd.DataFrame(
+        dict(
+            a=[1, 1, 2, 2, 3], b=[1.1, 1.1, 1.0, 5.0, 1.1], c=[1.1, 1.1, 1.0, 5.0, 1.1]
+        )
+    )
 
     normalizer = MultiNormalizer([GroupNormalizer(groups=["a"]), TorchNormalizer()])
 
@@ -160,8 +179,17 @@ def test_TorchNormalizer_dtype_consistency():
     """
     parameters = torch.tensor([[[366.4587]]])
     target_scale = torch.tensor([[427875.7500, 80367.4766]], dtype=torch.float64)
-    assert TorchNormalizer()(dict(prediction=parameters, target_scale=target_scale)).dtype == torch.float32
-    assert TorchNormalizer().transform(parameters, target_scale=target_scale).dtype == torch.float32
+    assert (
+        TorchNormalizer()(dict(prediction=parameters, target_scale=target_scale)).dtype
+        == torch.float32
+    )
+    assert (
+        TorchNormalizer().transform(parameters, target_scale=target_scale).dtype
+        == torch.float32
+    )
 
     y = np.array([1, 2, 3], dtype=np.float32)
-    assert TorchNormalizer(method="identity").fit(y).get_parameters().dtype == torch.float32
+    assert (
+        TorchNormalizer(method="identity").fit(y).get_parameters().dtype
+        == torch.float32
+    )

--- a/tests/test_data/test_samplers.py
+++ b/tests/test_data/test_samplers.py
@@ -13,14 +13,22 @@ from pytorch_forecasting.data import TimeSynchronizedBatchSampler
         (True, False, False, 1000),
     ],
 )
-def test_TimeSynchronizedBatchSampler(test_dataset, shuffle, drop_last, as_string, batch_size):
+def test_TimeSynchronizedBatchSampler(
+    test_dataset, shuffle, drop_last, as_string, batch_size
+):
     if as_string:
         dataloader = test_dataset.to_dataloader(
-            batch_sampler="synchronized", shuffle=shuffle, drop_last=drop_last, batch_size=batch_size
+            batch_sampler="synchronized",
+            shuffle=shuffle,
+            drop_last=drop_last,
+            batch_size=batch_size,
         )
     else:
         sampler = TimeSynchronizedBatchSampler(
-            SequentialSampler(test_dataset), shuffle=shuffle, drop_last=drop_last, batch_size=batch_size
+            SequentialSampler(test_dataset),
+            shuffle=shuffle,
+            drop_last=drop_last,
+            batch_size=batch_size,
         )
         dataloader = test_dataset.to_dataloader(batch_sampler=sampler)
 

--- a/tests/test_data/test_timeseries.py
+++ b/tests/test_data/test_timeseries.py
@@ -9,7 +9,12 @@ from sklearn.preprocessing import StandardScaler
 import torch
 from torch.utils.data.sampler import SequentialSampler
 
-from pytorch_forecasting.data import EncoderNormalizer, GroupNormalizer, NaNLabelEncoder, TimeSeriesDataSet
+from pytorch_forecasting.data import (
+    EncoderNormalizer,
+    GroupNormalizer,
+    NaNLabelEncoder,
+    TimeSeriesDataSet,
+)
 from pytorch_forecasting.data.encoders import MultiNormalizer, TorchNormalizer
 from pytorch_forecasting.data.timeseries import _find_end_indices
 from pytorch_forecasting.utils import to_list
@@ -17,10 +22,37 @@ from pytorch_forecasting.utils import to_list
 
 def test_find_end_indices():
     diffs = np.array([1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1])
-    max_lengths = np.array([4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1])
+    max_lengths = np.array(
+        [4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1, 4, 4, 4, 4, 4, 4, 4, 4, 3, 2, 1]
+    )
 
     ends, missings = _find_end_indices(diffs, max_lengths, min_length=3)
-    ends_test = np.array([3, 4, 4, 5, 6, 8, 9, 10, 10, 10, 10, 14, 15, 15, 16, 17, 19, 20, 21, 21, 21, 21])
+    ends_test = np.array(
+        [
+            3,
+            4,
+            4,
+            5,
+            6,
+            8,
+            9,
+            10,
+            10,
+            10,
+            10,
+            14,
+            15,
+            15,
+            16,
+            17,
+            19,
+            20,
+            21,
+            21,
+            21,
+            21,
+        ]
+    )
     missings_test = np.array([[0, 2], [5, 7], [11, 13], [16, 18]])
     np.testing.assert_array_equal(ends, ends_test)
     np.testing.assert_array_equal(missings, missings_test)
@@ -28,7 +60,11 @@ def test_find_end_indices():
 
 def test_raise_short_encoder_length(test_data):
     with pytest.warns(UserWarning):
-        test_data = test_data[lambda x: ~((x.agency == "Agency_22") & (x.sku == "SKU_01") & (x.time_idx > 3))]
+        test_data = test_data[
+            lambda x: ~(
+                (x.agency == "Agency_22") & (x.sku == "SKU_01") & (x.time_idx > 3)
+            )
+        ]
         TimeSeriesDataSet(
             test_data,
             time_idx="time_idx",
@@ -73,7 +109,9 @@ def check_dataloader_output(dataset: TimeSeriesDataSet, out: Dict[str, torch.Ten
             assert not torch.isnan(vi).any(), f"Values for {k} should not be nan"
 
     # check weight
-    assert y[1] is None or isinstance(y[1], torch.Tensor), "weights should be none or tensor"
+    assert y[1] is None or isinstance(
+        y[1], torch.Tensor
+    ), "weights should be none or tensor"
     if isinstance(y[1], torch.Tensor):
         assert torch.isfinite(y[1]).all(), "Values for weight should be finite"
         assert not torch.isnan(y[1]).any(), "Values for weight should not be nan"
@@ -114,8 +152,22 @@ def check_dataloader_output(dataset: TimeSeriesDataSet, out: Dict[str, torch.Ten
                 ]
             ),
         ),
-        dict(time_varying_known_reals=["time_idx", "price_regular", "discount_in_percent"]),
-        dict(time_varying_unknown_reals=["volume", "log_volume", "industry_volume", "soda_volume", "avg_max_temp"]),
+        dict(
+            time_varying_known_reals=[
+                "time_idx",
+                "price_regular",
+                "discount_in_percent",
+            ]
+        ),
+        dict(
+            time_varying_unknown_reals=[
+                "volume",
+                "log_volume",
+                "industry_volume",
+                "soda_volume",
+                "avg_max_temp",
+            ]
+        ),
         dict(
             target_normalizer=GroupNormalizer(
                 groups=["agency", "sku"],
@@ -137,7 +189,10 @@ def check_dataloader_output(dataset: TimeSeriesDataSet, out: Dict[str, torch.Ten
             time_varying_known_categoricals=["month"],
             time_varying_known_reals=["time_idx", "price_regular"],
         ),
-        dict(categorical_encoders={"month": NaNLabelEncoder(add_nan=True)}, time_varying_known_categoricals=["month"]),
+        dict(
+            categorical_encoders={"month": NaNLabelEncoder(add_nan=True)},
+            time_varying_known_categoricals=["month"],
+        ),
         dict(constant_fill_strategy=dict(volume=0.0), allow_missing_timesteps=True),
         dict(target_normalizer=None),
     ],
@@ -194,7 +249,10 @@ def test_from_dataset_equivalence(test_data):
         predict=True,
     )
     # ensure validation1 and validation2 datasets are exactly the same despite different data inputs
-    for v1, v2 in zip(iter(validation1.to_dataloader(train=False)), iter(validation2.to_dataloader(train=False))):
+    for v1, v2 in zip(
+        iter(validation1.to_dataloader(train=False)),
+        iter(validation2.to_dataloader(train=False)),
+    ):
         for k in v1[0].keys():
             if isinstance(v1[0][k], (tuple, list)):
                 assert len(v1[0][k]) == len(v2[0][k])
@@ -216,7 +274,11 @@ def test_dataset_index(test_dataset):
 @pytest.mark.parametrize("min_prediction_idx", [0, 1, 3, 7])
 def test_min_prediction_idx(test_dataset, test_data, min_prediction_idx):
     dataset = TimeSeriesDataSet.from_dataset(
-        test_dataset, test_data, min_prediction_idx=min_prediction_idx, min_encoder_length=1, max_prediction_length=10
+        test_dataset,
+        test_data,
+        min_prediction_idx=min_prediction_idx,
+        min_encoder_length=1,
+        max_prediction_length=10,
     )
 
     for x, _ in iter(dataset.to_dataloader(num_workers=0, batch_size=1000)):
@@ -250,7 +312,10 @@ def test_overwrite_values(test_dataset, value, variable, target):
         output_name_suffix = "cat"
 
     if target == "all":
-        output_names = [f"encoder_{output_name_suffix}", f"decoder_{output_name_suffix}"]
+        output_names = [
+            f"encoder_{output_name_suffix}",
+            f"decoder_{output_name_suffix}",
+        ]
     else:
         output_names = [f"{target}_{output_name_suffix}"]
 
@@ -269,7 +334,9 @@ def test_overwrite_values(test_dataset, value, variable, target):
     for name in outputs[0].keys():
         changed = torch.isclose(outputs[0][name], control_outputs[0][name]).all()
         assert changed, f"Output {name} should be reset"
-    assert torch.isclose(outputs[1][0], control_outputs[1][0]).all(), "Target should be reset"
+    assert torch.isclose(
+        outputs[1][0], control_outputs[1][0]
+    ).all(), "Target should be reset"
 
 
 @pytest.mark.parametrize(
@@ -277,7 +344,9 @@ def test_overwrite_values(test_dataset, value, variable, target):
     [
         {},
         dict(
-            target_normalizer=GroupNormalizer(groups=["agency", "sku"], transformation="log1p", scale_by_group=True),
+            target_normalizer=GroupNormalizer(
+                groups=["agency", "sku"], transformation="log1p", scale_by_group=True
+            ),
         ),
     ],
 )
@@ -293,7 +362,9 @@ def test_new_group_ids(test_data, kwargs):
         max_prediction_length=2,
         min_prediction_length=1,
         min_encoder_length=1,
-        categorical_encoders=dict(agency=NaNLabelEncoder(add_nan=True), sku=NaNLabelEncoder(add_nan=True)),
+        categorical_encoders=dict(
+            agency=NaNLabelEncoder(add_nan=True), sku=NaNLabelEncoder(add_nan=True)
+        ),
         **kwargs,
     )
 
@@ -343,7 +414,9 @@ def test_encoder_normalizer_for_covariates(test_data):
     [
         {},
         dict(
-            target_normalizer=MultiNormalizer(normalizers=[TorchNormalizer(), EncoderNormalizer()]),
+            target_normalizer=MultiNormalizer(
+                normalizers=[TorchNormalizer(), EncoderNormalizer()]
+            ),
         ),
         dict(add_target_scales=True),
         dict(weight="volume"),
@@ -421,15 +494,24 @@ def test_lagged_variables(test_data, kwargs):
             lag_idx = vars.index(f"{name}_lagged_by_{lag}")
             target = x[..., target_idx][:, 0]
             lagged_target = torch.roll(x[..., lag_idx], -lag, dims=1)[:, 0]
-            assert torch.isclose(target, lagged_target).all(), "lagged target must be the same as non-lagged target"
+            assert torch.isclose(
+                target, lagged_target
+            ).all(), "lagged target must be the same as non-lagged target"
 
 
 @pytest.mark.parametrize(
     "agency,first_prediction_idx,should_raise",
-    [("Agency_01", 0, False), ("xxxxx", 0, True), ("Agency_01", 100, True), ("Agency_01", 4, False)],
+    [
+        ("Agency_01", 0, False),
+        ("xxxxx", 0, True),
+        ("Agency_01", 100, True),
+        ("Agency_01", 4, False),
+    ],
 )
 def test_filter_data(test_dataset, agency, first_prediction_idx, should_raise):
-    func = lambda x: (x.agency == agency) & (x.time_idx_first_prediction >= first_prediction_idx)
+    func = lambda x: (x.agency == agency) & (
+        x.time_idx_first_prediction >= first_prediction_idx
+    )
     if should_raise:
         with pytest.raises(ValueError):
             test_dataset.filter(func)
@@ -441,7 +523,9 @@ def test_filter_data(test_dataset, agency, first_prediction_idx, should_raise):
         for x, _ in iter(filtered_dataset.to_dataloader()):
             index = test_dataset.x_to_index(x)
             assert (index["agency"] == agency).all(), "Agency filter has failed"
-            assert index["time_idx"].min() == first_prediction_idx, "First prediction filter has failed"
+            assert (
+                index["time_idx"].min() == first_prediction_idx
+            ), "First prediction filter has failed"
 
 
 def test_graph_sampler(test_dataset):
@@ -475,7 +559,10 @@ def test_graph_sampler(test_dataset):
                 indices = self.sampler.data_source.index.iloc[self._groups[name]]
                 selected_pos = indices["index_start"].iloc[sub_group_idx]
                 # remove selected sample
-                indices = indices[lambda x: x["sequence_id"] != indices["sequence_id"].iloc[sub_group_idx]]
+                indices = indices[
+                    lambda x: x["sequence_id"]
+                    != indices["sequence_id"].iloc[sub_group_idx]
+                ]
                 # filter duplicate timeseries
                 # indices = indices.sort_values("sequence_length").drop_duplicates("sequence_id", keep="last")
 
@@ -495,12 +582,17 @@ def test_graph_sampler(test_dataset):
                 # sample random subset of neighborhood
                 batch_size = min(len(relevant_indices), self.batch_size - 1)
                 batch_indices = [selected_index] + np.random.choice(
-                    relevant_indices, p=sample_weights / sample_weights.sum(), replace=False, size=batch_size
+                    relevant_indices,
+                    p=sample_weights / sample_weights.sum(),
+                    replace=False,
+                    size=batch_size,
                 ).tolist()
                 yield batch_indices
 
     dl = test_dataset.to_dataloader(
-        batch_sampler=NeighborhoodSampler(SequentialSampler(test_dataset), batch_size=200, shuffle=True)
+        batch_sampler=NeighborhoodSampler(
+            SequentialSampler(test_dataset), batch_size=200, shuffle=True
+        )
     )
     for idx, a in enumerate(dl):
         print(a[0]["groups"].shape)

--- a/tests/test_models/conftest.py
+++ b/tests/test_models/conftest.py
@@ -42,11 +42,15 @@ def data_with_covariates():
         "beer_capital",
         "music_fest",
     ]
-    data[special_days] = data[special_days].apply(lambda x: x.map({0: "", 1: x.name})).astype("category")
+    data[special_days] = (
+        data[special_days].apply(lambda x: x.map({0: "", 1: x.name})).astype("category")
+    )
     data = data.astype(dict(industry_volume=float))
 
     # select data subset
-    data = data[lambda x: x.sku.isin(data.sku.unique()[:2])][lambda x: x.agency.isin(data.agency.unique()[:2])]
+    data = data[lambda x: x.sku.isin(data.sku.unique()[:2])][
+        lambda x: x.agency.isin(data.agency.unique()[:2])
+    ]
 
     # default target
     data["target"] = data["volume"].clip(1e-3, 1.0)
@@ -73,7 +77,9 @@ def make_dataloaders(data_with_covariates, **kwargs):
     )
 
     validation = TimeSeriesDataSet.from_dataset(
-        training, data_with_covariates.copy(), min_prediction_idx=training.index.time.max() + 1
+        training,
+        data_with_covariates.copy(),
+        min_prediction_idx=training.index.time.max() + 1,
     )
     train_dataloader = training.to_dataloader(train=True, batch_size=2, num_workers=0)
     val_dataloader = validation.to_dataloader(train=False, batch_size=2, num_workers=0)
@@ -105,9 +111,21 @@ def make_dataloaders(data_with_covariates, **kwargs):
                     "music_fest",
                 ]
             ),
-            time_varying_known_reals=["time_idx", "price_regular", "price_actual", "discount", "discount_in_percent"],
+            time_varying_known_reals=[
+                "time_idx",
+                "price_regular",
+                "price_actual",
+                "discount",
+                "discount_in_percent",
+            ],
             time_varying_unknown_categoricals=[],
-            time_varying_unknown_reals=["volume", "log_volume", "industry_volume", "soda_volume", "avg_max_temp"],
+            time_varying_unknown_reals=[
+                "volume",
+                "log_volume",
+                "industry_volume",
+                "soda_volume",
+                "avg_max_temp",
+            ],
             constant_fill_strategy={"volume": 0},
             categorical_encoders={"sku": NaNLabelEncoder(add_nan=True)},
         ),
@@ -115,12 +133,18 @@ def make_dataloaders(data_with_covariates, **kwargs):
         dict(randomize_length=True, min_encoder_length=2),
         dict(target_normalizer=EncoderNormalizer(), min_encoder_length=2),
         dict(target_normalizer=GroupNormalizer(transformation="log1p")),
-        dict(target_normalizer=GroupNormalizer(groups=["agency", "sku"], transformation="softplus", center=False)),
+        dict(
+            target_normalizer=GroupNormalizer(
+                groups=["agency", "sku"], transformation="softplus", center=False
+            )
+        ),
         dict(target="agency"),
         # test multiple targets
         dict(target=["industry_volume", "volume"]),
         dict(target=["agency", "volume"]),
-        dict(target=["agency", "volume"], min_encoder_length=1, min_prediction_length=1),
+        dict(
+            target=["agency", "volume"], min_encoder_length=1, min_prediction_length=1
+        ),
         dict(target=["agency", "volume"], weight="volume"),
         # test weights
         dict(target="volume", weight="volume"),
@@ -153,9 +177,22 @@ def dataloaders_with_different_encoder_decoder_length(data_with_covariates):
                 "music_fest",
             ]
         ),
-        time_varying_known_reals=["time_idx", "price_regular", "price_actual", "discount", "discount_in_percent"],
+        time_varying_known_reals=[
+            "time_idx",
+            "price_regular",
+            "price_actual",
+            "discount",
+            "discount_in_percent",
+        ],
         time_varying_unknown_categoricals=[],
-        time_varying_unknown_reals=["target", "volume", "log_volume", "industry_volume", "soda_volume", "avg_max_temp"],
+        time_varying_unknown_reals=[
+            "target",
+            "volume",
+            "log_volume",
+            "industry_volume",
+            "soda_volume",
+            "avg_max_temp",
+        ],
         static_categoricals=["agency"],
         add_relative_time_idx=False,
         target_normalizer=GroupNormalizer(groups=["agency", "sku"], center=False),
@@ -212,8 +249,14 @@ def dataloaders_fixed_window_without_covariates():
         stop_randomization=True,
     )
     batch_size = 2
-    train_dataloader = training.to_dataloader(train=True, batch_size=batch_size, num_workers=0)
-    val_dataloader = validation.to_dataloader(train=False, batch_size=batch_size, num_workers=0)
-    test_dataloader = validation.to_dataloader(train=False, batch_size=batch_size, num_workers=0)
+    train_dataloader = training.to_dataloader(
+        train=True, batch_size=batch_size, num_workers=0
+    )
+    val_dataloader = validation.to_dataloader(
+        train=False, batch_size=batch_size, num_workers=0
+    )
+    test_dataloader = validation.to_dataloader(
+        train=False, batch_size=batch_size, num_workers=0
+    )
 
     return dict(train=train_dataloader, val=val_dataloader, test=test_dataloader)

--- a/tests/test_models/test_mlp.py
+++ b/tests/test_models/test_mlp.py
@@ -12,7 +12,9 @@ from pytorch_forecasting.metrics import MAE, CrossEntropy, MultiLoss, QuantileLo
 from pytorch_forecasting.models import DecoderMLP
 
 
-def _integration(data_with_covariates, tmp_path, data_loader_kwargs={}, train_only=False, **kwargs):
+def _integration(
+    data_with_covariates, tmp_path, data_loader_kwargs={}, train_only=False, **kwargs
+):
     data_loader_default_kwargs = dict(
         target="target",
         time_varying_known_reals=["price_actual"],
@@ -21,12 +23,19 @@ def _integration(data_with_covariates, tmp_path, data_loader_kwargs={}, train_on
         add_relative_time_idx=True,
     )
     data_loader_default_kwargs.update(data_loader_kwargs)
-    dataloaders_with_covariates = make_dataloaders(data_with_covariates, **data_loader_default_kwargs)
+    dataloaders_with_covariates = make_dataloaders(
+        data_with_covariates, **data_loader_default_kwargs
+    )
     train_dataloader = dataloaders_with_covariates["train"]
     val_dataloader = dataloaders_with_covariates["val"]
     test_dataloader = dataloaders_with_covariates["test"]
     early_stop_callback = EarlyStopping(
-        monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min", strict=False
+        monitor="val_loss",
+        min_delta=1e-4,
+        patience=1,
+        verbose=False,
+        mode="min",
+        strict=False,
     )
 
     logger = TensorBoardLogger(tmp_path)
@@ -61,17 +70,29 @@ def _integration(data_with_covariates, tmp_path, data_loader_kwargs={}, train_on
                 val_dataloaders=val_dataloader,
             )
         # check loading
-        net = DecoderMLP.load_from_checkpoint(trainer.checkpoint_callback.best_model_path)
+        net = DecoderMLP.load_from_checkpoint(
+            trainer.checkpoint_callback.best_model_path
+        )
 
         # check prediction
-        net.predict(val_dataloader, fast_dev_run=True, return_index=True, return_decoder_lengths=True)
+        net.predict(
+            val_dataloader,
+            fast_dev_run=True,
+            return_index=True,
+            return_decoder_lengths=True,
+        )
         # check test dataloader
         test_outputs = trainer.test(net, dataloaders=test_dataloader)
         assert len(test_outputs) > 0
     finally:
         shutil.rmtree(tmp_path, ignore_errors=True)
 
-    net.predict(val_dataloader, fast_dev_run=True, return_index=True, return_decoder_lengths=True)
+    net.predict(
+        val_dataloader,
+        fast_dev_run=True,
+        return_index=True,
+        return_decoder_lengths=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -100,7 +121,9 @@ def _integration(data_with_covariates, tmp_path, data_loader_kwargs={}, train_on
     ],
 )
 def test_integration(data_with_covariates, tmp_path, kwargs):
-    _integration(data_with_covariates.assign(target=lambda x: x.volume), tmp_path, **kwargs)
+    _integration(
+        data_with_covariates.assign(target=lambda x: x.volume), tmp_path, **kwargs
+    )
 
 
 @pytest.fixture

--- a/tests/test_models/test_nbeats.py
+++ b/tests/test_models/test_nbeats.py
@@ -15,7 +15,9 @@ def test_integration(dataloaders_fixed_window_without_covariates, tmp_path):
     val_dataloader = dataloaders_fixed_window_without_covariates["val"]
     test_dataloader = dataloaders_fixed_window_without_covariates["test"]
 
-    early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min")
+    early_stop_callback = EarlyStopping(
+        monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min"
+    )
 
     logger = TensorBoardLogger(tmp_path)
     trainer = pl.Trainer(
@@ -51,11 +53,21 @@ def test_integration(dataloaders_fixed_window_without_covariates, tmp_path):
         net = NBeats.load_from_checkpoint(trainer.checkpoint_callback.best_model_path)
 
         # check prediction
-        net.predict(val_dataloader, fast_dev_run=True, return_index=True, return_decoder_lengths=True)
+        net.predict(
+            val_dataloader,
+            fast_dev_run=True,
+            return_index=True,
+            return_decoder_lengths=True,
+        )
     finally:
         shutil.rmtree(tmp_path, ignore_errors=True)
 
-    net.predict(val_dataloader, fast_dev_run=True, return_index=True, return_decoder_lengths=True)
+    net.predict(
+        val_dataloader,
+        fast_dev_run=True,
+        return_index=True,
+        return_decoder_lengths=True,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -83,6 +95,9 @@ def test_pickle(model):
 )
 def test_interpretation(model, dataloaders_fixed_window_without_covariates):
     raw_predictions = model.predict(
-        dataloaders_fixed_window_without_covariates["val"], mode="raw", return_x=True, fast_dev_run=True
+        dataloaders_fixed_window_without_covariates["val"],
+        mode="raw",
+        return_x=True,
+        fast_dev_run=True,
     )
     model.plot_interpretation(raw_predictions.x, raw_predictions.output, idx=0)

--- a/tests/test_models/test_nhits.py
+++ b/tests/test_models/test_nhits.py
@@ -10,7 +10,9 @@ import pytest
 
 from pytorch_forecasting.data.timeseries import TimeSeriesDataSet
 from pytorch_forecasting.metrics import MQF2DistributionLoss, QuantileLoss
-from pytorch_forecasting.metrics.distributions import ImplicitQuantileNetworkDistributionLoss
+from pytorch_forecasting.metrics.distributions import (
+    ImplicitQuantileNetworkDistributionLoss,
+)
 from pytorch_forecasting.models import NHiTS
 from pytorch_forecasting.utils._dependencies import _get_installed_packages
 
@@ -20,7 +22,9 @@ def _integration(dataloader, tmp_path, trainer_kwargs=None, **kwargs):
     val_dataloader = dataloader["val"]
     test_dataloader = dataloader["test"]
 
-    early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min")
+    early_stop_callback = EarlyStopping(
+        monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min"
+    )
 
     logger = TensorBoardLogger(tmp_path)
     if trainer_kwargs is None:
@@ -123,7 +127,9 @@ def test_integration(
         kwargs["loss"] = ImplicitQuantileNetworkDistributionLoss()
     elif dataloader == "multivariate-quantiles":
         dataloader = dataloaders_with_covariates
-        kwargs["loss"] = MQF2DistributionLoss(prediction_length=dataloader["train"].dataset.max_prediction_length)
+        kwargs["loss"] = MQF2DistributionLoss(
+            prediction_length=dataloader["train"].dataset.max_prediction_length
+        )
         kwargs["learning_rate"] = 1e-9
         kwargs["trainer_kwargs"] = dict(accelerator="cpu")
     else:
@@ -155,8 +161,12 @@ def test_pickle(model):
     reason="skip test if required package matplotlib not installed",
 )
 def test_interpretation(model, dataloaders_with_covariates):
-    raw_predictions = model.predict(dataloaders_with_covariates["val"], mode="raw", return_x=True, fast_dev_run=True)
-    model.plot_prediction(raw_predictions.x, raw_predictions.output, idx=0, add_loss_to_title=True)
+    raw_predictions = model.predict(
+        dataloaders_with_covariates["val"], mode="raw", return_x=True, fast_dev_run=True
+    )
+    model.plot_prediction(
+        raw_predictions.x, raw_predictions.output, idx=0, add_loss_to_title=True
+    )
     model.plot_interpretation(raw_predictions.x, raw_predictions.output, idx=0)
 
 
@@ -195,7 +205,9 @@ def test_prediction_length(max_prediction_length: int):
         forecaster,
         train_dataloaders=training_data_loader,
     )
-    validation_dataset = TimeSeriesDataSet.from_dataset(training_dataset, data, stop_randomization=True, predict=True)
+    validation_dataset = TimeSeriesDataSet.from_dataset(
+        training_dataset, data, stop_randomization=True, predict=True
+    )
     validation_data_loader = validation_dataset.to_dataloader(train=False)
     forecaster.predict(
         validation_data_loader,

--- a/tests/test_models/test_nn/test_embeddings.py
+++ b/tests/test_models/test_nn/test_embeddings.py
@@ -20,7 +20,9 @@ from pytorch_forecasting import MultiEmbedding
 def test_MultiEmbedding(kwargs):
     x = torch.randint(0, 10, size=(4, 3))
     embedding = MultiEmbedding(**kwargs)
-    assert embedding.input_size == x.size(1), "Input size should be equal to number of features"
+    assert embedding.input_size == x.size(
+        1
+    ), "Input size should be equal to number of features"
     out = embedding(x)
     if isinstance(out, dict):
         assert isinstance(kwargs["embedding_sizes"], dict)

--- a/tests/test_models/test_nn/test_rnn.py
+++ b/tests/test_models/test_nn/test_rnn.py
@@ -45,7 +45,9 @@ def test_zero_length_sequence(klass, rnn_kwargs):
         init_hidden_state = [init_hidden_state]
 
     for idx in range(len(hidden_state)):
-        assert hidden_state[idx].size() == init_hidden_state[idx].size(), "Hidden state sizes should be equal"
+        assert (
+            hidden_state[idx].size() == init_hidden_state[idx].size()
+        ), "Hidden state sizes should be equal"
         assert (hidden_state[idx][:, lengths == 0] == 0).all() and (
             hidden_state[idx][:, lengths > 0] != 0
         ).all(), "Hidden state should be zero for zero-length sequences"

--- a/tests/test_models/test_rnn_model.py
+++ b/tests/test_models/test_rnn_model.py
@@ -12,7 +12,12 @@ from pytorch_forecasting.models import RecurrentNetwork
 
 
 def _integration(
-    data_with_covariates, tmp_path, cell_type="LSTM", data_loader_kwargs={}, clip_target: bool = False, **kwargs
+    data_with_covariates,
+    tmp_path,
+    cell_type="LSTM",
+    data_loader_kwargs={},
+    clip_target: bool = False,
+    **kwargs,
 ):
     data_with_covariates = data_with_covariates.copy()
     if clip_target:
@@ -27,12 +32,16 @@ def _integration(
         add_relative_time_idx=True,
     )
     data_loader_default_kwargs.update(data_loader_kwargs)
-    dataloaders_with_covariates = make_dataloaders(data_with_covariates, **data_loader_default_kwargs)
+    dataloaders_with_covariates = make_dataloaders(
+        data_with_covariates, **data_loader_default_kwargs
+    )
     train_dataloader = dataloaders_with_covariates["train"]
     val_dataloader = dataloaders_with_covariates["val"]
     test_dataloader = dataloaders_with_covariates["test"]
 
-    early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min")
+    early_stop_callback = EarlyStopping(
+        monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min"
+    )
 
     logger = TensorBoardLogger(tmp_path)
     trainer = pl.Trainer(
@@ -66,14 +75,26 @@ def _integration(
         test_outputs = trainer.test(net, dataloaders=test_dataloader)
         assert len(test_outputs) > 0
         # check loading
-        net = RecurrentNetwork.load_from_checkpoint(trainer.checkpoint_callback.best_model_path)
+        net = RecurrentNetwork.load_from_checkpoint(
+            trainer.checkpoint_callback.best_model_path
+        )
 
         # check prediction
-        net.predict(val_dataloader, fast_dev_run=True, return_index=True, return_decoder_lengths=True)
+        net.predict(
+            val_dataloader,
+            fast_dev_run=True,
+            return_index=True,
+            return_decoder_lengths=True,
+        )
     finally:
         shutil.rmtree(tmp_path, ignore_errors=True)
 
-    net.predict(val_dataloader, fast_dev_run=True, return_index=True, return_decoder_lengths=True)
+    net.predict(
+        val_dataloader,
+        fast_dev_run=True,
+        return_index=True,
+        return_decoder_lengths=True,
+    )
 
 
 @pytest.mark.parametrize(
@@ -82,11 +103,18 @@ def _integration(
         {},
         {"cell_type": "GRU"},
         dict(
-            data_loader_kwargs=dict(target_normalizer=GroupNormalizer(groups=["agency", "sku"], center=False)),
+            data_loader_kwargs=dict(
+                target_normalizer=GroupNormalizer(
+                    groups=["agency", "sku"], center=False
+                )
+            ),
         ),
         dict(
             data_loader_kwargs=dict(
-                lags={"volume": [2, 5]}, target="volume", time_varying_unknown_reals=["volume"], min_encoder_length=2
+                lags={"volume": [2, 5]},
+                target="volume",
+                time_varying_unknown_reals=["volume"],
+                min_encoder_length=2,
             )
         ),
         dict(

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -22,7 +22,9 @@ from pytorch_forecasting.metrics import (
     TweedieLoss,
 )
 from pytorch_forecasting.models import TemporalFusionTransformer
-from pytorch_forecasting.models.temporal_fusion_transformer.tuning import optimize_hyperparameters
+from pytorch_forecasting.models.temporal_fusion_transformer.tuning import (
+    optimize_hyperparameters,
+)
 from pytorch_forecasting.utils._dependencies import _get_installed_packages
 
 if sys.version.startswith("3.6"):  # python 3.6 does not have nullcontext
@@ -39,7 +41,11 @@ from test_models.conftest import make_dataloaders
 
 
 def test_integration(multiple_dataloaders_with_covariates, tmp_path):
-    _integration(multiple_dataloaders_with_covariates, tmp_path, trainer_kwargs=dict(accelerator="cpu"))
+    _integration(
+        multiple_dataloaders_with_covariates,
+        tmp_path,
+        trainer_kwargs=dict(accelerator="cpu"),
+    )
 
 
 def test_non_causal_attention(dataloaders_with_covariates, tmp_path):
@@ -53,7 +59,9 @@ def test_non_causal_attention(dataloaders_with_covariates, tmp_path):
 
 
 def test_distribution_loss(data_with_covariates, tmp_path):
-    data_with_covariates = data_with_covariates.assign(volume=lambda x: x.volume.round())
+    data_with_covariates = data_with_covariates.assign(
+        volume=lambda x: x.volume.round()
+    )
     dataloaders_with_covariates = make_dataloaders(
         data_with_covariates,
         target="volume",
@@ -75,7 +83,9 @@ def test_distribution_loss(data_with_covariates, tmp_path):
     reason="Test skipped if required package cpflows not available",
 )
 def test_mqf2_loss(data_with_covariates, tmp_path):
-    data_with_covariates = data_with_covariates.assign(volume=lambda x: x.volume.round())
+    data_with_covariates = data_with_covariates.assign(
+        volume=lambda x: x.volume.round()
+    )
     dataloaders_with_covariates = make_dataloaders(
         data_with_covariates,
         target="volume",
@@ -83,10 +93,14 @@ def test_mqf2_loss(data_with_covariates, tmp_path):
         time_varying_unknown_reals=["volume"],
         static_categoricals=["agency"],
         add_relative_time_idx=True,
-        target_normalizer=GroupNormalizer(groups=["agency", "sku"], center=False, transformation="log1p"),
+        target_normalizer=GroupNormalizer(
+            groups=["agency", "sku"], center=False, transformation="log1p"
+        ),
     )
 
-    prediction_length = dataloaders_with_covariates["train"].dataset.min_prediction_length
+    prediction_length = dataloaders_with_covariates[
+        "train"
+    ].dataset.min_prediction_length
 
     _integration(
         dataloaders_with_covariates,
@@ -102,7 +116,9 @@ def _integration(dataloader, tmp_path, loss=None, trainer_kwargs=None, **kwargs)
     val_dataloader = dataloader["val"]
     test_dataloader = dataloader["test"]
 
-    early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min")
+    early_stop_callback = EarlyStopping(
+        monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min"
+    )
 
     # check training
     logger = TensorBoardLogger(tmp_path)
@@ -138,7 +154,11 @@ def _integration(dataloader, tmp_path, loss=None, trainer_kwargs=None, **kwargs)
         elif isinstance(train_dataloader.dataset.target_normalizer, MultiNormalizer):
             loss = MultiLoss(
                 [
-                    CrossEntropy() if isinstance(normalizer, NaNLabelEncoder) else QuantileLoss()
+                    (
+                        CrossEntropy()
+                        if isinstance(normalizer, NaNLabelEncoder)
+                        else QuantileLoss()
+                    )
                     for normalizer in train_dataloader.dataset.target_normalizer.normalizers
                 ]
             )
@@ -171,7 +191,9 @@ def _integration(dataloader, tmp_path, loss=None, trainer_kwargs=None, **kwargs)
                 assert len(test_outputs) > 0
 
             # check loading
-            net = TemporalFusionTransformer.load_from_checkpoint(trainer.checkpoint_callback.best_model_path)
+            net = TemporalFusionTransformer.load_from_checkpoint(
+                trainer.checkpoint_callback.best_model_path
+            )
 
             # check prediction
             predictions = net.predict(
@@ -193,11 +215,15 @@ def _integration(dataloader, tmp_path, loss=None, trainer_kwargs=None, **kwargs)
                     for xi in x.values():
                         check(xi)
                 else:
-                    assert pred_len == x.shape[0], "first dimension should be prediction length"
+                    assert (
+                        pred_len == x.shape[0]
+                    ), "first dimension should be prediction length"
 
             check(predictions.output)
             if isinstance(predictions.output, torch.Tensor):
-                assert predictions.output.ndim == 2, "shape of predictions should be batch_size x timesteps"
+                assert (
+                    predictions.output.ndim == 2
+                ), "shape of predictions should be batch_size x timesteps"
             else:
                 assert all(
                     p.ndim == 2 for p in predictions.output
@@ -246,7 +272,9 @@ def test_tensorboard_graph_log(dataloaders_with_covariates, model, tmp_path):
 
 def test_init_shared_network(dataloaders_with_covariates):
     dataset = dataloaders_with_covariates["train"].dataset
-    net = TemporalFusionTransformer.from_dataset(dataset, share_single_variable_networks=True)
+    net = TemporalFusionTransformer.from_dataset(
+        dataset, share_single_variable_networks=True
+    )
     net.predict(dataset, fast_dev_run=True)
 
 
@@ -287,15 +315,26 @@ def test_pickle(model):
     pickle.loads(pkl)
 
 
-@pytest.mark.parametrize("kwargs", [dict(mode="dataframe"), dict(mode="series"), dict(mode="raw")])
-def test_predict_dependency(model, dataloaders_with_covariates, data_with_covariates, kwargs):
+@pytest.mark.parametrize(
+    "kwargs", [dict(mode="dataframe"), dict(mode="series"), dict(mode="raw")]
+)
+def test_predict_dependency(
+    model, dataloaders_with_covariates, data_with_covariates, kwargs
+):
     train_dataset = dataloaders_with_covariates["train"].dataset
     data_with_covariates = data_with_covariates.copy()
     dataset = TimeSeriesDataSet.from_dataset(
-        train_dataset, data_with_covariates[lambda x: x.agency == data_with_covariates.agency.iloc[0]], predict=True
+        train_dataset,
+        data_with_covariates[lambda x: x.agency == data_with_covariates.agency.iloc[0]],
+        predict=True,
     )
     model.predict_dependency(dataset, variable="discount", values=[0.1, 0.0], **kwargs)
-    model.predict_dependency(dataset, variable="agency", values=data_with_covariates.agency.unique()[:2], **kwargs)
+    model.predict_dependency(
+        dataset,
+        variable="agency",
+        values=data_with_covariates.agency.unique()[:2],
+        **kwargs,
+    )
 
 
 @pytest.mark.skipif(
@@ -304,7 +343,9 @@ def test_predict_dependency(model, dataloaders_with_covariates, data_with_covari
 )
 def test_actual_vs_predicted_plot(model, dataloaders_with_covariates):
     prediction = model.predict(dataloaders_with_covariates["val"], return_x=True)
-    averages = model.calculate_prediction_actual_by_variable(prediction.x, prediction.output)
+    averages = model.calculate_prediction_actual_by_variable(
+        prediction.x, prediction.output
+    )
     model.plot_prediction_actual_by_variable(averages)
 
 
@@ -359,7 +400,9 @@ def test_prediction_with_dataloder_raw(data_with_covariates, tmp_path):
     )
     logger = TensorBoardLogger(tmp_path)
     trainer = pl.Trainer(max_epochs=1, gradient_clip_val=1e-6, logger=logger)
-    trainer.fit(net, train_dataloaders=dataset.to_dataloader(batch_size=4, num_workers=0))
+    trainer.fit(
+        net, train_dataloaders=dataset.to_dataloader(batch_size=4, num_workers=0)
+    )
 
     # choose small batch size to provoke issue
     res = net.predict(dataset.to_dataloader(batch_size=2, num_workers=0), mode="raw")
@@ -399,7 +442,9 @@ SKIP_HYPEPARAM_TEST = (
     reason="Test skipped on Win due to bug #1632, or if missing required packages",
 )
 @pytest.mark.parametrize("use_learning_rate_finder", [True, False])
-def test_hyperparameter_optimization_integration(dataloaders_with_covariates, tmp_path, use_learning_rate_finder):
+def test_hyperparameter_optimization_integration(
+    dataloaders_with_covariates, tmp_path, use_learning_rate_finder
+):
     train_dataloader = dataloaders_with_covariates["train"]
     val_dataloader = dataloaders_with_covariates["val"]
     try:

--- a/tests/test_utils/test_show_versions.py
+++ b/tests/test_utils/test_show_versions.py
@@ -3,7 +3,11 @@
 import pathlib
 import uuid
 
-from pytorch_forecasting.utils._maint._show_versions import DEFAULT_DEPS_TO_SHOW, _get_deps_info, show_versions
+from pytorch_forecasting.utils._maint._show_versions import (
+    DEFAULT_DEPS_TO_SHOW,
+    _get_deps_info,
+    show_versions,
+)
 
 
 def test_show_versions_runs():


### PR DESCRIPTION
This PR updates the linting rules to make the code more readable and consistent with `sktime`:

* limit line length to 88 and apply throughout the code base
* add `isort` formatting and apply throughout the code base
* reorder `pyproject.toml` to ensure linting settings are at the end and project information is at the top