### PR TITLE
[ENH] clean-up refactor of `TimeSeriesDataSet`

### DIFF
--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -544,7 +544,7 @@ class TimeSeriesDataSet(Dataset):
         self._data_properties = self._data_properties(data)
 
         # target normalizer
-        self.target_normalizer = self._target_normalizer(
+        self.target_normalizer = self._set_target_normalizer(
             self._data_properties, self.target_normalizer
         )
 
@@ -837,7 +837,7 @@ class TimeSeriesDataSet(Dataset):
         else:
             return max([max(lag) for lag in self._lags.values()])
 
-    def _target_normalizer(self, data_properties, target_normalizer):
+    def _set_target_normalizer(self, data_properties, target_normalizer):
         """Determine target normalizer.
 
         Determines normalizers for variables based on self.target_normalizer setting.
@@ -887,7 +887,7 @@ class TimeSeriesDataSet(Dataset):
             f"class TorchNormalizer but found {target_normalizer}"
         )
         assert not self.multi_target or isinstance(
-            self.target_normalizer, MultiNormalizer
+            target_normalizer, MultiNormalizer
         ), (
             "multiple targets / list of targets requires MultiNormalizer as "
             f"target_normalizer but found {target_normalizer}"

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -922,9 +922,7 @@ class TimeSeriesDataSet(Dataset):
                 else:
                     transformer = None
                 if self.max_encoder_length > 20 and self.min_encoder_length > 1:
-                    normalizers.append(
-                        EncoderNormalizer(transformation=transformer)
-                    )
+                    normalizers.append(EncoderNormalizer(transformation=transformer))
                 else:
                     normalizers.append(GroupNormalizer(transformation=transformer))
         if self.multi_target:

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -94,15 +94,33 @@ except ImportError:
 def check_for_nonfinite(
     tensor: torch.Tensor, names: Union[str, List[str]]
 ) -> torch.Tensor:
-    """
-    Check if 2D tensor contains NAs or infinite values.
+    """Check if tensor contains NAs or infinite values and has correct dimension.
 
-    Args:
-        names (Union[str, List[str]]): name(s) of column(s) (used for error messages)
-        tensor (torch.Tensor): tensor to check
+    Checks:
 
-    Returns:
-        torch.Tensor: returns tensor if checks yield no issues
+    * whether tensor is finite, otherwise raises ValueError
+    * checks whether dimension of tensor is correct. If tensor is a str,
+      tensor.ndim has to be 1, and if tensor is a list, tensor.ndim has to be 2.
+      Otherwise raises AssertionError.
+
+    Parameters
+    ----------
+    names : str or list of str
+        name(s) of column(s) to check
+    tensor : torch.Tensor
+        tensor to check
+
+    Returns
+    -------
+    torch.Tensor
+        returns tensor unchanged, if checks yield no issues
+
+    Raises
+    ------
+    ValueError
+        if tensor contains NAs or infinite values
+    AssertionError
+        if tensor has incorrect dimension, see above
     """
     if isinstance(names, str):
         names = [names]
@@ -665,7 +683,7 @@ class TimeSeriesDataSet(Dataset):
             The following fields are returned:
 
             * columns : list[str]
-                list of columns in the data
+                list of column names in the data
             * target_type : dict[str, str]
                 type of target variable, categorial or real.
                 Keys are target variable names in self.target_names.

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1689,7 +1689,7 @@ class TimeSeriesDataSet(Dataset):
         parameters = deepcopy(parameters)
 
         if predict:
-            if not stop_randomization:
+            if isinstance(stop_randomization, bool) and not stop_randomization:
                 warnings.warn(
                     "If predicting, no randomization should be possible - "
                     "setting stop_randomization=True",

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1650,19 +1650,23 @@ class TimeSeriesDataSet(Dataset):
         return df_index
 
     def filter(self, filter_func: Callable, copy: bool = True) -> "TimeSeriesDataSet":
-        """
-        Filter subsequences in dataset.
+        """Filter subsequences in dataset.
 
         Uses interpretable version of index :py:meth:`~decoded_index`
         to filter subsequences in dataset.
 
-        Args:
-            filter_func (Callable): function to filter. Should take :py:meth:`~decoded_index`
-                dataframe as only argument which contains group ids and time index columns.
-            copy (bool): if to return copy of dataset or filter inplace.
+        Parameters
+        ----------
+        filter_func : Callable
+            function to filter. Should take :py:meth:`~decoded_index`
+            dataframe as only argument which contains group ids and time index columns.
+        copy : bool, optional, default=True
+            whether to return copy of dataset (True) or filter inplace (False).
 
-        Returns:
-            TimeSeriesDataSet: filtered dataset
+        Returns
+        -------
+        TimeSeriesDataSet
+            filtered dataset
         """
         # calculate filter
         filtered_index = self.index[np.asarray(filter_func(self.decoded_index))]
@@ -1726,17 +1730,21 @@ class TimeSeriesDataSet(Dataset):
         length: int = None,
         min_length: int = None,
     ):
-        """
-        Plot expected randomized length distribution.
+        """Plot expected randomized length distribution.
 
-        Args:
-            betas (Tuple[float, float], optional): Tuple of betas, e.g. ``(0.2, 0.05)`` to use for randomization.
-                Defaults to ``randomize_length`` of dataset.
-            length (int, optional): . Defaults to ``max_encoder_length``.
-            min_length (int, optional): [description]. Defaults to ``min_encoder_length``.
+        Parameters
+        ----------
+        betas : Tuple[float, float], optional, default=randomize_length of dataset
+            Tuple of betas, e.g. ``(0.2, 0.05)`` to use for randomization.
+        length : int, optional, default=max_encoder_length of dataset
+            Length of sequence to plot.
+        min_length : int, optional, default=min_encoder_length of dataset
+            Minimum length of sequence to plot.
 
-        Returns:
-            Tuple[plt.Figure, torch.Tensor]: tuple of figure and histogram based on 1000 samples
+        Returns
+        -------
+        Tuple[plt.Figure, torch.Tensor]
+            tuple of figure and histogram based on 1000 samples
         """
         _check_matplotlib("plot_randomization")
 

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -964,7 +964,8 @@ class TimeSeriesDataSet(Dataset):
                 name, data[name], inverse=False, group_id=True
             )
 
-        # encode categoricals first to ensure that group normalizer for relies on encoded categories
+        # encode categoricals first to ensure
+        # that group normalizer relies on encoded categories
         if isinstance(
             self.target_normalizer, (GroupNormalizer, MultiNormalizer)
         ):  # if we use a group normalizer, group_ids must be encoded as well
@@ -1687,9 +1688,8 @@ class TimeSeriesDataSet(Dataset):
             )
         ]
 
-        if (
-            predict_mode
-        ):  # keep longest element per series
+        if predict_mode:
+            # keep longest element per series
             # (i.e., the first element that spans to the end of the series)
             # filter all elements that are longer
             # than the allowed maximum sequence length

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1428,7 +1428,7 @@ class TimeSeriesDataSet(Dataset):
                 target = [_to_tensor(f"__target__{self.target}")]
 
         # continuous covariates
-        continuous = _to_tensor(self.reals, long=False)
+        continuous = _to_tensor(self.reals)
 
         tensors = dict(
             reals=continuous,

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1288,7 +1288,6 @@ class TimeSeriesDataSet(Dataset):
             dictionary of tensors for continous, categorical data, groups, target and
             time index
         """
-
         index = check_for_nonfinite(
             torch.tensor(data[self._group_ids].to_numpy(np.int64), dtype=torch.int64),
             self.group_ids,

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -471,6 +471,8 @@ class TimeSeriesDataSet(Dataset):
         """Timeseries dataset holding data for models."""
         super().__init__()
 
+        # write variables to self and handle defaults
+        # -------------------------------------------
         self.max_encoder_length = max_encoder_length
         if min_encoder_length is None:
             min_encoder_length = max_encoder_length
@@ -558,6 +560,9 @@ class TimeSeriesDataSet(Dataset):
         # check parameters
         self._check_params()
 
+        # data preprocessing in pandas
+        # ----------------------------
+
         # get metadata from data
         self._data_properties = self._data_properties(data)
 
@@ -624,8 +629,15 @@ class TimeSeriesDataSet(Dataset):
         for target in self.target_names:
             assert target not in self._scalers, msg
 
+        # index for getitem based resampling
+        # ----------------------------------
+        # NOTE: this should be refactored and probably in a DataLoader
+
         # create index
         self.index = self._construct_index(data, predict_mode=self.predict_mode)
+
+        # data conversion to torch tensors
+        # --------------------------------
 
         # convert to torch tensor for high performance data loading later
         self.data = self._data_to_tensors(data)

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -544,7 +544,9 @@ class TimeSeriesDataSet(Dataset):
         self._data_properties = self._data_properties(data)
 
         # target normalizer
-        self.target_normalizer = self._target_normalizer(self._data_properties)
+        self.target_normalizer = self._target_normalizer(
+            self._data_properties, self.target_normalizer
+        )
 
         # add time index relative to prediction position
         if self.add_relative_time_idx:
@@ -835,7 +837,7 @@ class TimeSeriesDataSet(Dataset):
         else:
             return max([max(lag) for lag in self._lags.values()])
 
-    def _target_normalizer(self, data_properties):
+    def _target_normalizer(self, data_properties, target_normalizer):
         """Determine target normalizer.
 
         Determines normalizers for variables based on self.target_normalizer setting.
@@ -859,17 +861,20 @@ class TimeSeriesDataSet(Dataset):
         ----------
         data_properties : dict
             Dictionary of data properties as returned by self._data_properties(data)
+        target_normalizer : Union[NORMALIZER, str, list, tuple, None]
+            Normalizer for target variable. If "auto", the normalizer is determined
+            as above.
 
         Returns
         -------
         TorchNormalizer
             Normalizer for target variable, determined as above.
         """
-        if isinstance(self.target_normalizer, str) and self.target_normalizer == "auto":
+        if isinstance(target_normalizer, str) and target_normalizer == "auto":
             target_normalizer = self._get_auto_normalizer(data_properties)
-        elif isinstance(self.target_normalizer, (tuple, list)):
+        elif isinstance(target_normalizer, (tuple, list)):
             target_normalizer = MultiNormalizer(self.target_normalizer)
-        elif self.target_normalizer is None:
+        elif target_normalizer is None:
             target_normalizer = TorchNormalizer(method="identity")
 
         # validation

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1389,7 +1389,7 @@ class TimeSeriesDataSet(Dataset):
             time index
         """
 
-        def _to_tensor(cols, long=False):
+        def _to_tensor(cols, long=True):
             """Convert data[cols] to torch tensor.
 
             Converts sub-frames to numpy and then to torch tensor.
@@ -1416,11 +1416,11 @@ class TimeSeriesDataSet(Dataset):
         time = _to_tensor("__time_idx__", long=False)
         categorical = _to_tensor(self.flat_categoricals, long=False)
 
-        weight = _to_tensor("__weight__", long=True)
+        weight = _to_tensor("__weight__")
 
         # get target
         if isinstance(self.target_normalizer, NaNLabelEncoder):
-            target = _to_tensor(f"__target__{self.target}", long=True)
+            target = _to_tensor(f"__target__{self.target}")
         else:
             if not isinstance(self.target, str):  # multi-target
                 target = [_to_tensor(f"__target__{name}") for name in self.target_names]

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1402,8 +1402,6 @@ class TimeSeriesDataSet(Dataset):
             if not isinstance(cols, list) and cols not in data.columns:
                 return None
             if isinstance(cols, list):
-                if len(cols) == 0:
-                    return []
                 dtypekind = data.dtypes[cols[0]].kind
             else:
                 dtypekind = data.dtypes[cols].kind

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -733,7 +733,7 @@ class TimeSeriesDataSet(Dataset):
 
         * generates lagged variable names and adds them to the appropriate lists
           of time-varying variables, typed by known/unknown and categorical/real
-        * checks that all lagged variables passed by user adhere to the 
+        * checks that all lagged variables passed by user adhere to the
           naming convention of lags
         """
         var_name_dict = {
@@ -1686,7 +1686,7 @@ class TimeSeriesDataSet(Dataset):
         TimeSeriesDataSet
             new dataset
         """
-        parameters = deepcopy(parameters)´
+        parameters = deepcopy(parameters)
 
         if predict:
             if not stop_randomization:

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1173,21 +1173,27 @@ class TimeSeriesDataSet(Dataset):
         group_id: bool = False,
         **kwargs,
     ) -> np.ndarray:
-        """
-        Scale and encode values.
+        """Scale and encode values.
 
-        Args:
-            name (str): name of variable
-            values (Union[pd.Series, torch.Tensor, np.ndarray]): values to encode/scale
-            data (pd.DataFrame, optional): extra data used for scaling (e.g. dataframe with groups columns).
-                Defaults to None.
-            inverse (bool, optional): if to conduct inverse transformation. Defaults to False.
-            group_id (bool, optional): If the passed name refers to a group id (different encoders are used for these).
-                Defaults to False.
-            **kwargs: additional arguments for transform/inverse_transform method
+        Parameters
+        ----------
+        name : str
+            name of variable
+        values : Union[pd.Series, torch.Tensor, np.ndarray]
+            values to encode/scale
+        data : pd.DataFrame, optional, default=None
+            extra data used for scaling (e.g. dataframe with groups columns), by default None
+        inverse : bool, optional, default=False
+            whether transform is plain (True), or inverse (False)
+        group_id : bool, optional, default=False
+            whether the passed name refers to a group id -
+            different encoders are used for these
+        **kwargs: additional arguments for transform/inverse_transform method
 
-        Returns:
-            np.ndarray: (de/en)coded/(de)scaled values
+        Returns
+        -------
+        np.ndarray
+            (de/en)coded/(de)scaled values
         """
         transformer = self.get_transformer(name, group_id=group_id)
         if transformer is None:
@@ -1473,20 +1479,30 @@ class TimeSeriesDataSet(Dataset):
         predict: bool = False,
         **update_kwargs,
     ):
-        """
-        Generate dataset with different underlying data but same variable encoders and scalers, etc.
+        """Generate dataset with different data, same variable encoders, scalers, etc.
 
-        Args:
-            parameters (Dict[str, Any]): dataset parameters which to use for the new dataset
-            data (pd.DataFrame): data from which new dataset will be generated
-            stop_randomization (bool, optional): If to stop randomizing encoder and decoder lengths,
-                e.g. useful for validation set. Defaults to False.
-            predict (bool, optional): If to predict the decoder length on the last entries in the
-                time index (i.e. one prediction per group only). Defaults to False.
-            **kwargs: keyword arguments overriding parameters
+        Returns TimeSeriesDataSet with same parameters as self, but different data.
+        May override parameters with update_kwargs.
 
-        Returns:
-            TimeSeriesDataSet: new dataset
+        Parameters
+        ----------
+        parameters : Dict[str, Any]
+            dataset parameters which to use for the new dataset
+        data : pd.DataFrame
+            data from which new dataset will be generated
+        stop_randomization : bool, optional, default=None
+            Whether to stop randomizing encoder and decoder lengths,
+            useful for validation set.
+        predict : bool, optional, default=False
+            Whether to predict the decoder length on the last entries in the
+            time index (i.e. one prediction per group only).
+        **update_kwargs
+            keyword arguments overrides, passed to constructor of the new dataset
+
+        Returns
+        -------
+        TimeSeriesDataSet
+            new dataset
         """
         parameters = deepcopy(parameters)
         if predict:
@@ -1755,15 +1771,19 @@ class TimeSeriesDataSet(Dataset):
         variable: str,
         target: Union[str, slice] = "decoder",
     ) -> None:
-        """
-        Convenience method to quickly overwrite values in decoder or encoder (or both) for a specific variable.
+        """Overwrite values in decoder or encoder (or both) for a specific variable.
 
-        Args:
-            values (Union[float, torch.Tensor]): values to use for overwrite.
-            variable (str): variable whose values should be overwritten.
-            target (Union[str, slice], optional): positions to overwrite. One of "decoder", "encoder" or "all" or
-                a slice object which is directly used to overwrite indices, e.g. ``slice(-5, None)`` will overwrite
-                the last 5 values. Defaults to "decoder".
+        Parameters
+        ----------
+        values : Union[float, torch.Tensor]
+            values to use for overwrite.
+        variable : str
+            variable whose values should be overwritten.
+        target : Union[str, slice], optional)
+            positions to overwrite. One of "decoder", "encoder" or "all" or
+            a slice object which is directly used to overwrite indices,
+            e.g., ``slice(-5, None)`` will overwrite
+            the last 5 values. Defaults to "decoder".
         """
         values = torch.tensor(
             self.transform_values(

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -2250,24 +2250,27 @@ class TimeSeriesDataSet(Dataset):
         batch_sampler: Union[Sampler, str] = None,
         **kwargs,
     ) -> DataLoader:
-        """
-        Get dataloader from dataset.
+        """Construct dataloader from dataset, for use in models.
 
-        The
+        Parameters
+        ----------
+        train : bool, optional, default=Trze
+            whether dataloader is used for training (True) or prediction (False).
+            Will shuffle and drop last batch if True. Defaults to True.
+        batch_size : int, optional, default=64
+            batch size for training model. Defaults to 64.
+        batch_sampler : Sampler, str, or None, optional, default=None
+            torch batch sampler or string. One of
 
-        Args:
-            train (bool, optional): if dataloader is used for training or prediction
-                Will shuffle and drop last batch if True. Defaults to True.
-            batch_size (int): batch size for training model. Defaults to 64.
-            batch_sampler (Union[Sampler, str]): batch sampler or string. One of
+            * "synchronized": ensure that samples in decoder are aligned in time.
+                Does not support missing values in dataset.
+                This makes only sense if the underlying algorithm makes use of
+                values aligned in time.
+            * PyTorch Sampler instance: any PyTorch sampler,
+                e.g., ``the WeightedRandomSampler()``
+            * None: samples are taken randomly from times series.
 
-                * "synchronized": ensure that samples in decoder are aligned in time. Does not support missing
-                  values in dataset. This makes only sense if the underlying algorithm makes use of values aligned
-                  in time.
-                * PyTorch Sampler instance: any PyTorch sampler, e.g. the WeightedRandomSampler()
-                * None: samples are taken randomly from times series.
-
-            **kwargs: additional arguments to ``DataLoader()``
+        **kwargs: additional arguments passed to ``DataLoader`` constructor
 
         Returns
         -------

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1685,22 +1685,22 @@ class TimeSeriesDataSet(Dataset):
         TimeSeriesDataSet
             new dataset
         """
-        parameters = deepcopy(parameters)
+        parameters = deepcopy(parameters)´
+
         if predict:
-            if stop_randomization is None:
-                stop_randomization = True
-            elif not stop_randomization:
+            if not stop_randomization:
                 warnings.warn(
                     "If predicting, no randomization should be possible - "
                     "setting stop_randomization=True",
                     UserWarning,
                 )
-                stop_randomization = True
             parameters["min_prediction_length"] = parameters["max_prediction_length"]
             parameters["predict_mode"] = True
-        elif stop_randomization is None:
-            stop_randomization = False
 
+        # this treats cases for randomize_length randomization:
+        # if predict mode, always turned off, i.e., always stop_ransomization=True
+        # otherwise, None defaults to False
+        stop_randomization = predict or stop_randomization
         if stop_randomization:
             parameters["randomize_length"] = None
         parameters.update(update_kwargs)

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1401,9 +1401,9 @@ class TimeSeriesDataSet(Dataset):
             """
             if not isinstance(cols, list) and cols not in data.columns:
                 return None
-            if isinstance(cols, list):
-                if len(cols) == 0:
-                    return []
+            if isinstance(cols, list) and len(cols) == 0:
+                dtypekind = "f"
+            elif isinstance(cols, list):  # and len(cols) > 0
                 dtypekind = data.dtypes[cols[0]].kind
             else:
                 dtypekind = data.dtypes[cols].kind

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1402,6 +1402,8 @@ class TimeSeriesDataSet(Dataset):
             if not isinstance(cols, list) and cols not in data.columns:
                 return None
             if isinstance(cols, list):
+                if len(cols) == 0:
+                    return []
                 dtypekind = data.dtypes[cols[0]].kind
             else:
                 dtypekind = data.dtypes[cols].kind

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1422,7 +1422,7 @@ class TimeSeriesDataSet(Dataset):
 
         # get target
         if isinstance(self.target_normalizer, NaNLabelEncoder):
-            target = _to_tensor(f"__target__{self.target}")
+            target = [_to_tensor(f"__target__{self.target}")]
         else:
             if not isinstance(self.target, str):  # multi-target
                 target = [_to_tensor(f"__target__{name}") for name in self.target_names]

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -906,9 +906,12 @@ class TimeSeriesDataSet(Dataset):
         # add lags to data
         for name in self._lags:
             # todo: add support for variable groups
-            assert (
-                name not in self._variable_groups
-            ), f"lagged variables that are in {self._variable_groups} are not supported yet"
+            msg = (
+                f"lagged variables that are in {self._variable_groups} "
+                "are not supported yet"
+            )
+            assert name not in self._variable_groups, msg
+
             for lagged_name, lag in self._get_lagged_names(name).items():
                 data[lagged_name] = data.groupby(self.group_ids, observed=True)[
                     name
@@ -1063,9 +1066,12 @@ class TimeSeriesDataSet(Dataset):
                     ):
                         for scale_idx, name in enumerate(["center", "scale"]):
                             feature_name = f"{target}_{name}"
-                            assert (
-                                feature_name not in data.columns
-                            ), f"{feature_name} is a protected column and must not be present in data"
+                            msg = (
+                                f"{feature_name} is a protected column "
+                                "and must not be present in data"
+                            )
+                            assert feature_name not in data.columns, msg
+
                             data[feature_name] = scales[target_idx][
                                 :, scale_idx
                             ].squeeze()
@@ -1421,11 +1427,14 @@ class TimeSeriesDataSet(Dataset):
         return target_normalizers
 
     def get_parameters(self) -> Dict[str, Any]:
-        """
-        Get parameters that can be used with :py:meth:`~from_parameters` to create a new dataset with the same scalers.
+        """Get parameters of self as dict.
 
-        Returns:
-            Dict[str, Any]: dictionary of parameters
+        These can be used with :py:meth:`~from_parameters`
+        to create a new dataset with the same scalers.
+
+        Returns
+        -------
+        Dict[str, Any]: dictionary of parameters
         """
         kwargs = {
             name: getattr(self, name)
@@ -1445,22 +1454,31 @@ class TimeSeriesDataSet(Dataset):
         predict: bool = False,
         **update_kwargs,
     ):
-        """
-        Generate dataset with different underlying data but same variable encoders and scalers, etc.
+        """Construct dataset with different data, same variable encoders, scalers, etc.
 
         Calls :py:meth:`~from_parameters` under the hood.
 
-        Args:
-            dataset (TimeSeriesDataSet): dataset from which to copy parameters
-            data (pd.DataFrame): data from which new dataset will be generated
-            stop_randomization (bool, optional): If to stop randomizing encoder and decoder lengths,
-                e.g. useful for validation set. Defaults to False.
-            predict (bool, optional): If to predict the decoder length on the last entries in the
-                time index (i.e. one prediction per group only). Defaults to False.
-            **kwargs: keyword arguments overriding parameters in the original dataset
+        May override parameters with update_kwargs.
 
-        Returns:
-            TimeSeriesDataSet: new dataset
+        Parameters
+        ----------
+        dataset : TimeSeriesDataSet
+            dataset from which to copy parameters
+        data : pd.DataFrame
+            data from which new dataset will be generated
+        stop_randomization : bool, optional, default=None
+            Whether to stop randomizing encoder and decoder lengths,
+            useful for validation set.
+        predict : bool, optional, default=False
+            Whether to predict the decoder length on the last entries in the
+            time index (i.e. one prediction per group only).
+        **update_kwargs
+            keyword arguments overrides, passed to constructor of the new dataset
+
+        Returns
+        -------
+        TimeSeriesDataSet
+            new dataset
         """
         return cls.from_parameters(
             dataset.get_parameters(),
@@ -1479,7 +1497,7 @@ class TimeSeriesDataSet(Dataset):
         predict: bool = False,
         **update_kwargs,
     ):
-        """Generate dataset with different data, same variable encoders, scalers, etc.
+        """Construct dataset with different data, same variable encoders, scalers, etc.
 
         Returns TimeSeriesDataSet with same parameters as self, but different data.
         May override parameters with update_kwargs.

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -115,11 +115,14 @@ def check_for_nonfinite(
         if na > 0:
             raise ValueError(
                 f"{na} ({na / tensor.size(0):.2%}) of {name} "
-                "values were found to be NA or infinite (even after encoding). NA values are not allowed "
-                "`allow_missing_timesteps` refers to missing rows, not to missing values. Possible strategies to "
+                "values were found to be NA or infinite (even after encoding). "
+                "NA values are not allowed "
+                "`allow_missing_timesteps` refers to missing rows, not to missing "
+                "values. Possible strategies to "
                 f"fix the issue are (a) dropping the variable {name}, "
                 "(b) using `NaNLabelEncoder(add_nan=True)` for categorical variables, "
-                "(c) filling missing values and/or (d) optionally adding a variable indicating filled values"
+                "(c) filling missing values and/or (d) optionally adding a variable "
+                "indicating filled values"
             )
     return tensor
 
@@ -2266,54 +2269,66 @@ class TimeSeriesDataSet(Dataset):
 
             **kwargs: additional arguments to ``DataLoader()``
 
-        Returns:
-            DataLoader: dataloader that returns Tuple.
-                First entry is ``x``, a dictionary of tensors with the entries (and shapes in brackets)
+        Returns
+        -------
+        DataLoader: dataloader that returns Tuple.
+            First entry is ``x``, a dictionary of tensors with the entries,
+            and shapes in brackets.
 
-                * encoder_cat (batch_size x n_encoder_time_steps x n_features): long tensor of encoded
-                  categoricals for encoder
-                * encoder_cont (batch_size x n_encoder_time_steps x n_features): float tensor of scaled continuous
-                  variables for encoder
-                * encoder_target (batch_size x n_encoder_time_steps or list thereof with each entry for a different
-                  target):
-                  float tensor with unscaled continous target or encoded categorical target,
-                  list of tensors for multiple targets
-                * encoder_lengths (batch_size): long tensor with lengths of the encoder time series. No entry will
-                  be greater than n_encoder_time_steps
-                * decoder_cat (batch_size x n_decoder_time_steps x n_features): long tensor of encoded
-                  categoricals for decoder
-                * decoder_cont (batch_size x n_decoder_time_steps x n_features): float tensor of scaled continuous
-                  variables for decoder
-                * decoder_target (batch_size x n_decoder_time_steps or list thereof with each entry for a different
-                  target):
-                  float tensor with unscaled continous target or encoded categorical target for decoder
-                  - this corresponds to first entry of ``y``, list of tensors for multiple targets
-                * decoder_lengths (batch_size): long tensor with lengths of the decoder time series. No entry will
-                  be greater than n_decoder_time_steps
-                * group_ids (batch_size x number_of_ids): encoded group ids that identify a time series in the dataset
-                * target_scale (batch_size x scale_size or list thereof with each entry for a different target):
-                  parameters used to normalize the target.
-                  Typically these are mean and standard deviation. Is list of tensors for multiple targets.
+            * encoder_cat : long (batch_size x n_encoder_time_steps x n_features)
+                long tensor of encoded categoricals for encoder
+            * encoder_cont : float (batch_size x n_encoder_time_steps x n_features)
+                float tensor of scaled continuous variables for encoder
+            * encoder_target : float (batch_size x n_encoder_time_steps) or list thereof
+                if list, each entry for a different target.
+                float tensor with unscaled continous target
+                or encoded categorical target,
+                list of tensors for multiple targets
+            * encoder_lengths : long (batch_size)
+                long tensor with lengths of the encoder time series. No entry will
+                be greater than n_encoder_time_steps
+            * decoder_cat : long (batch_size x n_decoder_time_steps x n_features)
+                long tensor of encoded categoricals for decoder
+            * decoder_cont : float (batch_size x n_decoder_time_steps x n_features)
+                float tensor of scaled continuous variables for decoder
+            * decoder_target : float (batch_size x n_decoder_time_steps) or list thereof
+                if list, with each entry for a different target.
+                float tensor with unscaled continous target or encoded categorical
+                target for decoder
+                - this corresponds to first entry of ``y``,
+                list of tensors for multiple targets
+            * decoder_lengths : long (batch_size)
+                long tensor with lengths of the decoder time series. No entry will
+                be greater than n_decoder_time_steps
+            * group_ids : float (batch_size x number_of_ids)
+                encoded group ids that identify a time series in the dataset
+            * target_scale : float (batch_size x scale_size) or list thereof.
+                if list, with each entry for a different target.
+                parameters used to normalize the target.
+                Typically these are mean and standard deviation.
+                Is list of tensors for multiple targets.
 
+            Second entry is ``y``, a tuple of the form (``target``, `weight`)
 
-                Second entry is ``y``, a tuple of the form (``target``, `weight`)
+            * target : float (batch_size x n_decoder_time_steps) or list thereof
+                if list, with each entry for a different target.
+                unscaled (continuous) or encoded (categories) targets,
+                list of tensors for multiple targets
+            * weight : None or float (batch_size x n_decoder_time_steps)
+                weights for each target, None if no weight is used (= equal weights)
 
-                * target (batch_size x n_decoder_time_steps or list thereof with each entry for a different target):
-                  unscaled (continuous) or encoded (categories) targets, list of tensors for multiple targets
-                * weight (None or batch_size x n_decoder_time_steps): weight
+        Example
+        -------
+        Weight by samples for training:
 
-        Example:
+        .. code-block:: python
 
-            Weight by samples for training:
+            from torch.utils.data import WeightedRandomSampler
 
-            .. code-block:: python
-
-                from torch.utils.data import WeightedRandomSampler
-
-                # length of probabilties for sampler have to be equal to the length of the index
-                probabilities = np.sqrt(1 + data.loc[dataset.index, "target"])
-                sampler = WeightedRandomSampler(probabilities, len(probabilities))
-                dataset.to_dataloader(train=True, sampler=sampler, shuffle=False)
+            # length of probabilties for sampler have to be equal to the length of index
+            probabilities = np.sqrt(1 + data.loc[dataset.index, "target"])
+            sampler = WeightedRandomSampler(probabilities, len(probabilities))
+            dataset.to_dataloader(train=True, sampler=sampler, shuffle=False)
         """
         default_kwargs = dict(
             shuffle=train,
@@ -2336,7 +2351,8 @@ class TimeSeriesDataSet(Dataset):
                     )
                 else:
                     raise ValueError(
-                        f"batch_sampler {sampler} unknown - see docstring for valid batch_sampler"
+                        f"batch_sampler {sampler} unknown - "
+                        "see docstring for valid batch_sampler"
                     )
             del kwargs["batch_size"]
             del kwargs["shuffle"]

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -324,6 +324,7 @@ class TimeSeriesDataSet(Dataset):
         to get all subseries.
         On the other hand, predict_mode = True is ideal for validation cases.
     """
+
     # todo: refactor:
     # - creating base class with minimal functionality
     # - "outsource" transformations -> use pytorch transformations as default
@@ -636,13 +637,8 @@ class TimeSeriesDataSet(Dataset):
                     if (
                         lag < self.max_prediction_length
                     ):  # keep in unknown as if lag is too small
-                        if (
-                            lagged_name
-                            not in self._time_varying_unknown_categoricals
-                        ):
-                            self._time_varying_unknown_categoricals.append(
-                                lagged_name
-                            )
+                        if lagged_name not in self._time_varying_unknown_categoricals:
+                            self._time_varying_unknown_categoricals.append(lagged_name)
                     if lagged_name not in self._time_varying_known_categoricals:
                         # switch to known so that lag can be used in decoder directly
                         self._time_varying_known_categoricals.append(lagged_name)
@@ -792,9 +788,7 @@ class TimeSeriesDataSet(Dataset):
             not isinstance(self.target_normalizer, EncoderNormalizer)
             or self.min_encoder_length >= self.target_normalizer.min_length
         ), "EncoderNormalizer is only allowed if min_encoder_length > 1"
-        assert isinstance(
-            self.target_normalizer, (TorchNormalizer, NaNLabelEncoder)
-        ), (
+        assert isinstance(self.target_normalizer, (TorchNormalizer, NaNLabelEncoder)), (
             f"target_normalizer has to be either None or of "
             f"class TorchNormalizer but found {self.target_normalizer}"
         )
@@ -863,13 +857,10 @@ class TimeSeriesDataSet(Dataset):
             for name in self._lags:
                 lagged_names = self._get_lagged_names(name)
                 for lagged_name in lagged_names:
-                    assert (
-                        lagged_name not in data.columns
-                    ), (
+                    assert lagged_name not in data.columns, (
                         f"{lagged_name} is a protected column and must not be "
                         "present in data"
                     )
-
 
     def save(self, fname: str) -> None:
         """

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -731,8 +731,10 @@ class TimeSeriesDataSet(Dataset):
     def _set_lagged_variables(self):
         """Add lagged variables to lists of variables.
 
-        Generates lagged variables and adds them to the appropriate lists
-        of time-varying variables.
+        * generates lagged variable names and adds them to the appropriate lists
+          of time-varying variables, typed by known/unknown and categorical/real
+        * checks that all lagged variables passed by user adhere to the 
+          naming convention of lags
         """
         var_name_dict = {
             ("real", "known"): "_time_varying_known_reals",

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -95,7 +95,7 @@ def check_for_nonfinite(
     tensor: torch.Tensor, names: Union[str, List[str]]
 ) -> torch.Tensor:
     """
-    Check if 2D tensor contains NAs or inifinite values.
+    Check if 2D tensor contains NAs or infinite values.
 
     Args:
         names (Union[str, List[str]]): name(s) of column(s) (used for error messages)
@@ -106,10 +106,10 @@ def check_for_nonfinite(
     """
     if isinstance(names, str):
         names = [names]
-        assert tensor.ndim == 1
+        assert tensor.ndim == 1, names
         nans = (~torch.isfinite(tensor).unsqueeze(-1)).sum(0)
     else:
-        assert tensor.ndim == 2
+        assert tensor.ndim == 2, names
         nans = (~torch.isfinite(tensor)).sum(0)
     for name, na in zip(names, nans):
         if na > 0:

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1402,9 +1402,9 @@ class TimeSeriesDataSet(Dataset):
             if not isinstance(cols, list) and cols not in data.columns:
                 return None
             if isinstance(cols, list):
-                dtypekind = data.dtype[cols[0]].kind
+                dtypekind = data.dtypes[cols[0]].kind
             else:
-                dtypekind = data.dtype[cols].kind
+                dtypekind = data.dtypes[cols].kind
             if not long:
                 return torch.tensor(data[cols].to_numpy(np.int64), dtype=torch.int64)
             elif dtypekind in "bi":


### PR DESCRIPTION
This PR carries out a clean-up refactor of `TimeSeriesDataSet`. No changes are made to the logic.

This is in preparation for major work items impacting the logic, e.g., removal of the `pandas` coupling (see https://github.com/sktime/pytorch-forecasting/issues/1685), or a 2.0 rework (see https://github.com/sktime/pytorch-forecasting/issues/1736).
In general, a clean state would make these easier.

Work carried out:

* clear, and complete docstrings, in numpydoc format
* separating logic, e.g., for parameter checking, data formatting, default handling
* reducing cognitive complexity and max indentations, addressing "code smells"
* linting