### PR TITLE
[MNT] Temporary fix for lint errors to conform to the recent changes in linting rules see #1749

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,11 +94,14 @@ def get_by_name(string: str):
     """
     Import by name and return imported module/function/class
 
-    Args:
-        string (str): module/function/class to import, e.g. 'pandas.read_csv' will return read_csv function as
-        defined by pandas
+    Parameters
+    ----------
+    string (str):
+        module/function/class to import, e.g. 'pandas.read_csv'
+        will return read_csv function as defined by pandas
 
-    Returns:
+    Returns
+    -------
         imported object
     """
     class_name = string.split(".")[-1]

--- a/examples/ar.py
+++ b/examples/ar.py
@@ -98,7 +98,7 @@ print(f"Number of parameters in network: {deepar.size() / 1e3:.1f}k")
 # deepar.hparams.log_val_interval = -1
 # trainer.limit_train_batches = 1.0
 # res = Tuner(trainer).lr_find(
-#     deepar, train_dataloaders=train_dataloader, val_dataloaders=val_dataloader, min_lr=1e-5, max_lr=1e2
+#     deepar, train_dataloaders=train_dataloader, val_dataloaders=val_dataloader, min_lr=1e-5, max_lr=1e2 # noqa: E501
 # )
 
 # print(f"suggested learning rate: {res.suggestion()}")

--- a/examples/nbeats.py
+++ b/examples/nbeats.py
@@ -87,7 +87,7 @@ print(f"Number of parameters in network: {net.size() / 1e3:.1f}k")
 # trainer.limit_train_batches = 1.0
 # # run learning rate finder
 # res = Tuner(trainer).lr_find(
-#     net, train_dataloaders=train_dataloader, val_dataloaders=val_dataloader, min_lr=1e-5, max_lr=1e2
+#     net, train_dataloaders=train_dataloader, val_dataloaders=val_dataloader, min_lr=1e-5, max_lr=1e2 # noqa: E501
 # )
 # print(f"suggested learning rate: {res.suggestion()}")
 # fig = res.plot(show=True, suggest=True)

--- a/examples/stallion.py
+++ b/examples/stallion.py
@@ -34,7 +34,7 @@ data["avg_volume_by_sku"] = data.groupby(
 data["avg_volume_by_agency"] = data.groupby(
     ["time_idx", "agency"], observed=True
 ).volume.transform("mean")
-# data = data[lambda x: (x.sku == data.iloc[0]["sku"]) & (x.agency == data.iloc[0]["agency"])]
+# data = data[lambda x: (x.sku == data.iloc[0]["sku"]) & (x.agency == data.iloc[0]["agency"])] # noqa: E501
 special_days = [
     "easter_day",
     "good_friday",
@@ -151,7 +151,7 @@ print(f"Number of parameters in network: {tft.size() / 1e3:.1f}k")
 # trainer.limit_train_batches = 1.0
 # # run learning rate finder
 # res = Tuner(trainer).lr_find(
-#     tft, train_dataloaders=train_dataloader, val_dataloaders=val_dataloader, min_lr=1e-5, max_lr=1e2
+#     tft, train_dataloaders=train_dataloader, val_dataloaders=val_dataloader, min_lr=1e-5, max_lr=1e2 # noqa: E501
 # )
 # print(f"suggested learning rate: {res.suggestion()}")
 # fig = res.plot(show=True, suggest=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,9 @@ exclude = [
   ".venv/",
   ".git/",
   ".history/",
+  "docs/source/tutorials/",
 ]
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "C4", "S"]
@@ -188,3 +190,6 @@ exclude = '''
 [tool.nbqa.mutate]
 ruff = 1
 black = 1
+
+[tool.nbqa.exclude]
+ruff = "docs/source/tutorials/" # ToDo: Remove this when fixing notebooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,11 @@ known-first-party = ["pytorch_forecasting"]
 combine-as-imports = true
 force-sort-within-sections = true
 
+[tool.ruff.lint.per-file-ignores]
+"pytorch_forecasting/data/timeseries.py" = [
+  "E501", # Line too long being fixed in #1746 To be removed after merging
+]
+
 [tool.black]
 line-length = 88
 include = '\.pyi?$'

--- a/pytorch_forecasting/data/__init__.py
+++ b/pytorch_forecasting/data/__init__.py
@@ -1,8 +1,8 @@
 """
 Datasets, etc. for timeseries data.
 
-Handling timeseries data is not trivial. It requires special treatment. This sub-package provides the necessary tools
-to abstracts the necessary work.
+Handling timeseries data is not trivial. It requires special treatment.
+This sub-package provides the necessary tools to abstracts the necessary work.
 """
 
 from pytorch_forecasting.data.encoders import (

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -181,12 +181,16 @@ class TransformMixIn:
     ) -> Dict[str, Callable]:
         """Return transformation functions.
 
-        Args:
-            transformation (Union[str, Dict[str, Callable]]): name of transformation or
-                dictionary with transformation information.
+        Parameters
+        ----------
+        transformation: Union[str, Dict[str, Callable]]
+            name of transformation or dictionary with transformation information.
 
-        Returns:
-            Dict[str, Callable]: dictionary with transformation functions (forward, reverse, inverse and inverse_torch)
+        Returns
+        -------
+        Dict[str, Callable]
+            dictionary with transformation functions
+            (forward, reverse, inverse and inverse_torch)
         """
         if isinstance(transformation, str):
             transform = cls.TRANSFORMATIONS[transformation]
@@ -204,8 +208,15 @@ class TransformMixIn:
 
         Uses ``transform`` attribute to determine how to apply transform.
 
-        Returns:
-            Union[np.ndarray, torch.Tensor]: return rescaled series with type depending on input type
+        Parameters
+        ----------
+        y: Union[pd.Series, pd.DataFrame, np.ndarray, torch.Tensor]
+            input data
+
+        Returns
+        -------
+        Union[np.ndarray, torch.Tensor]
+            return rescaled series with type depending on input type
         """
         if self.transformation is None:
             return y
@@ -229,8 +240,15 @@ class TransformMixIn:
 
         Uses ``transform`` attribute to determine how to apply inverse transform.
 
-        Returns:
-            Union[np.ndarray, torch.Tensor]: return rescaled series with type depending on input type
+        Parameters
+        ----------
+        y: Union[pd.Series, np.ndarray, torch.Tensor]
+            input data
+
+        Returns
+        -------
+        Union[np.ndarray, torch.Tensor]
+            return rescaled series with type depending on input type
         """
         if self.transformation is None:
             pass
@@ -249,15 +267,18 @@ class NaNLabelEncoder(
 ):
     """
     Labelencoder that can optionally always encode nan and unknown classes (in transform) as class ``0``
-    """
+    """  # noqa: E501
 
     def __init__(self, add_nan: bool = False, warn: bool = True):
         """
         init NaNLabelEncoder
 
-        Args:
-            add_nan: if to force encoding of nan at 0
-            warn: if to warn if additional nans are added because items are unknown
+        Returns
+        -------
+        add_nan
+            if to force encoding of nan at 0
+        warn
+            if to warn if additional nans are added because items are unknown
         """
         self.add_nan = add_nan
         self.warn = warn
@@ -267,12 +288,17 @@ class NaNLabelEncoder(
         """
         Fit and transform data.
 
-        Args:
-            y (pd.Series): input data
-            overwrite (bool): if to overwrite current mappings or if to add to it.
+        Parameters
+        ----------
+        y: pd.Series
+            input data
+        overwrite: bool
+            if to overwrite current mappings or if to add to it.
 
-        Returns:
-            np.ndarray: encoded data
+        Returns
+        -------
+        np.ndarray
+            encoded data
         """
         self.fit(y, overwrite=overwrite)
         return self.transform(y)
@@ -280,14 +306,18 @@ class NaNLabelEncoder(
     @staticmethod
     def is_numeric(y: pd.Series) -> bool:
         """
-        Determine if series is numeric or not. Will also return True if series is a categorical type with
-        underlying integers.
+        Determine if series is numeric or not. Will also return True
+        if series is a categorical type with underlying integers.
 
-        Args:
-            y (pd.Series): series for which to carry out assessment
+        Parameters
+        ----------
+        y: pd.Series
+            series for which to carry out assessment
 
-        Returns:
-            bool: True if series is numeric
+        Returns
+        -------
+        bool
+            True if series is numeric
         """
         return y.dtype.kind in "bcif" or (
             isinstance(y.dtype, pd.CategoricalDtype)
@@ -298,12 +328,16 @@ class NaNLabelEncoder(
         """
         Fit transformer
 
-        Args:
-            y (pd.Series): input data to fit on
-            overwrite (bool): if to overwrite current mappings or if to add to it.
+        Parameters
+        ----------
+        y: pd.Series
+            input data to fit on
+        overwrite: bool
+            whether to overwrite current mappings or if to add to it.
 
-        Returns:
-            NaNLabelEncoder: self
+        Returns
+        -------
+        NaNLabelEncoder: self
         """
         if not overwrite and hasattr(self, "classes_"):
             offset = len(self.classes_)
@@ -341,23 +375,33 @@ class NaNLabelEncoder(
         """
         Encode iterable with integers.
 
-        Args:
-            y (Iterable): iterable to encode
-            return_norm: only exists for compatability with other encoders - returns a tuple if true.
-            target_scale: only exists for compatability with other encoders - has no effect.
-            ignore_na (bool): if to ignore na values and map them to zeros
-                (this is different to `add_nan=True` option which maps ONLY NAs to zeros
-                while this options maps the first class and NAs to zeros)
+        Parameters
+        ----------
+        y: Iterable
+            iterable to encode
+        return_norm
+            only exists for compatability with other encoders - returns a tuple if true.
+        target_scale
+            only exists for compatability with other encoders - has no effect.
+        ignore_na: bool
+            if to ignore na values and map them to zeros
+            (this is different to `add_nan=True` option which maps ONLY NAs to zeros
+            while this options maps the first class and NAs to zeros)
 
-        Returns:
-            Union[torch.Tensor, np.ndarray]: returns encoded data as torch tensor or numpy array depending on input type
+        Returns
+        -------
+        Union[torch.Tensor, np.ndarray]
+            returns encoded data as torch tensor or numpy array depending on input type
         """
         if self.add_nan:
             if self.warn:
                 cond = np.array([item not in self.classes_ for item in y])
                 if cond.any():
                     warnings.warn(
-                        f"Found {np.unique(np.asarray(y)[cond]).size} unknown classes which were set to NaN",
+                        (
+                            f"Found {np.unique(np.asarray(y)[cond]).size} "
+                            "unknown classes which were set to NaN"
+                        ),
                         UserWarning,
                     )
 
@@ -372,7 +416,8 @@ class NaNLabelEncoder(
                     encoded = [self.classes_[v] for v in y]
                 except KeyError as e:
                     raise KeyError(
-                        f"Unknown category '{e.args[0]}' encountered. Set `add_nan=True` to allow unknown categories"
+                        f"Unknown category '{e.args[0]}' encountered. "
+                        "Set `add_nan=True` to allow unknown categories"
                     )
 
         if isinstance(y, torch.Tensor):
@@ -389,14 +434,20 @@ class NaNLabelEncoder(
         """
         Decode data, i.e. transform from integers to labels.
 
-        Args:
-            y (Union[torch.Tensor, np.ndarray]): encoded data
+        Parameters
+        ----------
+        y: Union[torch.Tensor, np.ndarray]
+            encoded data
 
-        Raises:
-            KeyError: if unknown elements should be decoded
+        Raises
+        ------
+        KeyError
+            if unknown elements should be decoded
 
-        Returns:
-            np.ndarray: decoded data
+        Returns
+        -------
+        np.ndarray
+            decoded data
         """
         if y.max() >= len(self.classes_vector_):
             raise KeyError("New unknown values detected")
@@ -405,17 +456,23 @@ class NaNLabelEncoder(
         decoded = self.classes_vector_[y]
         return decoded
 
-    def __call__(self, data: Dict[str, torch.Tensor]) -> torch.Tensor:
+    def __call__(self, data: dict[str, torch.Tensor]) -> torch.Tensor:
         """
         Extract prediction from network output. Does not map back to input
         categories as this would require a numpy tensor without grad-abilities.
 
-        Args:
-            data (Dict[str, torch.Tensor]): Dictionary with entries
-                * prediction: data to de-scale
+        Parameters
+        ----------
+        data: dict[str, torch.Tensor]
+            Dictionary with entries
 
-        Returns:
-            torch.Tensor: prediction
+            * prediction: data to de-scale
+            * target_scale: center and scale of data
+
+        Returns
+        -------
+        torch.Tensor
+            prediction
         """
         return data["prediction"]
 
@@ -425,8 +482,10 @@ class NaNLabelEncoder(
 
         All parameters are unused - exists for compatability.
 
-        Returns:
-            np.ndarray: zero array.
+        Returns
+        -------
+        np.ndarray
+            zero array.
         """
         return np.zeros(2, dtype=np.float64)
 
@@ -446,30 +505,42 @@ class TorchNormalizer(
         method_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
-        Args:
-            method (str, optional): method to rescale series. Either "identity", "standard" (standard scaling)
-                or "robust" (scale using quantiles 0.25-0.75). Defaults to "standard".
-            method_kwargs (Dict[str, Any], optional): Dictionary of method specific arguments as listed below
-                * "robust" method: "upper", "lower", "center" quantiles defaulting to 0.75, 0.25 and 0.5
-            center (bool, optional): If to center the output to zero. Defaults to True.
-            transformation (Union[str, Dict[str, Callable]] optional): Transform values before
-                applying normalizer. Available options are
+        Parameters
+        ----------
+        method: str, optional, default="standard"
+            method to rescale series. Either "identity", "standard" (standard scaling)
+            or "robust" (scale using quantiles 0.25-0.75). Defaults to "standard".
+        method_kwargs: Dict[str, Any], optional, default=None
+            Dictionary of method specific arguments as listed below
 
-                * None (default): No transformation of values
-                * log: Estimate in log-space leading to a multiplicative model
-                * log1p: Estimate in log-space but add 1 to values before transforming for stability
-                  (e.g. if many small values <<1 are present).
-                  Note, that inverse transform is still only `torch.exp()` and not `torch.expm1()`.
-                * logit: Apply logit transformation on values that are between 0 and 1
-                * count: Apply softplus to output (inverse transformation) and x + 1 to input (transformation)
-                * softplus: Apply softplus to output (inverse transformation) and inverse softplus to input
-                    (transformation)
-                * relu: Apply max(0, x) to output
-                * Dict[str, Callable] of PyTorch functions that transforms and inversely transforms values.
-                  ``forward`` and ``reverse`` entries are required. ``inverse`` transformation is optional and
-                  should be defined if ``reverse`` is not the inverse of the forward transformation. ``inverse_torch``
-                  can be defined to provide a torch distribution transform for inverse transformations.
-        """
+            - "robust" method: "upper", "lower", "center" quantiles defaulting to 0.75, 0.25 and 0.5
+
+        center: bool, optional, default=True
+            If to center the output to zero. Defaults to True.
+        transformation: Union[str, Dict[str, Callable]] optional, default=None
+            Transform values before applying normalizer. Available options are
+
+            - None (default): No transformation of values
+            - log: Estimate in log-space leading to a multiplicative model
+            - log1p: Estimate in log-space but add 1 to values before transforming for stability
+
+                (e.g. if many small values <<1 are present).
+                Note, that inverse transform is still only `torch.exp()` and
+                not `torch.expm1()`.
+
+            - logit: Apply logit transformation on values that are between 0 and 1
+            - count: Apply softplus to output (inverse transformation) and x + 1 to input (transformation)
+            - softplus: Apply softplus to output (inverse transformation) and inverse softplus to input (transformation)
+            - relu: Apply max(0, x) to output
+            - Dict[str, Callable] of PyTorch functions that transforms and inversely transforms values.
+
+                ``forward`` and ``reverse`` entries are required. ``inverse``
+                transformation is optional and
+                should be defined if ``reverse`` is not the
+                inverse of the forward transformation. ``inverse_torch``
+                can be defined to provide a torch distribution transform for
+                inverse transformations.
+        """  # noqa E501
         self.method = method
         assert method in [
             "standard",
@@ -487,8 +558,10 @@ class TorchNormalizer(
         """
         Returns parameters that were used for encoding.
 
-        Returns:
-            torch.Tensor: First element is center of data and second is scale
+        Returns
+        -------
+        torch.Tensor
+            First element is center of data and second is scale
         """
         return torch.stack(
             [torch.as_tensor(self.center_), torch.as_tensor(self.scale_)], dim=-1
@@ -498,11 +571,14 @@ class TorchNormalizer(
         """
         Fit transformer, i.e. determine center and scale of data
 
-        Args:
-            y (Union[pd.Series, np.ndarray, torch.Tensor]): input data
+        Parameters
+        ----------
+        y: Union[pd.Series, np.ndarray, torch.Tensor]
+            input data
 
-        Returns:
-            TorchNormalizer: self
+        Returns
+        -------
+        TorchNormalizer: self
         """
         y = self.preprocess(y)
         self._set_parameters(y_center=y, y_scale=y)
@@ -516,9 +592,12 @@ class TorchNormalizer(
         """
         Calculate parameters for scale and center based on input timeseries
 
-        Args:
-            y_center (Union[pd.Series, np.ndarray, torch.Tensor]): timeseries for calculating center
-            y_scale (Union[pd.Series, np.ndarray, torch.Tensor]): timeseries for calculating scale
+        Parameters
+        ----------
+        y_center: Union[pd.Series, np.ndarray, torch.Tensor]
+            timeseries for calculating center
+        y_scale: Union[pd.Series, np.ndarray, torch.Tensor]
+            timeseries for calculating scale
         """
         if isinstance(y_center, torch.Tensor):
             eps = torch.finfo(y_center.dtype).eps
@@ -529,8 +608,10 @@ class TorchNormalizer(
                 self.center_ = torch.zeros(y_center.size()[:-1])
                 self.scale_ = torch.ones(y_scale.size()[:-1])
             elif isinstance(y_center, (np.ndarray, pd.Series, pd.DataFrame)):
-                # numpy default type is numpy.float64 while torch default type is torch.float32 (if not changed)
-                # therefore, we first generate torch tensors (with torch default type) and then
+                # numpy default type is numpy.float64 while torch default
+                # type is torch.float32 (if not changed)
+                # therefore, we first generate torch tensors
+                # (with torch default type) and then
                 # convert them to numpy arrays
                 self.center_ = torch.zeros(y_center.shape[:-1]).numpy()
                 self.scale_ = torch.ones(y_scale.shape[:-1]).numpy()
@@ -548,7 +629,8 @@ class TorchNormalizer(
             else:
                 self.center_ = np.mean(y_center)
                 self.scale_ = np.std(y_scale) + eps
-            # correct numpy scalar dtype promotion, e.g. fix type from `np.float32(0.0) + 1e-8` gives `np.float64(1e-8)`
+            # correct numpy scalar dtype promotion, e.g. fix type from
+            # `np.float32(0.0) + 1e-8` gives `np.float64(1e-8)`
             if isinstance(self.scale_, np.ndarray):
                 self.scale_ = self.scale_.astype(y_scale.dtype)
 
@@ -606,15 +688,20 @@ class TorchNormalizer(
         """
         Rescale data.
 
-        Args:
-            y (Union[pd.Series, np.ndarray, torch.Tensor]): input data
-            return_norm (bool, optional): [description]. Defaults to False.
-            target_scale (torch.Tensor): target scale to use instead of fitted center and scale
+        Parameters
+        ----------
+        y: Union[pd.Series, np.ndarray, torch.Tensor]
+            input data
+        return_norm: bool, optional, default=False
+            [description]. Defaults to False.
+        target_scale: torch.Tensor, optional, default=None
+            target scale to use instead of fitted center and scale
 
-        Returns:
-            Union[Tuple[Union[np.ndarray, torch.Tensor], np.ndarray], Union[np.ndarray, torch.Tensor]]: rescaled
-                data with type depending on input type. returns second element if ``return_norm=True``
-        """
+        Returns
+        -------
+        Union[Tuple[Union[np.ndarray, torch.Tensor],np.ndarray],Union[np.ndarray, torch.Tensor]]
+            rescaled data with type depending on input type. returns second element if ``return_norm=True``
+        """  # noqa: E501
         y = self.preprocess(y)
         # get center and scale
         if target_scale is None:
@@ -643,11 +730,15 @@ class TorchNormalizer(
         """
         Inverse scale.
 
-        Args:
-            y (torch.Tensor): scaled data
+        Parameters
+        ----------
+        y: torch.Tensor
+            scaled data
 
-        Returns:
-            torch.Tensor: de-scaled data
+        Returns
+        -------
+        torch.Tensor
+            de-scaled data
         """
         return self(dict(prediction=y, target_scale=self.get_parameters().unsqueeze(0)))
 
@@ -655,13 +746,18 @@ class TorchNormalizer(
         """
         Inverse transformation but with network output as input.
 
-        Args:
-            data (Dict[str, torch.Tensor]): Dictionary with entries
-                * prediction: data to de-scale
-                * target_scale: center and scale of data
+        Parameters
+        ----------
+        data: Dict[str, torch.Tensor]
+            Dictionary with entries
 
-        Returns:
-            torch.Tensor: de-scaled data
+            * prediction: data to de-scale
+            * target_scale: center and scale of data
+
+        Returns
+        -------
+        torch.Tensor
+            de-scaled data
         """
         # ensure output dtype matches input dtype
         dtype = data["prediction"].dtype
@@ -703,33 +799,42 @@ class EncoderNormalizer(TorchNormalizer):
         """
         Initialize
 
-        Args:
-            method (str, optional): method to rescale series. Either "identity", "standard" (standard scaling)
-                or "robust" (scale using quantiles 0.25-0.75). Defaults to "standard".
-            method_kwargs (Dict[str, Any], optional): Dictionary of method specific arguments as listed below
+        Parameters
+        ----------
+        method: str, optional, default="standard"
+            method to rescale series. Either "identity", "standard" (standard scaling)
+            or "robust" (scale using quantiles 0.25-0.75). Defaults to "standard".
+        method_kwargs: Dict[str, Any], optional, default=None
+            Dictionary of method specific arguments as listed below
+
                 * "robust" method: "upper", "lower", "center" quantiles defaulting to 0.75, 0.25 and 0.5
-            center (bool, optional): If to center the output to zero. Defaults to True.
-            max_length(Union[int, List[int]], optional): Maximum length to take into account for calculating
-                parameters. If tuple, first length is maximum length for calculating center and second is maximum
-                length for calculating scale. Defaults to entire length of time series.
-            transformation (Union[str, Tuple[Callable, Callable]] optional): Transform values before
-                applying normalizer. Available options are
+
+        center: bool, optional, default=True
+            If to center the output to zero. Defaults to True.
+        max_length: Union[int, List[int]], optional
+            Maximum length to take into account for calculating parameters.
+            If tuple, first length is maximum length for calculating center and second is maximum
+            length for calculating scale. Defaults to entire length of time series.
+        transformation: Union[str, Tuple[Callable, Callable]] optional:
+            Transform values before applying normalizer. Available options are
 
                 * None (default): No transformation of values
                 * log: Estimate in log-space leading to a multiplicative model
                 * log1p: Estimate in log-space but add 1 to values before transforming for stability
+
                     (e.g. if many small values <<1 are present).
                     Note, that inverse transform is still only `torch.exp()` and not `torch.expm1()`.
+
                 * logit: Apply logit transformation on values that are between 0 and 1
                 * count: Apply softplus to output (inverse transformation) and x + 1 to input (transformation)
-                * softplus: Apply softplus to output (inverse transformation) and inverse softplus to input
-                    (transformation)
+                * softplus: Apply softplus to output (inverse transformation) and inverse softplus to input (transformation)
                 * relu: Apply max(0, x) to output
                 * Dict[str, Callable] of PyTorch functions that transforms and inversely transforms values.
+
                   ``forward`` and ``reverse`` entries are required. ``inverse`` transformation is optional and
                   should be defined if ``reverse`` is not the inverse of the forward transformation. ``inverse_torch``
                   can be defined to provide a torch distribution transform for inverse transformations.
-        """
+        """  # noqa: E501
         method_kwargs = deepcopy(method_kwargs) if method_kwargs is not None else {}
         super().__init__(
             method=method,
@@ -743,11 +848,14 @@ class EncoderNormalizer(TorchNormalizer):
         """
         Fit transformer, i.e. determine center and scale of data
 
-        Args:
-            y (Union[pd.Series, np.ndarray, torch.Tensor]): input data
+        Parameters
+        ----------
+        y: Union[pd.Series, np.ndarray, torch.Tensor]
+            input data
 
-        Returns:
-            TorchNormalizer: self
+        Returns
+        -------
+        TorchNormalizer: self
         """
         # reduce size of time series - take only max length
         if self.max_length is None:
@@ -784,12 +892,17 @@ class EncoderNormalizer(TorchNormalizer):
         """
         Slice pandas data frames, numpy arrays and tensors.
 
-        Args:
-            x (Union[pd.Series, np.ndarray, torch.Tensor]): object to slice
-            s (slice): slice, e.g. ``slice(None, -5)```
+        Parameters
+        ----------
+        x: Union[pd.Series, np.ndarray, torch.Tensor]
+            object to slice
+        s: slice
+            slice, e.g. ``slice(None, -5)```
 
-        Returns:
-            Union[pd.Series, np.ndarray, torch.Tensor]: sliced object
+        Returns
+        -------
+        Union[pd.Series, np.ndarray, torch.Tensor]
+            sliced object
         """
 
         if isinstance(x, (pd.DataFrame, pd.Series)):
@@ -802,8 +915,8 @@ class GroupNormalizer(TorchNormalizer):
     """
     Normalizer that scales by groups.
 
-    For each group a scaler is fitted and applied. This scaler can be used as target normalizer or
-    also to normalize any other variable.
+    For each group a scaler is fitted and applied. This scaler can be used
+    as target normalizer or also to normalize any other variable.
     """
 
     def __init__(
@@ -818,23 +931,33 @@ class GroupNormalizer(TorchNormalizer):
         """
         Group normalizer to normalize a given entry by groups. Can be used as target normalizer.
 
-        Args:
-            method (str, optional): method to rescale series. Either "standard" (standard scaling) or "robust"
-                (scale using quantiles 0.25-0.75). Defaults to "standard".
-            method_kwargs (Dict[str, Any], optional): Dictionary of method specific arguments as listed below
+        Parameters
+        ----------
+        method: str, optional, default="standard"
+            method to rescale series. Either "standard" (standard scaling) or "robust"
+            (scale using quantiles 0.25-0.75). Defaults to "standard".
+        method_kwargs: Dict[str, Any], optional, default=None
+            Dictionary of method specific arguments as listed below
+
                 * "robust" method: "upper", "lower", "center" quantiles defaulting to 0.75, 0.25 and 0.5
-            groups (List[str], optional): Group names to normalize by. Defaults to [].
-            center (bool, optional): If to center the output to zero. Defaults to True.
-            scale_by_group (bool, optional): If to scale the output by group, i.e. norm is calculated as
-                ``(group1_norm * group2_norm * ...) ^ (1 / n_groups)``. Defaults to False.
-            transformation (Union[str, Tuple[Callable, Callable]] optional): Transform values before
-                applying normalizer. Available options are
+
+        groups: List[str], optional, default=[]
+            Group names to normalize by. Defaults to [].
+        center: bool, optional, default=True
+            If to center the output to zero. Defaults to True.
+        scale_by_group: bool, optional
+            If to scale the output by group, i.e. norm is calculated as
+            ``(group1_norm * group2_norm * ...) ^ (1 / n_groups)``. Defaults to False.
+        transformation: Union[str, Tuple[Callable, Callable]] optional, default=None):
+            Transform values before applying normalizer. Available options are
 
                 * None (default): No transformation of values
                 * log: Estimate in log-space leading to a multiplicative model
                 * log1p: Estimate in log-space but add 1 to values before transforming for stability
+
                     (e.g. if many small values <<1 are present).
                     Note, that inverse transform is still only `torch.exp()` and not `torch.expm1()`.
+
                 * logit: Apply logit transformation on values that are between 0 and 1
                 * count: Apply softplus to output (inverse transformation) and x + 1 to input
                     (transformation)
@@ -846,7 +969,7 @@ class GroupNormalizer(TorchNormalizer):
                   should be defined if ``reverse`` is not the inverse of the forward transformation. ``inverse_torch``
                   can be defined to provide a torch distribution transform for inverse transformations.
 
-        """
+        """  # noqa: E501
         self.groups = groups
         self._groups = list(groups) if groups is not None else []
         self.scale_by_group = scale_by_group
@@ -862,12 +985,16 @@ class GroupNormalizer(TorchNormalizer):
         """
         Determine scales for each group
 
-        Args:
-            y (pd.Series): input data
-            X (pd.DataFrame): dataframe with columns for each group defined in ``groups`` parameter.
+        Parameters
+        ----------
+        y: pd.Series
+            input data
+        X: pd.DataFrame
+            dataframe with columns for each group defined in ``groups`` parameter.
 
-        Returns:
-            self
+        Returns
+        -------
+        self
         """
         y = self.preprocess(y)
         eps = np.finfo(np.float16).eps
@@ -1014,8 +1141,10 @@ class GroupNormalizer(TorchNormalizer):
         """
         Names of determined scales.
 
-        Returns:
-            List[str]: list of names
+        Returns
+        -------
+        List[str]
+            list of names
         """
         return ["center", "scale"]
 
@@ -1025,21 +1154,26 @@ class GroupNormalizer(TorchNormalizer):
         """
         Fit normalizer and scale input data.
 
-        Args:
-            y (pd.Series): data to scale
-            X (pd.DataFrame): dataframe with ``groups`` columns
-            return_norm (bool, optional): If to return . Defaults to False.
+        Parameters
+        ----------
+        y: pd.Series
+            data to scale
+        X: pd.DataFrame
+            dataframe with ``groups`` columns
+        return_norm: bool, optional, default=False
+            If to return . Defaults to False.
 
-        Returns:
-            Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]: Scaled data, if ``return_norm=True``, returns also scales
-                as second element
+        Returns
+        -------
+        Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]
+            Scaled data, if ``return_norm=True``, returns also scales as second element
         """
         return self.fit(y, X).transform(y, X, return_norm=return_norm)
 
     def inverse_transform(self, y: pd.Series, X: pd.DataFrame):
         """
         Rescaling data to original scale - not implemented - call class with target scale instead.
-        """
+        """  # noqa: E501
         raise NotImplementedError()
 
     def transform(
@@ -1052,15 +1186,21 @@ class GroupNormalizer(TorchNormalizer):
         """
         Scale input data.
 
-        Args:
-            y (pd.Series): data to scale
-            X (pd.DataFrame): dataframe with ``groups`` columns
-            return_norm (bool, optional): If to return . Defaults to False.
-            target_scale (torch.Tensor): target scale to use instead of fitted center and scale
+        Parameters
+        ----------
+        y: pd.Series
+            data to scale
+        X: pd.DataFrame
+            dataframe with ``groups`` columns
+        return_norm: bool, optional, default=False
+            If to return . Defaults to False.
+        target_scale: torch.Tensor
+            target scale to use instead of fitted center and scale
 
-        Returns:
-            Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]: Scaled data, if ``return_norm=True``, returns also scales
-                as second element
+        Returns
+        -------
+        Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]
+            Scaled data, if ``return_norm=True``, returns also scales as second element
         """
         # # check if arguments are wrong way round
         if isinstance(y, pd.DataFrame) and not isinstance(X, pd.DataFrame):
@@ -1076,13 +1216,18 @@ class GroupNormalizer(TorchNormalizer):
         """
         Get fitted scaling parameters for a given group.
 
-        Args:
-            groups (Union[torch.Tensor, list, tuple]): group ids for which to get parameters
-            group_names (List[str], optional): Names of groups corresponding to positions
-                in ``groups``. Defaults to None, i.e. the instance attribute ``groups``.
+        Parameters
+        ----------
+        groups: Union[torch.Tensor, list, tuple]
+            group ids for which to get parameters
+        group_names: List[str], optional, default=None
+            Names of groups corresponding to positions in ``groups``.
+            Defaults to None, i.e. the instance attribute ``groups``.
 
-        Returns:
-            np.ndarray: parameters used for scaling
+        Returns
+        -------
+        np.ndarray
+            parameters used for scaling
         """
         if isinstance(groups, torch.Tensor):
             groups = groups.tolist()
@@ -1121,11 +1266,16 @@ class GroupNormalizer(TorchNormalizer):
         """
         Get scaling parameters for multiple groups.
 
-        Args:
-            X (pd.DataFrame): dataframe with ``groups`` columns
+        Parameters
+        ----------
+        X: pd.DataFrame
+            dataframe with ``groups`` columns
 
-        Returns:
-            pd.DataFrame: dataframe with scaling parameterswhere each row corresponds to the input dataframe
+        Returns
+        -------
+        pd.DataFrame
+            dataframe with scaling parameterswhere each row corresponds
+            to the input dataframe
         """
         if len(self._groups) == 0:
             norm = np.asarray([self.norm_["center"], self.norm_["scale"]]).reshape(
@@ -1166,8 +1316,10 @@ class MultiNormalizer(TorchNormalizer):
 
     def __init__(self, normalizers: List[TorchNormalizer]):
         """
-        Args:
-            normalizers (List[TorchNormalizer]): list of normalizers to apply to targets
+        Parameters
+        ----------
+        normalizers: List[TorchNormalizer]
+            list of normalizers to apply to targets
         """
         self.normalizers = normalizers
 
@@ -1177,11 +1329,14 @@ class MultiNormalizer(TorchNormalizer):
         """
         Fit transformer, i.e. determine center and scale of data
 
-        Args:
-            y (Union[pd.Series, np.ndarray, torch.Tensor]): input data
+        Parameters
+        ----------
+        y: Union[pd.Series, np.ndarray, torch.Tensor]
+            input data
 
-        Returns:
-            MultiNormalizer: self
+        Returns
+        -------
+        MultiNormalizer: self
         """
         if isinstance(y, pd.DataFrame):
             y = y.to_numpy()
@@ -1199,8 +1354,10 @@ class MultiNormalizer(TorchNormalizer):
         """
         Return normalizer.
 
-        Args:
-            idx (int): metric index
+        Parameters
+        ----------
+        idx: int
+            metric index
         """
         return self.normalizers[idx]
 
@@ -1229,17 +1386,23 @@ class MultiNormalizer(TorchNormalizer):
         """
         Scale input data.
 
-        Args:
-            y (Union[pd.DataFrame, np.ndarray, torch.Tensor]): data to scale
-            X (pd.DataFrame): dataframe with ``groups`` columns. Only necessary if :py:class:`~GroupNormalizer`
-                is among normalizers
-            return_norm (bool, optional): If to return . Defaults to False.
-            target_scale (List[torch.Tensor]): target scale to use instead of fitted center and scale
+        Parameters
+        ----------
+        y: Union[pd.DataFrame, np.ndarray, torch.Tensor]
+            data to scale
+        X: pd.DataFrame
+            dataframe with ``groups`` columns. Only necessary
+            if :py:class:`~GroupNormalizer` is among normalizers
+        return_norm: bool, optional
+            If to return . Defaults to False.
+        target_scale: List[torch.Tensor]
+            target scale to use instead of fitted center and scale
 
-        Returns:
-            Union[List[Tuple[Union[np.ndarray, torch.Tensor], np.ndarray]], List[Union[np.ndarray, torch.Tensor]]]:
+        Returns
+        -------
+        Union[List[Tuple[Union[np.ndarray, torch.Tensor], np.ndarray]], List[Union[np.ndarray, torch.Tensor]]]
                 List of scaled data, if ``return_norm=True``, returns also scales as second element
-        """
+        """  # noqa: E501
         if isinstance(y, pd.DataFrame):
             y = y.to_numpy().transpose()
 
@@ -1270,13 +1433,18 @@ class MultiNormalizer(TorchNormalizer):
         """
         Inverse transformation but with network output as input.
 
-        Args:
-            data (Dict[str, Union[List[torch.Tensor], torch.Tensor]]): Dictionary with entries
-                * prediction: list of data to de-scale
-                * target_scale: list of center and scale of data
+        Parameters
+        ----------
+        data: Dict[str, Union[List[torch.Tensor], torch.Tensor]])
+            Dictionary with entries
 
-        Returns:
-            List[torch.Tensor]: list of de-scaled data
+            * prediction: list of data to de-scale
+            * target_scale: list of center and scale of data
+
+        Returns
+        -------
+        List[torch.Tensor]
+            list of de-scaled data
         """
         denormalized = [
             normalizer(
@@ -1293,8 +1461,10 @@ class MultiNormalizer(TorchNormalizer):
         """
         Returns parameters that were used for encoding.
 
-        Returns:
-            List[torch.Tensor]: First element is center of data and second is scale
+        Returns
+        -------
+        List[torch.Tensor]
+            First element is center of data and second is scale
         """
         return [
             normalizer.get_parameters(*args, **kwargs)
@@ -1305,16 +1475,20 @@ class MultiNormalizer(TorchNormalizer):
         """
         Return dynamically attributes.
 
-        Return attributes if defined in this class. If not, create dynamically attributes based on
-        attributes of underlying normalizers that are lists. Create functions if necessary.
-        Arguments to functions are distributed to the functions if they are lists and their length
-        matches the number of normalizers. Otherwise, they are directly passed to each callable of the
-        normalizers.
+        Return attributes if defined in this class. If not,
+        create dynamically attributes based on attributes of underlying normalizers
+        that are lists. Create functions if necessary. Arguments to functions are
+        distributed to the functions if they are lists and their length matches the
+        number of normalizers. Otherwise, they are directly passed to each callable of
+        the normalizers.
 
-        Args:
-            name (str): name of attribute
+        Parameters
+        name: str
+            name of attribute
 
-        Returns:
+        Returns
+        -------
+        ret
             attributes of this class or list of attributes of underlying class
         """
         try:
@@ -1327,7 +1501,8 @@ class MultiNormalizer(TorchNormalizer):
                     n = len(self.normalizers)
 
                     def func(*args, **kwargs):
-                        # if arg/kwarg is list and of length normalizers, then apply each part to a normalizer.
+                        # if arg/kwarg is list and of length normalizers,
+                        # then apply each part to a normalizer.
                         #  otherwise pass it directly to all normalizers
                         results = []
                         for idx, norm in enumerate(self.normalizers):

--- a/pytorch_forecasting/data/examples.py
+++ b/pytorch_forecasting/data/examples.py
@@ -28,7 +28,7 @@ def _get_data_by_filename(fname: str) -> Path:
     # check if file exists - download if necessary
     if not full_fname.exists():
         url = BASE_URL + fname
-        urlretrieve(url, full_fname)
+        urlretrieve(url, full_fname)  # noqa: S310
 
     return full_fname
 
@@ -82,7 +82,7 @@ def generate_ar_data(
 
     Returns:
         pd.DataFrame: data
-    """
+    """  # noqa: E501
     # sample parameters
     np.random.seed(seed)
     linear_trends = np.random.normal(size=n_series)[:, None] / timesteps

--- a/pytorch_forecasting/data/samplers.py
+++ b/pytorch_forecasting/data/samplers.py
@@ -1,6 +1,6 @@
 """
 Samplers for sampling time series from the :py:class:`~pytorch_forecasting.data.timeseries.TimeSeriesDataSet`
-"""
+"""  # noqa: E501
 
 import warnings
 
@@ -16,7 +16,7 @@ class GroupedSampler(Sampler):
 
     This means that the items from the different groups are always sampled together.
     This is an abstract class. Implement the :py:meth:`~get_groups` method which creates groups to be sampled from.
-    """
+    """  # noqa: E501
 
     def __init__(
         self,
@@ -36,7 +36,7 @@ class GroupedSampler(Sampler):
             batch_size (int, optional): Number of samples in a mini-batch. This is rather the maximum number
                 of samples. Because mini-batches are grouped by prediction time, chances are that there
                 are multiple where batch size will be smaller than the maximum. Defaults to 64.
-        """
+        """  # noqa: E501
         # Since collections.abc.Iterable does not check for `__getitem__`, which
         # is one way for an object to be an iterable, we don't do an `isinstance`
         # check here.
@@ -71,7 +71,7 @@ class GroupedSampler(Sampler):
 
         Returns:
             dict-like: dictionary-like object with data_source.index as values and group names as keys
-        """
+        """  # noqa: E501
         raise NotImplementedError()
 
     def construct_batch_groups(self, groups):
@@ -94,7 +94,8 @@ class GroupedSampler(Sampler):
                 warns.append(name)
         if len(warns) > 0:
             warnings.warn(
-                f"Less than {self.batch_size} samples available for {len(warns)} prediction times. "
+                f"Less than {self.batch_size} samples available for "
+                f"{len(warns)} prediction times. "
                 f"Use batch size smaller than {self.batch_size}. "
                 f"First 10 prediction times with small batch sizes: {warns[:10]}"
             )
@@ -134,7 +135,7 @@ class TimeSynchronizedBatchSampler(GroupedSampler):
 
     Time-synchornisation means that the time index of the first decoder samples are aligned across the batch.
     This sampler does not support missing values in the dataset.
-    """
+    """  # noqa: E501
 
     def get_groups(self, sampler: Sampler):
         data_source = sampler.data_source

--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -1,8 +1,9 @@
 """
 Timeseries datasets.
 
-Timeseries data is special and has to be processed and fed to algorithms in a special way. This module
-defines a class that is able to handle a wide variety of timeseries data problems.
+Timeseries data is special and has to be processed and passed in a special way.
+This module defines TimeSeriesDataSet,
+a class that is able to handle a wide variety of timeseries data problems.
 """
 
 from copy import copy as _copy, deepcopy
@@ -40,14 +41,20 @@ def _find_end_indices(
     """
     Identify end indices in series even if some values are missing.
 
-    Args:
-        diffs (np.ndarray): array of differences to next time step. nans should be filled up with ones
-        max_lengths (np.ndarray): maximum length of sequence by position.
-        min_length (int): minimum length of sequence.
+    Parameters
+    ----------
+    diffs : np.ndarray
+        array of differences to next time step. nans should be filled up with ones
+    max_lengths : np.ndarray
+        maximum length of sequence by position.
+    min_length : int
+        minimum length of sequence.
 
-    Returns:
-        Tuple[np.ndarray, np.ndarray]: tuple of arrays where first is end indices and second is list of start
-            and end indices that are currently missing.
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray]
+        tuple of arrays where first is end indices and second is list of start
+        and end indices that are currently missing.
     """
     missing_start_ends = []
     end_indices = []
@@ -87,32 +94,53 @@ except ImportError:
 def check_for_nonfinite(
     tensor: torch.Tensor, names: Union[str, List[str]]
 ) -> torch.Tensor:
-    """
-    Check if 2D tensor contains NAs or inifinite values.
+    """Check if tensor contains NAs or infinite values and has correct dimension.
 
-    Args:
-        names (Union[str, List[str]]): name(s) of column(s) (used for error messages)
-        tensor (torch.Tensor): tensor to check
+    Checks:
 
-    Returns:
-        torch.Tensor: returns tensor if checks yield no issues
+    * whether tensor is finite, otherwise raises ValueError
+    * checks whether dimension of tensor is correct. If tensor is a str,
+      tensor.ndim has to be 1, and if tensor is a list, tensor.ndim has to be 2.
+      Otherwise raises AssertionError.
+
+    Parameters
+    ----------
+    names : str or list of str
+        name(s) of column(s) to check
+    tensor : torch.Tensor
+        tensor to check
+
+    Returns
+    -------
+    torch.Tensor
+        returns tensor unchanged, if checks yield no issues
+
+    Raises
+    ------
+    ValueError
+        if tensor contains NAs or infinite values
+    AssertionError
+        if tensor has incorrect dimension, see above
     """
     if isinstance(names, str):
         names = [names]
-        assert tensor.ndim == 1
+        assert tensor.ndim == 1, names
         nans = (~torch.isfinite(tensor).unsqueeze(-1)).sum(0)
     else:
-        assert tensor.ndim == 2
+        assert tensor.ndim == 2, names
         nans = (~torch.isfinite(tensor)).sum(0)
     for name, na in zip(names, nans):
         if na > 0:
             raise ValueError(
                 f"{na} ({na / tensor.size(0):.2%}) of {name} "
-                "values were found to be NA or infinite (even after encoding). NA values are not allowed "
-                "`allow_missing_timesteps` refers to missing rows, not to missing values. Possible strategies to "
+                "values were found to be NA or infinite (even after encoding). "
+                "NA values are not allowed "
+                "`allow_missing_timesteps` refers to missing rows, not to missing "
+                "values. Possible strategies to "
                 f"fix the issue are (a) dropping the variable {name}, "
                 "(b) using `NaNLabelEncoder(add_nan=True)` for categorical variables, "
-                "(c) filling missing values and/or (d) optionally adding a variable indicating filled values"
+                "(c) filling missing values and/or (d) optionally adding a variable "
+                "indicating filled values"
             )
     return tensor
 
@@ -121,19 +149,235 @@ NORMALIZER = Union[TorchNormalizer, NaNLabelEncoder, EncoderNormalizer]
 
 
 class TimeSeriesDataSet(Dataset):
-    """
-    PyTorch Dataset for fitting timeseries models.
+    """PyTorch Dataset for fitting timeseries models.
 
     The dataset automates common tasks such as
 
     * scaling and encoding of variables
     * normalizing the target variable
     * efficiently converting timeseries in pandas dataframes to torch tensors
-    * holding information about static and time-varying variables known and unknown in the future
+    * holding information about static and time-varying variables known and unknown in
+      the future
     * holding information about related categories (such as holidays)
     * downsampling for data augmentation
     * generating inference, validation and test datasets
-    * etc.
+
+    The :ref:`tutorial on passing data to models <passing-data>` is helpful to
+    understand the output of the dataset
+    and how it is coupled to models.
+
+    Each sample is a subsequence of a full time series. The subsequence consists of
+    encoder and decoder/prediction
+    timepoints for a given time series. This class constructs an index which defined
+    which subsequences exists and
+    can be samples from (``index`` attribute). The samples in the index are defined
+    by the various parameters.
+    to the class (encoder and prediction lengths, minimum prediction length, randomize
+    length and predict keywords).
+    How samples are
+    sampled into batches for training, is determined by the DataLoader.
+    The class provides the
+    :py:meth:`~TimeSeriesDataSet.to_dataloader` method
+    to convert the dataset into a dataloader.
+
+    Large datasets:
+
+    Currently the class is limited to in-memory operations (that can be sped up by an
+    existing installation of `numba <https://pypi.org/project/numba/>`_).
+    If you have extremely large data,
+    however, you can pass prefitted encoders and and scalers to it and a subset of
+    sequences to the class to
+    construct a valid dataset (plus, likely the EncoderNormalizer should be used to
+    normalize targets).
+    when fitting a network, you would then to create a custom DataLoader that rotates
+    through the datasets.
+    There are currently no in-built methods to do this.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        dataframe with sequence data - each row can be identified with
+        ``time_idx`` and the ``group_ids``
+
+    time_idx : str
+        integer typed column denoting the time index within ``data``.
+        This columns is used to determine the sequence of samples.
+        If there are no missings observations,
+        the time index should increase by ``+1`` for each subsequent sample.
+        The first time_idx for each series does not necessarily
+        have to be ``0`` but any value is allowed.
+
+    target : Union[str, List[str]]
+        column(s) in ``data`` denoting the forecasting target.
+        Can be categorical or continous dtype.
+
+    group_ids : List[str]
+        list of column names identifying a time series instance within ``data``
+        This means that the ``group_ids``
+        identify a sample together with the ``time_idx``.
+        If you have only one timeseries, set this to the
+        name of column that is constant.
+
+    weight : str, optional, default=None
+        column name for weights. Defaults to None.
+
+    max_encoder_length : int, optional, default=30
+        maximum length to encode.
+        This is the maximum history length used by the time series dataset.
+
+    min_encoder_length : int, optional, default=max_encoder_length
+        minimum allowed length to encode. Defaults to max_encoder_length.
+
+    min_prediction_idx : int, optional, default = first time_idx in data
+        minimum ``time_idx`` from where to start predictions.
+        This parameter can be useful to create a validation or test set.
+
+    max_prediction_length : int, optional, default=1
+        maximum prediction/decoder length
+        (choose this not too short as it can help convergence)
+
+    min_prediction_length : int, optional, default=max_prediction_length
+        minimum prediction/decoder length
+
+    static_categoricals : list of str, optional, default=None
+        list of categorical variables that do not change over time, in ``data``,
+        entries can be also lists which are then encoded together
+        (e.g. useful for product categories)
+
+    static_reals : list of str, optional, default=None
+        list of continuous variables that do not change over time
+
+    time_varying_known_categoricals : list of str, optional, default=None
+        list of categorical variables that change over time and are known in the future,
+        entries can be also lists which are then encoded together
+        (e.g. useful for special days or promotion categories)
+
+    time_varying_known_reals : list of str, optional, default=None
+        list of continuous variables that change over time and are known in the future
+        (e.g. price of a product, but not demand of a product)
+
+    time_varying_unknown_categoricals : list of str, optional, default=None
+        list of categorical variables that are not known in the future
+        and change over time.
+        entries can be also lists which are then encoded together
+        (e.g. useful for weather categories).
+        Target variables should be included here, if categorical.
+
+    time_varying_unknown_reals : list of str, optional, default=None
+        list of continuous variables that are not known in the future
+        and change over time.
+        Target variables should be included here, if real.
+
+    variable_groups : Dict[str, List[str]], optional, default=None
+        dictionary mapping a name to a list of columns in the data.
+        The name should be present
+        in a categorical or real class argument, to be able to encode or scale the
+        columns by group.
+        This will effectively combine categorical variables is particularly useful
+        if a categorical variable can have multiple values at the same time.
+        An example are holidays which can be overlapping.
+
+    constant_fill_strategy : dict, optional, default=None
+        Keys must be str, values can be str, float, int or bool.
+        Dictionary of column names with constants to fill in missing values if there
+        are gaps in the sequence (by default forward fill strategy is used).
+        The values will be only used if ``allow_missing_timesteps=True``.
+        A common use case is to denote that demand was 0 if the sample is not in the
+        dataset.
+
+    allow_missing_timesteps : bool, optional, default=False
+        whether to allow missing timesteps that are automatically filled up.
+        Missing values refer to gaps in the ``time_idx``, e.g. if a specific
+        timeseries has only samples for 1, 2, 4, 5, the sample for 3 will be
+        generated on-the-fly.
+        Allow missings does not deal with ``NA`` values. You should fill NA values
+        before passing the dataframe to the TimeSeriesDataSet.
+
+    lags : Dict[str, List[int]], optional, default=None
+        dictionary of variable names mapped to list of time steps by which the
+        variable should be lagged.
+        Lags can be useful to indicate seasonality to the models.
+        Useful to add if seasonalit(ies) of the data are known.,
+        In this case, it is recommended to add the target variables
+        with the corresponding lags to improve performance.
+        Lags must be at not larger than the shortest time series as all time series
+        will be cut by the largest lag value to prevent NA values.
+        A lagged variable has to appear in the time-varying variables.
+        If you only want the lagged but not the current value, lag it manually in
+        your input data using
+        ``data[lagged_varname] = ``
+        ``data.sort_values(time_idx).groupby(group_ids, observed=True).shift(lag)``.
+
+    add_relative_time_idx : bool, optional, default=False
+        whether to add a relative time index as feature, i.e.,
+        for each sampled sequence, the index will range from -encoder_length to
+        prediction_length.
+
+    add_target_scales : bool, optional, default=False
+        whether to add scales for target to static real features, i.e., add the
+        center and scale of the unnormalized timeseries as features.
+
+    add_encoder_length : Union[bool, str], optional, default="auto"
+        whether to add encoder length to list of static real variables.
+        Defaults to "auto", iwhich is same as
+        ``True`` iff ``min_encoder_length != max_encoder_length``.
+
+    target_normalizer : torch transformer, str, list, tuple, optional, default="auto"
+        Transformer that takes group_ids, target and time_idx to normalize targets.
+        You can choose from
+        :py:class:`~pytorch_forecasting.data.encoders.TorchNormalizer`,
+        :py:class:`~pytorch_forecasting.data.encoders.GroupNormalizer`,
+        :py:class:`~pytorch_forecasting.data.encoders.NaNLabelEncoder`,
+        :py:class:`~pytorch_forecasting.data.encoders.EncoderNormalizer`
+        (on which overfitting tests will fail)
+        or ``None`` for using no normalizer. For multiple targets, use a
+        :py:class`~pytorch_forecasting.data.encoders.MultiNormalizer`.
+        By default an appropriate normalizer is chosen automatically.
+
+    categorical_encoders : dict[str, BaseEstimator]
+        dictionary of scikit learn label transformers.
+        If you have unobserved categories in
+        the future  / a cold-start problem, you can use the
+        :py:class:`~pytorch_forecasting.data.encoders.NaNLabelEncoder` with
+        ``add_nan=True``.
+        Defaults effectively to sklearn's ``LabelEncoder()``.
+        Prefitted encoders will not be fit again.
+
+    scalers : optional, dict with str keys and torch or sklearn scalers as values
+        dictionary of scikit-learn or torch scalers.
+        Defaults to sklearn's ``StandardScaler()``.
+        Other options
+        are :py:class:`~pytorch_forecasting.data.encoders.EncoderNormalizer`,
+        :py:class:`~pytorch_forecasting.data.encoders.GroupNormalizer`
+        or scikit-learn's ``StandarScaler()``,
+        ``RobustScaler()`` or ``None`` for using no normalizer / normalizer
+        with ``center=0`` and ``scale=1``
+        (``method="identity"``).
+        Prefittet encoders will not be fit again (with the exception of the
+        :py:class:`~pytorch_forecasting.data.encoders.EncoderNormalizer` that is
+        fit on every encoder sequence).
+
+    randomize_length : optional, None, bool, or tuple of float.
+        None or False if not to randomize lengths.
+        Tuple of beta distribution concentrations from which
+        probabilities are sampled that are used to sample new sequence lengths
+        with a binomial distribution.
+        If True, defaults to (0.2, 0.05), i.e. ~1/4 of samples
+        around minimum encoder length.
+        Defaults to False otherwise.
+
+    predict_mode : bool
+        If True, the TimeSeriesDataSet will only create one sequence
+        per time series (i.e. only from the latest provided samples).
+        Effectively, this will select each time series identified by ``group_ids``
+        the last ``max_prediction_length`` samples of each time series as
+        prediction samples and everthing previous up to ``max_encoder_length``
+        samples as encoder samples.
+        If False, the TimeSeriesDataSet will create subsequences by sliding a
+        window over the data samples.
+        For training use cases, it's preferable to set predict_mode=False
+        to get all subseries.
+        On the other hand, predict_mode = True is ideal for validation cases.
     """
 
     # todo: refactor:
@@ -155,26 +399,33 @@ class TimeSeriesDataSet(Dataset):
     #     -> do we also need torch_sparse, etc.? -> can we avoid this? probably not
     # - networkx graph: define what makes sense from user perspective
     # - define conversion into pytorch geometric graph? is this a two-step process of
-    #     - encoding networkx graph and converting it into "unfilled" pytorch geometric graph
+    #     - encoding networkx graph and converting it into "unfilled" pytorch geometric
+    #       graph
     #     - then creating full graph in collate function on the fly?
-    #     - or is data already stored in pytorch geometric graph and we only cut through it?
+    #     - or is data already stored in pytorch geometric graph, only cut through it?
     #     - dataformat would change? Is is all timeseries data? + mask when valid?
     #     - then making cuts through the graph in sampling?
-    #     - would it be best in this case to re-think the timeseries class and design it as series of transformations?
+    #     - would it be best in this case to re-think the timeseries class and design it
+    #       as series of transformations?
     #     - what is the new master data? very off current state or very similar?
-    #     - current approach is storing data in long format which is memory efficient and using the index object to
+    #     - current approach is storing data in long format which is memory efficient
+    #       and using the index object to
     #       make sense of it when accessing. graphs would require wide format?
-    # - do NOT overengineer, i.e. support only usecase of single static graph, but only subset might be relevant
-    #     -> however, should think what happens if we want a dynamic graph. would this completely change the
+    # - do NOT overengineer, i.e. support only usecase of single static graph,
+    #   but only subset might be relevant
+    #     -> however, should think what happens if we want a dynamic graph. would this
+    #        completely change the
     #        data format?
 
     # decisions:
-    # - stay with long format and create graph on the fly even if hampering efficiency and performance
+    # - stay with long format and create graph on the fly even if hampering
+    #   efficiency and performance
     # - go with pytorch_geometric approach for future proofing
     # - directly convert networkx into pytorch_geometric graph
     # - sampling: support only time-synchronized.
     #     - sample randomly an instance from index as now.
-    #     - then get additional samples as per graph (that has been created) and available data
+    #     - then get additional samples as per graph (that has been created) and
+    #       available data
     #     - then collate into graph object
 
     def __init__(
@@ -217,199 +468,47 @@ class TimeSeriesDataSet(Dataset):
         randomize_length: Union[None, Tuple[float, float], bool] = False,
         predict_mode: bool = False,
     ):
-        """
-        Timeseries dataset holding data for models.
-
-        The :ref:`tutorial on passing data to models <passing-data>` is helpful to understand the output of the dataset
-        and how it is coupled to models.
-
-        Each sample is a subsequence of a full time series. The subsequence consists of encoder and decoder/prediction
-        timepoints for a given time series. This class constructs an index which defined which subsequences exists and
-        can be samples from (``index`` attribute). The samples in the index are defined by by the various parameters.
-        to the class (encoder and prediction lengths, minimum prediction length, randomize length and predict keywords).
-        How samples are
-        sampled into batches for training, is determined by the DataLoader. The class provides the
-        :py:meth:`~TimeSeriesDataSet.to_dataloader` method to convert the dataset into a dataloader.
-
-        Large datasets:
-
-            Currently the class is limited to in-memory operations (that can be sped up by an
-            existing installation of `numba <https://pypi.org/project/numba/>`_). If you have extremely large data,
-            however, you can pass prefitted encoders and and scalers to it and a subset of sequences to the class to
-            construct a valid dataset (plus, likely the EncoderNormalizer should be used to normalize targets).
-            when fitting a network, you would then to create a custom DataLoader that rotates through the datasets.
-            There is currently no in-built methods to do this.
-
-        Args:
-            data (pd.DataFrame): dataframe with sequence data - each row can be identified with
-                ``time_idx`` and the ``group_ids``
-            time_idx (str): integer column denoting the time index. This columns is used to determine
-                the sequence of samples.
-                If there no missings observations, the time index should increase by ``+1`` for each subsequent sample.
-                The first time_idx for each series does not necessarily have to be ``0`` but any value is allowed.
-            target (Union[str, List[str]]): column denoting the target or list of columns denoting the target -
-                categorical or continous.
-            group_ids (List[str]): list of column names identifying a time series. This means that the ``group_ids``
-                identify a sample together with the ``time_idx``. If you have only one timeseries, set this to the
-                name of column that is constant.
-            weight (str): column name for weights. Defaults to None.
-            max_encoder_length (int): maximum length to encode.
-                This is the maximum history length used by the time series dataset.
-            min_encoder_length (int): minimum allowed length to encode. Defaults to max_encoder_length.
-            min_prediction_idx (int): minimum ``time_idx`` from where to start predictions. This parameter
-                can be useful to create a validation or test set.
-            max_prediction_length (int): maximum prediction/decoder length (choose this not too short as it can help
-                convergence)
-            min_prediction_length (int): minimum prediction/decoder length. Defaults to max_prediction_length
-            static_categoricals (List[str]): list of categorical variables that do not change over time,
-                entries can be also lists which are then encoded together
-                (e.g. useful for product categories)
-            static_reals (List[str]): list of continuous variables that do not change over time
-            time_varying_known_categoricals (List[str]): list of categorical variables that change over
-                time and are known in the future, entries can be also lists which are then encoded together
-                (e.g. useful for special days or promotion categories)
-            time_varying_known_reals (List[str]): list of continuous variables that change over
-                time and are known in the future (e.g. price of a product, but not demand of a product)
-            time_varying_unknown_categoricals (List[str]): list of categorical variables that change over
-                time and are not known in the future, entries can be also lists which are then encoded together
-                (e.g. useful for weather categories). You might want to include your target here.
-            time_varying_unknown_reals (List[str]): list of continuous variables that change over
-                time and are not known in the future.  You might want to include your target here.
-            variable_groups (Dict[str, List[str]]): dictionary mapping a name to a list of columns in the data.
-                The name should be present
-                in a categorical or real class argument, to be able to encode or scale the columns by group.
-                This will effectively combine categorical variables is particularly useful if a categorical variable can
-                have multiple values at the same time. An example are holidays which can be overlapping.
-            constant_fill_strategy (Dict[str, Union[str, float, int, bool]]): dictionary of column names with
-                constants to fill in missing values if there are
-                gaps in the sequence (by default forward fill strategy is used). The values will be only used if
-                ``allow_missing_timesteps=True``. A common use case is to denote that demand was 0 if the sample
-                is not in the dataset.
-            allow_missing_timesteps (bool): if to allow missing timesteps that are automatically filled up. Missing
-                values
-                refer to gaps in the ``time_idx``, e.g. if a specific timeseries has only samples for
-                1, 2, 4, 5, the sample for 3 will be generated on-the-fly.
-                Allow missings does not deal with ``NA`` values. You should fill NA values before
-                passing the dataframe to the TimeSeriesDataSet.
-            lags (Dict[str, List[int]]): dictionary of variable names mapped to list of time steps by
-                which the variable should be lagged.
-                Lags can be useful to indicate seasonality to the models. If you know the seasonalit(ies) of your data,
-                add at least the target variables with the corresponding lags to improve performance.
-                Lags must be at not larger than the shortest time series as all time series will be cut by the largest
-                lag value to prevent NA values. A lagged variable has to appear in the time-varying variables. If you
-                only want the lagged but not the current value, lag it manually in your input data using
-                ``data[lagged_variable_name] = data.sort_values(time_idx).groupby(group_ids, observed=True).shift(lag)``
-                .
-                Defaults to no lags.
-            add_relative_time_idx (bool): if to add a relative time index as feature (i.e. for each sampled sequence,
-                the index will range from -encoder_length to prediction_length)
-            add_target_scales (bool): if to add scales for target to static real features (i.e. add the center and scale
-                of the unnormalized timeseries as features)
-            add_encoder_length (bool): if to add encoder length to list of static real variables.
-                Defaults to "auto", i.e. ``True`` if ``min_encoder_length != max_encoder_length``.
-            target_normalizer (Union[TorchNormalizer, NaNLabelEncoder, EncoderNormalizer, str, list, tuple]):
-                transformer that take group_ids, target and time_idx to normalize targets.
-                You can choose from :py:class:`~pytorch_forecasting.data.encoders.TorchNormalizer`,
-                :py:class:`~pytorch_forecasting.data.encoders.GroupNormalizer`,
-                :py:class:`~pytorch_forecasting.data.encoders.NaNLabelEncoder`,
-                :py:class:`~pytorch_forecasting.data.encoders.EncoderNormalizer` (on which overfitting tests will fail)
-                or `None` for using no normalizer. For multiple targets, use a
-                :py:class`~pytorch_forecasting.data.encoders.MultiNormalizer`.
-                By default an appropriate normalizer is chosen automatically.
-            categorical_encoders (Dict[str, NaNLabelEncoder]): dictionary of scikit learn label transformers.
-                If you have unobserved categories in
-                the future  / a cold-start problem, you can use the
-                :py:class:`~pytorch_forecasting.data.encoders.NaNLabelEncoder` with
-                ``add_nan=True``. Defaults effectively to sklearn's ``LabelEncoder()``. Prefittet encoders will not
-                be fit again.
-            scalers (Dict[str, Union[StandardScaler, RobustScaler, TorchNormalizer, EncoderNormalizer]]): dictionary of
-                scikit-learn scalers. Defaults to sklearn's ``StandardScaler()``.
-                Other options are :py:class:`~pytorch_forecasting.data.encoders.EncoderNormalizer`,
-                :py:class:`~pytorch_forecasting.data.encoders.GroupNormalizer` or scikit-learn's ``StandarScaler()``,
-                ``RobustScaler()`` or `None` for using no normalizer / normalizer with `center=0` and `scale=1`
-                (`method="identity"`).
-                Prefittet encoders will not be fit again (with the exception of the
-                :py:class:`~pytorch_forecasting.data.encoders.EncoderNormalizer` that is fit on every encoder sequence).
-            randomize_length (Union[None, Tuple[float, float], bool]): None or False if not to randomize lengths.
-                Tuple of beta distribution concentrations from which
-                probabilities are sampled that are used to sample new sequence lengths with a binomial
-                distribution.
-                If True, defaults to (0.2, 0.05), i.e. ~1/4 of samples around minimum encoder length.
-                Defaults to False otherwise.
-            predict_mode (bool): If True, the TimeSeriesDataSet will only create one sequence
-                per time series (i.e. only from the latest provided samples).
-                Effectively, this will select each time series identified by ``group_ids``
-                the last ``max_prediction_length`` samples of each time series as
-                prediction samples and everthing previous up to ``max_encoder_length`` samples as encoder samples.
-                If False, the TimeSeriesDataSet will create subsequences by sliding a window over the data samples.
-                For training use cases, it's preferable to set predict_mode=False to get all subseries.
-                On the other hand, predict_mode = True is ideal for validation cases.
-        """
+        """Timeseries dataset holding data for models."""
         super().__init__()
+
+        # write variables to self and handle defaults
+        # -------------------------------------------
         self.max_encoder_length = max_encoder_length
-        assert isinstance(
-            self.max_encoder_length, int
-        ), "max encoder length must be integer"
         if min_encoder_length is None:
             min_encoder_length = max_encoder_length
         self.min_encoder_length = min_encoder_length
-        assert (
-            self.min_encoder_length <= self.max_encoder_length
-        ), "max encoder length has to be larger equals min encoder length"
-        assert isinstance(
-            self.min_encoder_length, int
-        ), "min encoder length must be integer"
         self.max_prediction_length = max_prediction_length
-        assert isinstance(
-            self.max_prediction_length, int
-        ), "max prediction length must be integer"
         if min_prediction_length is None:
             min_prediction_length = max_prediction_length
         self.min_prediction_length = min_prediction_length
-        assert (
-            self.min_prediction_length <= self.max_prediction_length
-        ), "max prediction length has to be larger equals min prediction length"
-        assert (
-            self.min_prediction_length > 0
-        ), "min prediction length must be larger than 0"
-        assert isinstance(
-            self.min_prediction_length, int
-        ), "min prediction length must be integer"
-        assert (
-            data[time_idx].dtype.kind == "i"
-        ), "Timeseries index should be of type integer"
+
         self.target = target
         self.weight = weight
         self.time_idx = time_idx
-        self.group_ids = [] if group_ids is None else list(group_ids)
+        self.group_ids = _coerce_to_list(group_ids)
+
         self.static_categoricals = static_categoricals
-        self._static_categoricals = (
-            [] if static_categoricals is None else list(static_categoricals)
-        )
+        self._static_categoricals = _coerce_to_list(static_categoricals)
+
         self.static_reals = static_reals
-        self._static_reals = [] if static_reals is None else list(static_reals)
+        self._static_reals = _coerce_to_list(static_reals)
+
         self.time_varying_known_categoricals = time_varying_known_categoricals
-        self._time_varying_known_categoricals = (
-            []
-            if time_varying_known_categoricals is None
-            else list(time_varying_known_categoricals)
+        self._time_varying_known_categoricals = _coerce_to_list(
+            time_varying_known_categoricals
         )
+
         self.time_varying_known_reals = time_varying_known_reals
-        self._time_varying_known_reals = (
-            [] if time_varying_known_reals is None else list(time_varying_known_reals)
-        )
+        self._time_varying_known_reals = _coerce_to_list(time_varying_known_reals)
+
         self.time_varying_unknown_categoricals = time_varying_unknown_categoricals
-        self._time_varying_unknown_categoricals = (
-            []
-            if time_varying_unknown_categoricals is None
-            else list(time_varying_unknown_categoricals)
+        self._time_varying_unknown_categoricals = _coerce_to_list(
+            time_varying_unknown_categoricals
         )
+
         self.time_varying_unknown_reals = time_varying_unknown_reals
-        self._time_varying_unknown_reals = (
-            []
-            if time_varying_unknown_reals is None
-            else list(time_varying_unknown_reals)
-        )
+        self._time_varying_unknown_reals = _coerce_to_list(time_varying_unknown_reals)
+
         self.add_relative_time_idx = add_relative_time_idx
 
         # set automatic defaults
@@ -418,56 +517,61 @@ class TimeSeriesDataSet(Dataset):
                 randomize_length = None
             else:
                 randomize_length = (0.2, 0.05)
+
         self.randomize_length = randomize_length
+
         if min_prediction_idx is None:
             min_prediction_idx = data[self.time_idx].min()
         self.min_prediction_idx = min_prediction_idx
+
         self.constant_fill_strategy = constant_fill_strategy
-        self._constant_fill_strategy = (
-            {} if constant_fill_strategy is None else deepcopy(constant_fill_strategy)
-        )
+        self._constant_fill_strategy = _coerce_to_dict(constant_fill_strategy)
+
         self.predict_mode = predict_mode
         self.allow_missing_timesteps = allow_missing_timesteps
         self.target_normalizer = target_normalizer
+
         self.categorical_encoders = categorical_encoders
-        self._categorical_encoders = (
-            {} if categorical_encoders is None else deepcopy(categorical_encoders)
-        )
+        self._categorical_encoders = _coerce_to_dict(categorical_encoders)
+
         self.scalers = scalers
-        self._scalers = {} if scalers is None else deepcopy(scalers)
+        self._scalers = _coerce_to_dict(scalers)
+
         self.add_target_scales = add_target_scales
         self.variable_groups = variable_groups
-        self._variable_groups = (
-            {} if variable_groups is None else deepcopy(variable_groups)
-        )
+        self._variable_groups = _coerce_to_dict(variable_groups)
+
         self.lags = lags
-        self._lags = {} if lags is None else deepcopy(lags)
+        self._lags = _coerce_to_dict(lags)
 
         # add_encoder_length
         if isinstance(add_encoder_length, str):
-            assert (
-                add_encoder_length == "auto"
-            ), f"Only 'auto' allowed for add_encoder_length but found {add_encoder_length}"
+            msg = (
+                f"Only 'auto' allowed for add_encoder_length "
+                f"but found {add_encoder_length}"
+            )
+            assert add_encoder_length == "auto", msg
             add_encoder_length = self.min_encoder_length != self.max_encoder_length
-        assert isinstance(
-            add_encoder_length, bool
-        ), f"add_encoder_length should be boolean or 'auto' but found {add_encoder_length}"
         self.add_encoder_length = add_encoder_length
-
-        # target normalizer
-        self._set_target_normalizer(data)
 
         # overwrite values
         self.reset_overwrite_values()
 
-        for target in self.target_names:
-            assert (
-                target not in self._time_varying_known_reals
-            ), f"target {target} should be an unknown continuous variable in the future"
+        # check parameters
+        self._check_params()
+
+        # data preprocessing in pandas
+        # ----------------------------
+
+        # get metadata from data
+        self._data_properties = self._data_properties(data)
+
+        # target normalizer
+        self.target_normalizer = self._set_target_normalizer(
+            self._data_properties, self.target_normalizer
+        )
 
         # add time index relative to prediction position
-        if self.add_relative_time_idx or self.add_encoder_length:
-            data = data.copy()  # only copies indices (underlying data is NOT copied)
         if self.add_relative_time_idx:
             assert (
                 "relative_time_idx" not in data.columns
@@ -477,9 +581,6 @@ class TimeSeriesDataSet(Dataset):
                 and "relative_time_idx" not in self.reals
             ):
                 self._time_varying_known_reals.append("relative_time_idx")
-            data.loc[:, "relative_time_idx"] = (
-                0.0  # dummy - real value will be set dynamically in __getitem__()
-            )
 
         # add decoder length to static real variables
         if self.add_encoder_length:
@@ -491,68 +592,30 @@ class TimeSeriesDataSet(Dataset):
                 and "encoder_length" not in self.reals
             ):
                 self._static_reals.append("encoder_length")
+
+        # add columns for additional features
+        if self.add_relative_time_idx or self.add_encoder_length:
+            data = data.copy()  # only copies indices (underlying data is NOT copied)
+        if self.add_relative_time_idx:
+            data.loc[:, "relative_time_idx"] = (
+                0.0  # dummy - real value will be set dynamically in __getitem__()
+            )
+        if self.add_encoder_length:
             data.loc[:, "encoder_length"] = (
                 0  # dummy - real value will be set dynamically in __getitem__()
             )
 
         # validate
         self._validate_data(data)
-        assert data.index.is_unique, "data index has to be unique"
 
         # add lags
-        assert self.min_lag > 0, "lags should be positive"
         if len(self._lags) > 0:
-            # add variables
-            for name in self._lags:
-                lagged_names = self._get_lagged_names(name)
-                for lagged_name in lagged_names:
-                    assert (
-                        lagged_name not in data.columns
-                    ), f"{lagged_name} is a protected column and must not be present in data"
-                # add lags
-                if name in self._time_varying_known_reals:
-                    for lagged_name in lagged_names:
-                        if lagged_name not in self._time_varying_known_reals:
-                            self._time_varying_known_reals.append(lagged_name)
-                elif name in self._time_varying_known_categoricals:
-                    for lagged_name in lagged_names:
-                        if lagged_name not in self._time_varying_known_categoricals:
-                            self._time_varying_known_categoricals.append(lagged_name)
-                elif name in self._time_varying_unknown_reals:
-                    for lagged_name, lag in lagged_names.items():
-                        if (
-                            lag < self.max_prediction_length
-                        ):  # keep in unknown as if lag is too small
-                            if lagged_name not in self._time_varying_unknown_reals:
-                                self._time_varying_unknown_reals.append(lagged_name)
-                        else:
-                            if lagged_name not in self._time_varying_known_reals:
-                                # switch to known so that lag can be used in decoder directly
-                                self._time_varying_known_reals.append(lagged_name)
-                elif name in self._time_varying_unknown_categoricals:
-                    for lagged_name, lag in lagged_names.items():
-                        if (
-                            lag < self.max_prediction_length
-                        ):  # keep in unknown as if lag is too small
-                            if (
-                                lagged_name
-                                not in self._time_varying_unknown_categoricals
-                            ):
-                                self._time_varying_unknown_categoricals.append(
-                                    lagged_name
-                                )
-                        if lagged_name not in self._time_varying_known_categoricals:
-                            # switch to known so that lag can be used in decoder directly
-                            self._time_varying_known_categoricals.append(lagged_name)
-                else:
-                    raise KeyError(
-                        f"lagged variable {name} is not a known nor unknown time-varying variable"
-                    )
+            self._set_lagged_variables()
 
         # filter data
         if min_prediction_idx is not None:
-            # filtering for min_prediction_idx will be done on subsequence level ensuring
-            # minimal decoder index is always >= min_prediction_idx
+            # filtering for min_prediction_idx will be done on subsequence level,
+            # ensuring that minimal decoder index is always >= min_prediction_idx
             data = data[
                 lambda x: x[self.time_idx]
                 >= self.min_prediction_idx - self.max_encoder_length - self.max_lag
@@ -561,16 +624,156 @@ class TimeSeriesDataSet(Dataset):
 
         # preprocess data
         data = self._preprocess_data(data)
+
+        msg = "Target normalizer is separate and not in scalers."
         for target in self.target_names:
-            assert (
-                target not in self._scalers
-            ), "Target normalizer is separate and not in scalers."
+            assert target not in self._scalers, msg
+
+        # index for getitem based resampling
+        # ----------------------------------
+        # NOTE: this should be refactored and probably in a DataLoader
 
         # create index
         self.index = self._construct_index(data, predict_mode=self.predict_mode)
 
+        # data conversion to torch tensors
+        # --------------------------------
+
         # convert to torch tensor for high performance data loading later
         self.data = self._data_to_tensors(data)
+
+        # check that all tensors are finite
+        self._check_tensors(self.data)
+
+    def _check_params(self):
+        """Check parameters of self against assumptions."""
+        assert isinstance(
+            self.max_encoder_length, int
+        ), "max encoder length must be integer"
+        assert (
+            self.min_encoder_length <= self.max_encoder_length
+        ), "max encoder length has to be larger equals min encoder length"
+        assert isinstance(
+            self.min_encoder_length, int
+        ), "min encoder length must be integer"
+        assert isinstance(
+            self.max_prediction_length, int
+        ), "max prediction length must be integer"
+        assert (
+            self.min_prediction_length <= self.max_prediction_length
+        ), "max prediction length has to be larger equals min prediction length"
+        assert (
+            self.min_prediction_length > 0
+        ), "min prediction length must be larger than 0"
+        assert isinstance(
+            self.min_prediction_length, int
+        ), "min prediction length must be integer"
+        msg = (
+            f"add_encoder_length should be boolean or 'auto' "
+            f"but found {self.add_encoder_length}"
+        )
+        assert isinstance(self.add_encoder_length, bool), msg
+
+        for target in self.target_names:
+            assert (
+                target not in self._time_varying_known_reals
+            ), f"target {target} should be an unknown continuous variable in the future"
+
+        assert self.min_lag > 0, "lags should be positive"
+
+    def _data_properties(self, data):
+        """Returns a dict with properties of the data used later.
+
+        Parameters
+        ----------
+        data : pd.DataFrame
+
+        Returns
+        -------
+        dict
+            dictionary with properties of the data.
+            The following fields are returned:
+
+            * columns : list[str]
+                list of column names in the data
+            * target_type : dict[str, str]
+                type of target variable, categorial or real.
+                Keys are target variable names in self.target_names.
+                Value is either "categorical" or "real".
+            * target_positive : dict[str, bool]
+                whether target variable is positive.
+                Keys are target variable names in self.target_names that are real.
+                Value is True if all values of the target variable are positive.
+                Computed and returned only if target_normalizer is "auto".
+            * target_skew : dict[str, float]
+                skew of target variable.
+                Keys are target variable names in self.target_names that are
+                real and positive. Value is the skew of the target variable.
+                Computed and returned only if target_normalizer is "auto".
+        """
+        target_norm = self.target_normalizer
+        details_required = isinstance(target_norm, str) and target_norm == "auto"
+
+        props = {"target_type": {}, "target_skew": {}, "target_positive": {}}
+        props["columns"] = data.columns.tolist()
+        for target in self.target_names:
+            if data[target].dtype.kind != "f":  # category
+                props["target_type"][target] = "categorical"
+            else:
+                props["target_type"][target] = "real"
+
+                if details_required:
+                    props["target_positive"][target] = (data[target] > 0).all()
+                    if props["target_positive"][target]:
+                        props["target_skew"][target] = data[target].skew()
+        return props
+
+    def _set_lagged_variables(self):
+        """Add lagged variables to lists of variables.
+
+        * generates lagged variable names and adds them to the appropriate lists
+          of time-varying variables, typed by known/unknown and categorical/real
+        * checks that all lagged variables passed by user adhere to the
+          naming convention of lags
+        """
+        var_name_dict = {
+            ("real", "known"): "_time_varying_known_reals",
+            ("real", "unknown"): "_time_varying_unknown_reals",
+            ("cat", "known"): "_time_varying_known_categoricals",
+            ("cat", "unknown"): "_time_varying_unknown_categoricals",
+        }
+
+        def _attr(realcat, known):
+            return getattr(self, var_name_dict[(realcat, known)])
+
+        def _append_if_new(lst, x):
+            if x not in lst:
+                lst.append(x)
+
+        # check that all names passed in self._lags appear as variables
+        all_time_varying_var_names = [x for kw in var_name_dict for x in _attr(*kw)]
+        for name in self._lags:
+            if name not in all_time_varying_var_names:
+                raise KeyError(
+                    f"lagged variable {name} is not a known "
+                    "nor unknown time-varying variable"
+                )
+
+        # add lagged variables to type indicators
+        for name in self._lags:
+            lagged_names = self._get_lagged_names(name)
+
+            # add lags
+            for realcat, known in var_name_dict:
+                var_names = _attr(realcat, known)
+
+                if name in var_names:
+                    for lagged_name, lag in lagged_names.items():
+                        # if lag is longer than horizon, lagged var becomes future-known
+                        if known or lag < self.max_prediction_length:
+                            _append_if_new(var_names, lagged_name)
+                        elif lag < self.max_prediction_length:
+                            _append_if_new(_attr(realcat, "known"), lagged_name)
 
     @property
     def dropout_categoricals(self) -> List[str]:
@@ -588,23 +791,28 @@ class TimeSeriesDataSet(Dataset):
         """
         Generate names for lagged variables
 
-        Args:
-            name (str): name of variable to lag
+        Parameters
+        ----------
+        name : str
+            name of variable to lag
 
-        Returns:
-            Dict[str, int]: dictionary mapping new variable names to lags
+        Returns
+        -------
+        Dict[str, int]
+            dictionary mapping new variable names to lags
         """
         return {f"{name}_lagged_by_{lag}": lag for lag in self._lags.get(name, [])}
 
     @property
     @lru_cache(None)
     def lagged_variables(self) -> Dict[str, str]:
-        """
-        Lagged variables.
+        """Lagged variables.
 
-        Returns:
-            Dict[str, str]: dictionary of variable names corresponding to lagged variables
-                mapped to variable that is lagged
+        Parameters
+        ----------
+        Dict[str, str]
+            dictionary of variable names corresponding to lagged variables,
+            mapped to variable that is lagged
         """
         vars = {}
         for name in self._lags:
@@ -614,7 +822,14 @@ class TimeSeriesDataSet(Dataset):
     @property
     @lru_cache(None)
     def lagged_targets(self) -> Dict[str, str]:
-        """Subset of `lagged_variables` but only includes variables that are lagged targets."""
+        """Subset of lagged_variables to variables that are lagged targets.
+
+        Parameters
+        ----------
+        Dict[str, str]
+            dictionary of variable names corresponding to lagged variables,
+            mapped to variable that is lagged
+        """
         vars = {}
         for name in self._lags:
             vars.update(
@@ -632,8 +847,9 @@ class TimeSeriesDataSet(Dataset):
         """
         Minimum number of time steps variables are lagged.
 
-        Returns:
-            int: minimum lag
+        Returns
+        -------
+        int: minimum lag
         """
         if len(self._lags) == 0:
             return 1e9
@@ -646,67 +862,113 @@ class TimeSeriesDataSet(Dataset):
         """
         Maximum number of time steps variables are lagged.
 
-        Returns:
-            int: maximum lag
+        Returns
+        -------
+        int: maximum lag
         """
         if len(self._lags) == 0:
             return 0
         else:
             return max([max(lag) for lag in self._lags.values()])
 
-    def _set_target_normalizer(self, data: pd.DataFrame):
-        """
-        Determine target normalizer.
+    def _set_target_normalizer(self, data_properties, target_normalizer):
+        """Determine target normalizer.
 
-        Args:
-            data (pd.DataFrame): input data
+        Determines normalizers for variables based on self.target_normalizer setting.
+
+        Coerces normalizers to torch normalizer, and deals with the "auto" setting.
+
+        In the auto case, the normalizer for a variable x is determined as follows:
+
+        * if x is categorical, a NaNLabelEncoder is used
+        * if x is real and max_encoder_length > 20 and min_encoder_length > 1,
+            an EncoderNormalizer is used, otherwise a GroupNormalizer is used.
+            The transformation used in it is determined as follows:
+        * if x is real and positive, a log transformation is used if the skew of x is
+            larger than 2.5, otherwise a ReLU transformation is used
+        * if x is real and not positive, no transformation is used
+
+        The "auto" case uses metadata from the data passed in ``data_properties``,
+        otherwise the ``data_properties`` are not used.
+
+        Parameters
+        ----------
+        data_properties : dict
+            Dictionary of data properties as returned by self._data_properties(data)
+        target_normalizer : Union[NORMALIZER, str, list, tuple, None]
+            Normalizer for target variable. If "auto", the normalizer is determined
+            as above.
+
+        Returns
+        -------
+        TorchNormalizer
+            Normalizer for target variable, determined as above.
         """
-        if isinstance(self.target_normalizer, str) and self.target_normalizer == "auto":
-            normalizers = []
-            for target in self.target_names:
-                if data[target].dtype.kind != "f":  # category
-                    normalizers.append(NaNLabelEncoder())
-                    if self.add_target_scales:
-                        warnings.warn(
-                            "Target scales will be only added for continous targets",
-                            UserWarning,
-                        )
-                else:
-                    data_positive = (data[target] > 0).all()
-                    if data_positive:
-                        if data[target].skew() > 2.5:
-                            transformer = "log"
-                        else:
-                            transformer = "relu"
-                    else:
-                        transformer = None
-                    if self.max_encoder_length > 20 and self.min_encoder_length > 1:
-                        normalizers.append(
-                            EncoderNormalizer(transformation=transformer)
-                        )
-                    else:
-                        normalizers.append(GroupNormalizer(transformation=transformer))
-            if self.multi_target:
-                self.target_normalizer = MultiNormalizer(normalizers)
-            else:
-                self.target_normalizer = normalizers[0]
-        elif isinstance(self.target_normalizer, (tuple, list)):
-            self.target_normalizer = MultiNormalizer(self.target_normalizer)
-        elif self.target_normalizer is None:
-            self.target_normalizer = TorchNormalizer(method="identity")
+        if isinstance(target_normalizer, str) and target_normalizer == "auto":
+            target_normalizer = self._get_auto_normalizer(data_properties)
+        elif isinstance(target_normalizer, (tuple, list)):
+            target_normalizer = MultiNormalizer(self.target_normalizer)
+        elif target_normalizer is None:
+            target_normalizer = TorchNormalizer(method="identity")
+
+        # validation
         assert (
-            not isinstance(self.target_normalizer, EncoderNormalizer)
-            or self.min_encoder_length >= self.target_normalizer.min_length
+            not isinstance(target_normalizer, EncoderNormalizer)
+            or self.min_encoder_length >= target_normalizer.min_length
         ), "EncoderNormalizer is only allowed if min_encoder_length > 1"
-        assert isinstance(
-            self.target_normalizer, (TorchNormalizer, NaNLabelEncoder)
-        ), f"target_normalizer has to be either None or of class TorchNormalizer but found {self.target_normalizer}"
-        assert not self.multi_target or isinstance(
-            self.target_normalizer, MultiNormalizer
-        ), (
-            "multiple targets / list of targets requires MultiNormalizer as target_normalizer "
-            f"but found {self.target_normalizer}"
+        assert isinstance(target_normalizer, (TorchNormalizer, NaNLabelEncoder)), (
+            f"target_normalizer has to be either None or of "
+            f"class TorchNormalizer but found {target_normalizer}"
         )
+        assert not self.multi_target or isinstance(
+            target_normalizer, MultiNormalizer
+        ), (
+            "multiple targets / list of targets requires MultiNormalizer as "
+            f"target_normalizer but found {target_normalizer}"
+        )
+        return target_normalizer
+
+    def _get_auto_normalizer(self, data_properties):
+        """Get normalizer for auto setting, using data_properties.
+
+        See docstring of _set_target_normalizer for details.
+
+        Parameters
+        ----------
+        data_properties : dict
+            Dictionary of data properties as returned by self._data_properties(data)
+
+        Returns
+        -------
+        TorchNormalizer
+            Normalizer for target variable
+        """
+        normalizers = []
+        for target in self.target_names:
+            if data_properties["target_type"][target] == "categorical":
+                normalizers.append(NaNLabelEncoder())
+                if self.add_target_scales:
+                    warnings.warn(
+                        "Target scales will be only added for continous targets",
+                        UserWarning,
+                    )
+            else:  # real
+                if data_properties["target_positive"][target]:
+                    if data_properties["target_skew"][target] > 2.5:
+                        transformer = "log"
+                    else:
+                        transformer = "relu"
+                else:
+                    transformer = None
+                if self.max_encoder_length > 20 and self.min_encoder_length > 1:
+                    normalizers.append(EncoderNormalizer(transformation=transformer))
+                else:
+                    normalizers.append(GroupNormalizer(transformation=transformer))
+        if self.multi_target:
+            target_normalizer = MultiNormalizer(normalizers)
+        else:
+            target_normalizer = normalizers[0]
+        return target_normalizer
 
     @property
     @lru_cache(None)
@@ -714,7 +976,9 @@ class TimeSeriesDataSet(Dataset):
         """
         Mapping of group id names to group ids used to identify series in dataset -
         group ids can also be used for target normalizer.
-        The former can change from training to validation and test dataset while the later must not.
+
+        The former can change from training to validation and test dataset
+        while the later must not.
         """
         return {name: f"__group_id__{name}" for name in self.group_ids}
 
@@ -729,10 +993,11 @@ class TimeSeriesDataSet(Dataset):
         return list(self._group_ids_mapping.values())
 
     def _validate_data(self, data: pd.DataFrame):
-        """
-        Validate that data will not cause hick-ups later on.
-        """
-        # check for numeric categoricals which can cause hick-ups in logging in tensorboard
+        """Validate assumptions on data.."""
+        assert (
+            data[self.time_idx].dtype.kind == "i"
+        ), "Timeseries index should be of type integer"
+        # numeric categoricals which can cause issues in tensorborad logging
         category_columns = data.head(1).select_dtypes("category").columns
         object_columns = data.head(1).select_dtypes(object).columns
         for name in self.flat_categoricals:
@@ -746,14 +1011,27 @@ class TimeSeriesDataSet(Dataset):
                 )
             ):
                 raise ValueError(
-                    f"Data type of category {name} was found to be numeric - use a string type / categorified string"
+                    f"Data type of category {name} was found to be numeric"
+                    " - use a string type / categorified string"
                 )
         # check for "." in column names
         columns_with_dot = data.columns[data.columns.str.contains(r"\.")]
         if len(columns_with_dot) > 0:
             raise ValueError(
-                f"column names must not contain '.' characters. Names {columns_with_dot.tolist()} are invalid"
+                f"column names must not contain '.' characters. "
+                f"Names {columns_with_dot.tolist()} are invalid"
             )
+
+        assert data.index.is_unique, "data index has to be unique"
+
+        if len(self._lags) > 0:
+            for name in self._lags:
+                lagged_names = self._get_lagged_names(name)
+                for lagged_name in lagged_names:
+                    assert lagged_name not in data.columns, (
+                        f"{lagged_name} is a protected column and must not be "
+                        "present in data"
+                    )
 
     def save(self, fname: str) -> None:
         """
@@ -792,9 +1070,12 @@ class TimeSeriesDataSet(Dataset):
         # add lags to data
         for name in self._lags:
             # todo: add support for variable groups
-            assert (
-                name not in self._variable_groups
-            ), f"lagged variables that are in {self._variable_groups} are not supported yet"
+            msg = (
+                f"lagged variables that are in {self._variable_groups} "
+                "are not supported yet"
+            )
+            assert name not in self._variable_groups, msg
+
             for lagged_name, lag in self._get_lagged_names(name).items():
                 data[lagged_name] = data.groupby(self.group_ids, observed=True)[
                     name
@@ -813,7 +1094,8 @@ class TimeSeriesDataSet(Dataset):
                 name, data[name], inverse=False, group_id=True
             )
 
-        # encode categoricals first to ensure that group normalizer for relies on encoded categories
+        # encode categoricals first to ensure
+        # that group normalizer relies on encoded categories
         if isinstance(
             self.target_normalizer, (GroupNormalizer, MultiNormalizer)
         ):  # if we use a group normalizer, group_ids must be encoded as well
@@ -867,9 +1149,11 @@ class TimeSeriesDataSet(Dataset):
         ), "__time_idx__ is a protected column and must not be present in data"
         data["__time_idx__"] = data[self.time_idx]  # save unscaled
         for target in self.target_names:
-            assert (
-                f"__target__{target}" not in data.columns
-            ), f"__target__{target} is a protected column and must not be present in data"
+            msg = (
+                f"__target__{target} is a protected column "
+                "and must not be present in data"
+            )
+            assert f"__target__{target}" not in data.columns, msg
             data[f"__target__{target}"] = data[target]
         if self.weight is not None:
             data["__weight__"] = data[self.weight]
@@ -925,12 +1209,14 @@ class TimeSeriesDataSet(Dataset):
                     data[target] = transformed[idx]
 
                     if isinstance(self.target_normalizer[idx], NaNLabelEncoder):
-                        # overwrite target because it requires encoding (continuous targets should not be normalized)
+                        # overwrite target because it requires encoding
+                        # (continuous targets should not be normalized)
                         data[f"__target__{target}"] = data[target]
 
             elif isinstance(self.target_normalizer, NaNLabelEncoder):
                 data[self.target] = self.target_normalizer.transform(data[self.target])
-                # overwrite target because it requires encoding (continuous targets should not be normalized)
+                # overwrite target because it requires encoding
+                # (continuous targets should not be normalized)
                 data[f"__target__{self.target}"] = data[self.target]
                 scales = None
 
@@ -949,9 +1235,12 @@ class TimeSeriesDataSet(Dataset):
                     ):
                         for scale_idx, name in enumerate(["center", "scale"]):
                             feature_name = f"{target}_{name}"
-                            assert (
-                                feature_name not in data.columns
-                            ), f"{feature_name} is a protected column and must not be present in data"
+                            msg = (
+                                f"{feature_name} is a protected column "
+                                "and must not be present in data"
+                            )
+                            assert feature_name not in data.columns, msg
+
                             data[feature_name] = scales[target_idx][
                                 :, scale_idx
                             ].squeeze()
@@ -1004,24 +1293,29 @@ class TimeSeriesDataSet(Dataset):
                 name, np.array([value]), data=data, inverse=False
             )[0]
 
-        # shorten data by maximum of lagged sequences to avoid NA values - shorten only after encoding
+        # shorten data by maximum of lagged sequences to avoid NA values -
+        # shorten only after encoding
         if self.max_lag > 0:
-            # negative tail implementation as .groupby().tail(-self.max_lag) is not implemented in pandas
+            # negative tail implementation as .groupby().tail(-self.max_lag)
+            # is not implemented in pandas
             g = data.groupby(self._group_ids, observed=True)
             data = g._selected_obj[g.cumcount() >= self.max_lag]
         return data
 
     def get_transformer(self, name: str, group_id: bool = False):
-        """
-        Get transformer for variable.
+        """Get transformer for variable.
 
-        Args:
-            name (str): variable name
-            group_id (bool, optional): If the passed name refers to a group id (different encoders are used for these).
-                Defaults to False.
+        Parameters
+        ----------
+        name : str
+            variable name
+        group_id : bool, optional, default=False
+            Whether the passed name refers to a group id,
+            different encoders are used for these.
 
-        Returns:
-            transformer
+        Returns
+        -------
+        transformer
         """
         if group_id:
             name = self._group_ids_mapping[name]
@@ -1059,21 +1353,27 @@ class TimeSeriesDataSet(Dataset):
         group_id: bool = False,
         **kwargs,
     ) -> np.ndarray:
-        """
-        Scale and encode values.
+        """Scale and encode values.
 
-        Args:
-            name (str): name of variable
-            values (Union[pd.Series, torch.Tensor, np.ndarray]): values to encode/scale
-            data (pd.DataFrame, optional): extra data used for scaling (e.g. dataframe with groups columns).
-                Defaults to None.
-            inverse (bool, optional): if to conduct inverse transformation. Defaults to False.
-            group_id (bool, optional): If the passed name refers to a group id (different encoders are used for these).
-                Defaults to False.
-            **kwargs: additional arguments for transform/inverse_transform method
+        Parameters
+        ----------
+        name : str
+            name of variable
+        values : Union[pd.Series, torch.Tensor, np.ndarray]
+            values to encode/scale
+        data : pd.DataFrame, optional, default=None
+            extra data used for scaling (e.g. dataframe with groups columns)
+        inverse : bool, optional, default=False
+            whether transform is plain (True), or inverse (False)
+        group_id : bool, optional, default=False
+            whether the passed name refers to a group id -
+            different encoders are used for these
+        **kwargs: additional arguments for transform/inverse_transform method
 
-        Returns:
-            np.ndarray: (de/en)coded/(de)scaled values
+        Returns
+        -------
+        np.ndarray
+            (de/en)coded/(de)scaled values
         """
         transformer = self.get_transformer(name, group_id=group_id)
         if transformer is None:
@@ -1106,93 +1406,62 @@ class TimeSeriesDataSet(Dataset):
             return values
 
     def _data_to_tensors(self, data: pd.DataFrame) -> Dict[str, torch.Tensor]:
+        """Convert data to tensors for faster access with :py:meth:`~__getitem__`.
+
+        Parameters
+        ----------
+        data : pd.DataFrame
+            preprocessed data
+
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            dictionary of tensors for continous, categorical data, groups, target and
+            time index
         """
-        Convert data to tensors for faster access with :py:meth:`~__getitem__`.
 
-        Args:
-            data (pd.DataFrame): preprocessed data
+        def _to_tensor(cols, long=True):
+            """Convert data[cols] to torch tensor.
 
-        Returns:
-            Dict[str, torch.Tensor]: dictionary of tensors for continous, categorical data, groups, target and
-                time index
-        """
+            Converts sub-frames to numpy and then to torch tensor.
+            Makes the following choices for types:
 
-        index = check_for_nonfinite(
-            torch.tensor(data[self._group_ids].to_numpy(np.int64), dtype=torch.int64),
-            self.group_ids,
-        )
-        time = check_for_nonfinite(
-            torch.tensor(data["__time_idx__"].to_numpy(np.int64), dtype=torch.int64),
-            self.time_idx,
-        )
+            * float columns are converted to torch.float
+            * integer columns are converted to torch.int64 or torch.long,
+              depending on the long argument
+            """
+            if not isinstance(cols, list) and cols not in data.columns:
+                return None
+            if isinstance(cols, list) and len(cols) == 0:
+                dtypekind = "f"
+            elif isinstance(cols, list):  # and len(cols) > 0
+                dtypekind = data.dtypes[cols[0]].kind
+            else:
+                dtypekind = data.dtypes[cols].kind
+            if not long:
+                return torch.tensor(data[cols].to_numpy(np.int64), dtype=torch.int64)
+            elif dtypekind in "bi":
+                return torch.tensor(data[cols].to_numpy(np.int64), dtype=torch.long)
+            else:
+                return torch.tensor(data[cols].to_numpy(np.float64), dtype=torch.float)
 
-        # categorical covariates
-        categorical = check_for_nonfinite(
-            torch.tensor(
-                data[self.flat_categoricals].to_numpy(np.int64), dtype=torch.int64
-            ),
-            self.flat_categoricals,
-        )
+        index = _to_tensor(self._group_ids, long=False)
+        time = _to_tensor("__time_idx__", long=False)
+        categorical = _to_tensor(self.flat_categoricals, long=False)
 
-        # get weight
-        if self.weight is not None:
-            weight = check_for_nonfinite(
-                torch.tensor(
-                    data["__weight__"].to_numpy(dtype=np.float64),
-                    dtype=torch.float,
-                ),
-                self.weight,
-            )
-        else:
-            weight = None
+        weight = _to_tensor("__weight__")
 
         # get target
         if isinstance(self.target_normalizer, NaNLabelEncoder):
-            target = [
-                check_for_nonfinite(
-                    torch.tensor(
-                        data[f"__target__{self.target}"].to_numpy(dtype=np.int64),
-                        dtype=torch.long,
-                    ),
-                    self.target,
-                )
-            ]
+            target = [_to_tensor(f"__target__{self.target}")]
         else:
             if not isinstance(self.target, str):  # multi-target
-                target = [
-                    check_for_nonfinite(
-                        torch.tensor(
-                            data[f"__target__{name}"].to_numpy(
-                                dtype=[np.float64, np.int64][
-                                    data[name].dtype.kind in "bi"
-                                ]
-                            ),
-                            dtype=[torch.float, torch.long][
-                                data[name].dtype.kind in "bi"
-                            ],
-                        ),
-                        name,
-                    )
-                    for name in self.target_names
-                ]
+                target = [_to_tensor(f"__target__{name}") for name in self.target_names]
             else:
-                target = [
-                    check_for_nonfinite(
-                        torch.tensor(
-                            data[f"__target__{self.target}"].to_numpy(dtype=np.float64),
-                            dtype=torch.float,
-                        ),
-                        self.target,
-                    )
-                ]
+                target = [_to_tensor(f"__target__{self.target}")]
 
         # continuous covariates
-        continuous = check_for_nonfinite(
-            torch.tensor(
-                data[self.reals].to_numpy(dtype=np.float64), dtype=torch.float
-            ),
-            self.reals,
-        )
+        continuous = _to_tensor(self.reals)
 
         tensors = dict(
             reals=continuous,
@@ -1202,8 +1471,27 @@ class TimeSeriesDataSet(Dataset):
             weight=weight,
             time=time,
         )
-
         return tensors
+
+    def _check_tensors(self, tensors):
+        """Check for non-finite values in tensors."""
+        var_names_dict = {
+            "reals": self.reals,
+            "categoricals": self.flat_categoricals,
+            "groups": self.group_ids,
+            "target": self.target_names,
+            "weight": self.weight,
+            "time": self.time_idx,
+        }
+
+        for key, tensor in tensors.items():
+            var_names = var_names_dict[key]
+            if tensor is not None:
+                if isinstance(tensor, list):
+                    for idx, target_tensor in enumerate(tensor):
+                        check_for_nonfinite(target_tensor, var_names[idx])
+                else:
+                    check_for_nonfinite(tensor, var_names)
 
     @property
     def categoricals(self) -> List[str]:
@@ -1240,8 +1528,10 @@ class TimeSeriesDataSet(Dataset):
         """
         Mapping from categorical variables to variables in input data.
 
-        Returns:
-            Dict[str, str]: dictionary mapping from :py:meth:`~categorical` to :py:meth:`~flat_categoricals`.
+        Returns
+        -------
+        Dict[str, str]
+            dictionary, maps :py:meth:`~categorical` to :py:meth:`~flat_categoricals`.
         """
         groups = {}
         for group_name, sublist in self._variable_groups.items():
@@ -1301,11 +1591,14 @@ class TimeSeriesDataSet(Dataset):
         return target_normalizers
 
     def get_parameters(self) -> Dict[str, Any]:
-        """
-        Get parameters that can be used with :py:meth:`~from_parameters` to create a new dataset with the same scalers.
+        """Get parameters of self as dict.
 
-        Returns:
-            Dict[str, Any]: dictionary of parameters
+        These can be used with :py:meth:`~from_parameters`
+        to create a new dataset with the same scalers.
+
+        Returns
+        -------
+        Dict[str, Any]: dictionary of parameters
         """
         kwargs = {
             name: getattr(self, name)
@@ -1325,22 +1618,31 @@ class TimeSeriesDataSet(Dataset):
         predict: bool = False,
         **update_kwargs,
     ):
-        """
-        Generate dataset with different underlying data but same variable encoders and scalers, etc.
+        """Construct dataset with different data, same variable encoders, scalers, etc.
 
         Calls :py:meth:`~from_parameters` under the hood.
 
-        Args:
-            dataset (TimeSeriesDataSet): dataset from which to copy parameters
-            data (pd.DataFrame): data from which new dataset will be generated
-            stop_randomization (bool, optional): If to stop randomizing encoder and decoder lengths,
-                e.g. useful for validation set. Defaults to False.
-            predict (bool, optional): If to predict the decoder length on the last entries in the
-                time index (i.e. one prediction per group only). Defaults to False.
-            **kwargs: keyword arguments overriding parameters in the original dataset
+        May override parameters with update_kwargs.
 
-        Returns:
-            TimeSeriesDataSet: new dataset
+        Parameters
+        ----------
+        dataset : TimeSeriesDataSet
+            dataset from which to copy parameters
+        data : pd.DataFrame
+            data from which new dataset will be generated
+        stop_randomization : bool, optional, default=None
+            Whether to stop randomizing encoder and decoder lengths,
+            useful for validation set.
+        predict : bool, optional, default=False
+            Whether to predict the decoder length on the last entries in the
+            time index (i.e. one prediction per group only).
+        **update_kwargs
+            keyword arguments overrides, passed to constructor of the new dataset
+
+        Returns
+        -------
+        TimeSeriesDataSet
+            new dataset
         """
         return cls.from_parameters(
             dataset.get_parameters(),
@@ -1359,36 +1661,47 @@ class TimeSeriesDataSet(Dataset):
         predict: bool = False,
         **update_kwargs,
     ):
-        """
-        Generate dataset with different underlying data but same variable encoders and scalers, etc.
+        """Construct dataset with different data, same variable encoders, scalers, etc.
 
-        Args:
-            parameters (Dict[str, Any]): dataset parameters which to use for the new dataset
-            data (pd.DataFrame): data from which new dataset will be generated
-            stop_randomization (bool, optional): If to stop randomizing encoder and decoder lengths,
-                e.g. useful for validation set. Defaults to False.
-            predict (bool, optional): If to predict the decoder length on the last entries in the
-                time index (i.e. one prediction per group only). Defaults to False.
-            **kwargs: keyword arguments overriding parameters
+        Returns TimeSeriesDataSet with same parameters as self, but different data.
+        May override parameters with update_kwargs.
 
-        Returns:
-            TimeSeriesDataSet: new dataset
+        Parameters
+        ----------
+        parameters : Dict[str, Any]
+            dataset parameters which to use for the new dataset
+        data : pd.DataFrame
+            data from which new dataset will be generated
+        stop_randomization : bool, optional, default=None
+            Whether to stop randomizing encoder and decoder lengths,
+            useful for validation set.
+        predict : bool, optional, default=False
+            Whether to predict the decoder length on the last entries in the
+            time index (i.e. one prediction per group only).
+        **update_kwargs
+            keyword arguments overrides, passed to constructor of the new dataset
+
+        Returns
+        -------
+        TimeSeriesDataSet
+            new dataset
         """
         parameters = deepcopy(parameters)
+
         if predict:
-            if stop_randomization is None:
-                stop_randomization = True
-            elif not stop_randomization:
+            if isinstance(stop_randomization, bool) and not stop_randomization:
                 warnings.warn(
-                    "If predicting, no randomization should be possible - setting stop_randomization=True",
+                    "If predicting, no randomization should be possible - "
+                    "setting stop_randomization=True",
                     UserWarning,
                 )
-                stop_randomization = True
             parameters["min_prediction_length"] = parameters["max_prediction_length"]
             parameters["predict_mode"] = True
-        elif stop_randomization is None:
-            stop_randomization = False
 
+        # this treats cases for randomize_length randomization:
+        # if predict mode, always turned off, i.e., always stop_ransomization=True
+        # otherwise, None defaults to False
+        stop_randomization = predict or stop_randomization
         if stop_randomization:
             parameters["randomize_length"] = None
         parameters.update(update_kwargs)
@@ -1397,16 +1710,21 @@ class TimeSeriesDataSet(Dataset):
         return new
 
     def _construct_index(self, data: pd.DataFrame, predict_mode: bool) -> pd.DataFrame:
-        """
-        Create index of samples.
+        """Create index of samples returned by getitem dunder.
 
-        Args:
-            data (pd.DataFrame): preprocessed data
-            predict_mode (bool): if to create one same per group with prediction length equals ``max_decoder_length``
+        Parameters
+        ----------
+        data : pd.DataFrame
+            preprocessed data
+        predict_mode : bool
+            whether to create one sample per group
+            with prediction length equals ``max_decoder_length``
 
-        Returns:
-            pd.DataFrame: index dataframe for timesteps and index dataframe for groups.
-                It contains a list of all possible subsequences.
+        Returns
+        -------
+        pd.DataFrame
+            index dataframe for timesteps and index dataframe for groups.
+            It contains a list of all possible subsequences.
         """
         g = data.groupby(self._group_ids, observed=True)
 
@@ -1438,12 +1756,15 @@ class TimeSeriesDataSet(Dataset):
             upper=df_index["count"] + df_index.time_first - 1
         )
 
-        # if there are missing timesteps, we cannot say directly what is the last timestep to include
+        # if there are missing timesteps, we cannot say directly what
+        # is the last timestep to include
         # therefore we iterate until it is found
         if (df_index["time_diff_to_next"] != 1).any():
-            assert (
-                self.allow_missing_timesteps
-            ), "Time difference between steps has been idenfied as larger than 1 - set allow_missing_timesteps=True"
+            msg = (
+                "Time difference between steps has been idenfied as larger than 1 - "
+                "set allow_missing_timesteps=True"
+            )
+            assert self.allow_missing_timesteps, msg
 
         df_index["index_end"], missing_sequences = _find_end_indices(
             diffs=df_index.time_diff_to_next.to_numpy(),
@@ -1451,7 +1772,8 @@ class TimeSeriesDataSet(Dataset):
             min_length=min_sequence_length,
         )
         # add duplicates but mostly with shorter sequence length for start of timeseries
-        # while the previous steps have ensured that we start a sequence on every time step, the missing_sequences
+        # while the previous steps have ensured that we start a sequence on every time
+        # step, the missing_sequences
         # ensure that there is a sequence that finishes on every timestep
         if len(missing_sequences) > 0:
             shortened_sequences = df_index.iloc[missing_sequences[:, 0]].assign(
@@ -1475,17 +1797,18 @@ class TimeSeriesDataSet(Dataset):
             # sequence must be at least of minimal prediction length
             lambda x: (x.sequence_length >= min_sequence_length)
             &
-            # prediction must be for after minimal prediction index + length of prediction
+            # prediction must be for minimal prediction index + length of prediction
             (
                 x["sequence_length"] + x["time"]
                 >= self.min_prediction_idx + self.min_prediction_length
             )
         ]
 
-        if (
-            predict_mode
-        ):  # keep longest element per series (i.e. the first element that spans to the end of the series)
-            # filter all elements that are longer than the allowed maximum sequence length
+        if predict_mode:
+            # keep longest element per series
+            # (i.e., the first element that spans to the end of the series)
+            # filter all elements that are longer
+            # than the allowed maximum sequence length
             df_index = df_index[
                 lambda x: (x["time_last"] - x["time"] + 1 <= max_sequence_length)
                 & (x["sequence_length"] >= min_sequence_length)
@@ -1506,33 +1829,41 @@ class TimeSeriesDataSet(Dataset):
                     name, missing_groups[id], inverse=True, group_id=True
                 )
             warnings.warn(
-                "Min encoder length and/or min_prediction_idx and/or min prediction length and/or lags are "
-                "too large for "
-                f"{len(missing_groups)} series/groups which therefore are not present in the dataset index. "
+                "Min encoder length and/or min_prediction_idx and/or min "
+                "prediction length and/or lags are too large for "
+                f"{len(missing_groups)} series/groups which therefore are not present"
+                " in the dataset index. "
                 "This means no predictions can be made for those series. "
-                f"First 10 removed groups: {list(missing_groups.iloc[:10].to_dict(orient='index').values())}",
+                f"First 10 removed groups: "
+                f"{list(missing_groups.iloc[:10].to_dict(orient='index').values())}",
                 UserWarning,
             )
-        assert (
-            len(df_index) > 0
-        ), "filters should not remove entries all entries - check encoder/decoder lengths and lags"
+        msg = (
+            "filters should not remove entries all entries - "
+            "check encoder/decoder lengths and lags"
+        )
+        assert len(df_index) > 0, msg
 
         return df_index
 
     def filter(self, filter_func: Callable, copy: bool = True) -> "TimeSeriesDataSet":
-        """
-        Filter subsequences in dataset.
+        """Filter subsequences in dataset.
 
         Uses interpretable version of index :py:meth:`~decoded_index`
         to filter subsequences in dataset.
 
-        Args:
-            filter_func (Callable): function to filter. Should take :py:meth:`~decoded_index`
-                dataframe as only argument which contains group ids and time index columns.
-            copy (bool): if to return copy of dataset or filter inplace.
+        Parameters
+        ----------
+        filter_func : Callable
+            function to filter. Should take :py:meth:`~decoded_index`
+            dataframe as only argument which contains group ids and time index columns.
+        copy : bool, optional, default=True
+            whether to return copy of dataset (True) or filter inplace (False).
 
-        Returns:
-            TimeSeriesDataSet: filtered dataset
+        Returns
+        -------
+        TimeSeriesDataSet
+            filtered dataset
         """
         # calculate filter
         filtered_index = self.index[np.asarray(filter_func(self.decoded_index))]
@@ -1596,17 +1927,21 @@ class TimeSeriesDataSet(Dataset):
         length: int = None,
         min_length: int = None,
     ):
-        """
-        Plot expected randomized length distribution.
+        """Plot expected randomized length distribution.
 
-        Args:
-            betas (Tuple[float, float], optional): Tuple of betas, e.g. ``(0.2, 0.05)`` to use for randomization.
-                Defaults to ``randomize_length`` of dataset.
-            length (int, optional): . Defaults to ``max_encoder_length``.
-            min_length (int, optional): [description]. Defaults to ``min_encoder_length``.
+        Parameters
+        ----------
+        betas : Tuple[float, float], optional, default=randomize_length of dataset
+            Tuple of betas, e.g. ``(0.2, 0.05)`` to use for randomization.
+        length : int, optional, default=max_encoder_length of dataset
+            Length of sequence to plot.
+        min_length : int, optional, default=min_encoder_length of dataset
+            Minimum length of sequence to plot.
 
-        Returns:
-            Tuple[plt.Figure, torch.Tensor]: tuple of figure and histogram based on 1000 samples
+        Returns
+        -------
+        Tuple[plt.Figure, torch.Tensor]
+            tuple of figure and histogram based on 1000 samples
         """
         _check_matplotlib("plot_randomization")
 
@@ -1641,31 +1976,32 @@ class TimeSeriesDataSet(Dataset):
         variable: str,
         target: Union[str, slice] = "decoder",
     ) -> None:
-        """
-        Convenience method to quickly overwrite values in decoder or encoder (or both) for a specific variable.
+        """Overwrite values in decoder or encoder (or both) for a specific variable.
 
-        Args:
-            values (Union[float, torch.Tensor]): values to use for overwrite.
-            variable (str): variable whose values should be overwritten.
-            target (Union[str, slice], optional): positions to overwrite. One of "decoder", "encoder" or "all" or
-                a slice object which is directly used to overwrite indices, e.g. ``slice(-5, None)`` will overwrite
-                the last 5 values. Defaults to "decoder".
+        Parameters
+        ----------
+        values : Union[float, torch.Tensor]
+            values to use for overwrite.
+        variable : str
+            variable whose values should be overwritten.
+        target : Union[str, slice], optional)
+            positions to overwrite. One of "decoder", "encoder" or "all" or
+            a slice object which is directly used to overwrite indices,
+            e.g., ``slice(-5, None)`` will overwrite
+            the last 5 values. Defaults to "decoder".
         """
         values = torch.tensor(
             self.transform_values(
                 variable, np.asarray(values).reshape(-1), inverse=False
             )
         ).squeeze()
-        assert target in [
-            "all",
-            "decoder",
-            "encoder",
-        ], f"target has be one of 'all', 'decoder' or 'encoder' but target={target} instead"
+        msg = (
+            f"target has be one of 'all', 'decoder' or 'encoder' "
+            f"but got target={target} instead"
+        )
+        assert target in ["all", "decoder", "encoder"], msg
 
-        if (
-            variable in self._static_categoricals
-            or variable in self._static_categoricals
-        ):
+        if variable in self._static_categoricals or variable in self._static_reals:
             target = "all"
 
         if variable in self.target_names:
@@ -1697,15 +2033,19 @@ class TimeSeriesDataSet(Dataset):
         time_last: Union[int, pd.Series, np.ndarray],
         sequence_length: Union[int, pd.Series, np.ndarray],
     ) -> Union[int, pd.Series, np.ndarray]:
-        """
-        Calculate length of decoder.
+        """Calculate length of decoder.
 
-        Args:
-            time_last (Union[int, pd.Series, np.ndarray]): last time index of the sequence
-            sequence_length (Union[int, pd.Series, np.ndarray]): total length of the sequence
+        Parameters
+        ----------
+        time_last : Union[int, pd.Series, np.ndarray]
+            last time index of the sequence
+        sequence_length : Union[int, pd.Series, np.ndarray]
+            total length of the sequence
 
-        Returns:
-            Union[int, pd.Series, np.ndarray]: decoder length(s)
+        Returns
+        -------
+        Union[int, pd.Series, np.ndarray]
+            decoder length(s)
         """
         if isinstance(time_last, int):
             decoder_length = min(
@@ -1736,29 +2076,25 @@ class TimeSeriesDataSet(Dataset):
             Tuple[Dict[str, torch.Tensor], torch.Tensor]: x and y for model
         """
         index = self.index.iloc[idx]
-        # get index data
-        data_cont = self.data["reals"][index.index_start : index.index_end + 1].clone()
-        data_cat = self.data["categoricals"][
-            index.index_start : index.index_end + 1
-        ].clone()
-        time = self.data["time"][index.index_start : index.index_end + 1].clone()
-        target = [
-            d[index.index_start : index.index_end + 1].clone()
-            for d in self.data["target"]
-        ]
+
+        # slice data based on index
+        idx_slice = slice(index.index_start, index.index_end + 1)
+
+        data_cont = self.data["reals"][idx_slice].clone()
+        data_cat = self.data["categoricals"][idx_slice].clone()
+        time = self.data["time"][idx_slice].clone()
+        target = [d[idx_slice].clone() for d in self.data["target"]]
         groups = self.data["groups"][index.index_start].clone()
         if self.data["weight"] is None:
             weight = None
         else:
-            weight = self.data["weight"][
-                index.index_start : index.index_end + 1
-            ].clone()
+            weight = self.data["weight"][idx_slice].clone()
         # get target scale in the form of a list
         target_scale = self.target_normalizer.get_parameters(groups, self.group_ids)
         if not isinstance(self.target_normalizer, MultiNormalizer):
             target_scale = [target_scale]
 
-        # fill in missing values (if not all time indices are specified
+        # fill in missing values (if not all time indices are specified)
         sequence_length = len(time)
         if sequence_length < index.sequence_length:
             assert (
@@ -1959,9 +2295,11 @@ class TimeSeriesDataSet(Dataset):
                 idx = self.reals.index(self._overwrite_values["variable"])
                 data_cont[positions, idx] = self._overwrite_values["values"]
             else:
-                assert (
-                    self._overwrite_values["variable"] in self.flat_categoricals
-                ), "overwrite values variable has to be either in real or categorical variables"
+                msg = (
+                    "overwrite values variable has to be "
+                    "either in real or categorical variables"
+                )
+                assert self._overwrite_values["variable"] in self.flat_categoricals, msg
                 idx = self.flat_categoricals.index(self._overwrite_values["variable"])
                 data_cat[positions, idx] = self._overwrite_values["values"]
 
@@ -1999,12 +2337,43 @@ class TimeSeriesDataSet(Dataset):
         """
         Collate function to combine items into mini-batch for dataloader.
 
-        Args:
-            batches (List[Tuple[Dict[str, torch.Tensor], torch.Tensor]]): List of samples generated with
-                :py:meth:`~__getitem__`.
+        Parameters
+        ----------
+        batches (List[Tuple[Dict[str, torch.Tensor], torch.Tensor]]):
+            List of samples generated with :py:meth:`~__getitem__`.
 
-        Returns:
-            Tuple[Dict[str, torch.Tensor], Tuple[Union[torch.Tensor, List[torch.Tensor]], torch.Tensor]: minibatch
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            dictionary of minibatches with keys:
+
+            * encoder_cat: (batch_size, encoder_length, num_categorical),
+                categorical variables for encoder
+            * encoder_cont: (batch_size, encoder_length, num_real),
+                continuous variables for encoder
+            * encoder_target: (batch_size, encoder_length, num_target),
+                target variables for encoder
+            * encoder_lengths: (batch_size), length of encoder
+            * decoder_cat: (batch_size, decoder_length, num_categorical),
+                categorical variables for decoder
+            * decoder_cont: (batch_size, decoder_length, num_real),
+                continuous variables for decoder
+            * decoder_target: (batch_size, decoder_length, num_target),
+                target variables for decoder
+            * decoder_lengths: (batch_size), length of decoder
+            * decoder_time_idx: (batch_size, decoder_length),
+                time index for decoder
+            * groups: (batch_size), group ids
+            * target_scale: (batch_size, num_target),
+                scale of target variables
+
+        Tuple[torch.Tensor, torch.Tensor]
+            minibatch, 2-tuple with entries:
+
+            * target: (batch_size, decoder_length, num_target),
+                target variables
+            * weight: (batch_size, decoder_length),
+                weights for target variables
         """
         # collate function for dataloader
         # lengths
@@ -2140,73 +2509,88 @@ class TimeSeriesDataSet(Dataset):
         batch_sampler: Union[Sampler, str] = None,
         **kwargs,
     ) -> DataLoader:
-        """
-        Get dataloader from dataset.
+        """Construct dataloader from dataset, for use in models.
 
-        The
+        Parameters
+        ----------
+        train : bool, optional, default=Trze
+            whether dataloader is used for training (True) or prediction (False).
+            Will shuffle and drop last batch if True. Defaults to True.
+        batch_size : int, optional, default=64
+            batch size for training model. Defaults to 64.
+        batch_sampler : Sampler, str, or None, optional, default=None
+            torch batch sampler or string. One of
 
-        Args:
-            train (bool, optional): if dataloader is used for training or prediction
-                Will shuffle and drop last batch if True. Defaults to True.
-            batch_size (int): batch size for training model. Defaults to 64.
-            batch_sampler (Union[Sampler, str]): batch sampler or string. One of
+            * "synchronized": ensure that samples in decoder are aligned in time.
+                Does not support missing values in dataset.
+                This makes only sense if the underlying algorithm makes use of
+                values aligned in time.
+            * PyTorch Sampler instance: any PyTorch sampler,
+                e.g., ``the WeightedRandomSampler()``
+            * None: samples are taken randomly from times series.
 
-                * "synchronized": ensure that samples in decoder are aligned in time. Does not support missing
-                  values in dataset. This makes only sense if the underlying algorithm makes use of values aligned
-                  in time.
-                * PyTorch Sampler instance: any PyTorch sampler, e.g. the WeightedRandomSampler()
-                * None: samples are taken randomly from times series.
+        **kwargs: additional arguments passed to ``DataLoader`` constructor
 
-            **kwargs: additional arguments to ``DataLoader()``
+        Returns
+        -------
+        DataLoader: dataloader that returns Tuple.
+            First entry is ``x``, a dictionary of tensors with the entries,
+            and shapes in brackets.
 
-        Returns:
-            DataLoader: dataloader that returns Tuple.
-                First entry is ``x``, a dictionary of tensors with the entries (and shapes in brackets)
+            * encoder_cat : long (batch_size x n_encoder_time_steps x n_features)
+                long tensor of encoded categoricals for encoder
+            * encoder_cont : float (batch_size x n_encoder_time_steps x n_features)
+                float tensor of scaled continuous variables for encoder
+            * encoder_target : float (batch_size x n_encoder_time_steps) or list thereof
+                if list, each entry for a different target.
+                float tensor with unscaled continous target
+                or encoded categorical target,
+                list of tensors for multiple targets
+            * encoder_lengths : long (batch_size)
+                long tensor with lengths of the encoder time series. No entry will
+                be greater than n_encoder_time_steps
+            * decoder_cat : long (batch_size x n_decoder_time_steps x n_features)
+                long tensor of encoded categoricals for decoder
+            * decoder_cont : float (batch_size x n_decoder_time_steps x n_features)
+                float tensor of scaled continuous variables for decoder
+            * decoder_target : float (batch_size x n_decoder_time_steps) or list thereof
+                if list, with each entry for a different target.
+                float tensor with unscaled continous target or encoded categorical
+                target for decoder
+                - this corresponds to first entry of ``y``,
+                list of tensors for multiple targets
+            * decoder_lengths : long (batch_size)
+                long tensor with lengths of the decoder time series. No entry will
+                be greater than n_decoder_time_steps
+            * group_ids : float (batch_size x number_of_ids)
+                encoded group ids that identify a time series in the dataset
+            * target_scale : float (batch_size x scale_size) or list thereof.
+                if list, with each entry for a different target.
+                parameters used to normalize the target.
+                Typically these are mean and standard deviation.
+                Is list of tensors for multiple targets.
 
-                * encoder_cat (batch_size x n_encoder_time_steps x n_features): long tensor of encoded
-                  categoricals for encoder
-                * encoder_cont (batch_size x n_encoder_time_steps x n_features): float tensor of scaled continuous
-                  variables for encoder
-                * encoder_target (batch_size x n_encoder_time_steps or list thereof with each entry for a different
-                  target):
-                  float tensor with unscaled continous target or encoded categorical target,
-                  list of tensors for multiple targets
-                * encoder_lengths (batch_size): long tensor with lengths of the encoder time series. No entry will
-                  be greater than n_encoder_time_steps
-                * decoder_cat (batch_size x n_decoder_time_steps x n_features): long tensor of encoded
-                  categoricals for decoder
-                * decoder_cont (batch_size x n_decoder_time_steps x n_features): float tensor of scaled continuous
-                  variables for decoder
-                * decoder_target (batch_size x n_decoder_time_steps or list thereof with each entry for a different
-                  target):
-                  float tensor with unscaled continous target or encoded categorical target for decoder
-                  - this corresponds to first entry of ``y``, list of tensors for multiple targets
-                * decoder_lengths (batch_size): long tensor with lengths of the decoder time series. No entry will
-                  be greater than n_decoder_time_steps
-                * group_ids (batch_size x number_of_ids): encoded group ids that identify a time series in the dataset
-                * target_scale (batch_size x scale_size or list thereof with each entry for a different target):
-                  parameters used to normalize the target.
-                  Typically these are mean and standard deviation. Is list of tensors for multiple targets.
+            Second entry is ``y``, a tuple of the form (``target``, `weight`)
 
+            * target : float (batch_size x n_decoder_time_steps) or list thereof
+                if list, with each entry for a different target.
+                unscaled (continuous) or encoded (categories) targets,
+                list of tensors for multiple targets
+            * weight : None or float (batch_size x n_decoder_time_steps)
+                weights for each target, None if no weight is used (= equal weights)
 
-                Second entry is ``y``, a tuple of the form (``target``, `weight`)
+        Example
+        -------
+        Weight by samples for training:
 
-                * target (batch_size x n_decoder_time_steps or list thereof with each entry for a different target):
-                  unscaled (continuous) or encoded (categories) targets, list of tensors for multiple targets
-                * weight (None or batch_size x n_decoder_time_steps): weight
+        .. code-block:: python
 
-        Example:
+            from torch.utils.data import WeightedRandomSampler
 
-            Weight by samples for training:
-
-            .. code-block:: python
-
-                from torch.utils.data import WeightedRandomSampler
-
-                # length of probabilties for sampler have to be equal to the length of the index
-                probabilities = np.sqrt(1 + data.loc[dataset.index, "target"])
-                sampler = WeightedRandomSampler(probabilities, len(probabilities))
-                dataset.to_dataloader(train=True, sampler=sampler, shuffle=False)
+            # length of probabilties for sampler have to be equal to the length of index
+            probabilities = np.sqrt(1 + data.loc[dataset.index, "target"])
+            sampler = WeightedRandomSampler(probabilities, len(probabilities))
+            dataset.to_dataloader(train=True, sampler=sampler, shuffle=False)
         """
         default_kwargs = dict(
             shuffle=train,
@@ -2229,7 +2613,8 @@ class TimeSeriesDataSet(Dataset):
                     )
                 else:
                     raise ValueError(
-                        f"batch_sampler {sampler} unknown - see docstring for valid batch_sampler"
+                        f"batch_sampler {sampler} unknown - "
+                        "see docstring for valid batch_sampler"
                     )
             del kwargs["batch_size"]
             del kwargs["shuffle"]
@@ -2263,3 +2648,23 @@ class TimeSeriesDataSet(Dataset):
             attributes=self.get_parameters(),
             extra_attributes=dict(length=len(self)),
         )
+
+
+def _coerce_to_list(obj):
+    """Coerce object to list.
+
+    None is coerced to empty list, otherwise list constructor is used.
+    """
+    if obj is None:
+        return []
+    return list(obj)
+
+
+def _coerce_to_dict(obj):
+    """Coerce object to dict.
+
+    None is coerce to empty dict, otherwise deepcopy is used.
+    """
+    if obj is None:
+        return {}
+    return deepcopy(obj)

--- a/pytorch_forecasting/metrics/_mqf2_utils.py
+++ b/pytorch_forecasting/metrics/_mqf2_utils.py
@@ -432,7 +432,7 @@ class MQF2Distribution(Distribution):
             layout=self.hidden_state.layout,
         ).clamp(
             min=1e-4, max=1 - 1e-4
-        )  # prevent numerical issues by preventing to sample beyond 0.1% and 99.9% percentiles
+        )  # prevent numerical issues by preventing to sample beyond 0.1% and 99.9% percentiles # noqa: E501
 
         samples = (
             self.quantile(alpha, hidden_state_repeat)

--- a/pytorch_forecasting/metrics/base_metrics.py
+++ b/pytorch_forecasting/metrics/base_metrics.py
@@ -22,7 +22,7 @@ class Metric(LightningMetric):
     for details of how to implement a new metric
 
     Other metrics should inherit from this base class
-    """
+    """  # noqa: E501
 
     full_state_update = False
     higher_is_better = False
@@ -42,7 +42,7 @@ class Metric(LightningMetric):
             name (str): metric name. Defaults to class name.
             quantiles (List[float], optional): quantiles for probability range. Defaults to None.
             reduction (str, optional): Reduction, "none", "mean" or "sqrt-mean". Defaults to "mean".
-        """
+        """  # noqa: E501
         self.quantiles = quantiles
         self.reduction = reduction
         if name is None:
@@ -84,7 +84,7 @@ class Metric(LightningMetric):
 
         Returns:
             torch.Tensor: parameters in real/not normalized space
-        """
+        """  # noqa: E501
         return encoder(dict(prediction=parameters, target_scale=target_scale))
 
     def to_prediction(self, y_pred: torch.Tensor) -> torch.Tensor:
@@ -120,7 +120,7 @@ class Metric(LightningMetric):
 
         Returns:
             torch.Tensor: prediction quantiles
-        """
+        """  # noqa: E501
         if quantiles is None:
             quantiles = self.quantiles
 
@@ -166,14 +166,14 @@ class TorchMetricWrapper(Metric):
     Wrap a torchmetric to work with PyTorch Forecasting.
 
     Does not support weighting of errors and only supports metrics for point predictions.
-    """
+    """  # noqa: E501
 
     def __init__(self, torchmetric: LightningMetric, reduction: str = None, **kwargs):
         """
         Args:
             torchmetric (LightningMetric): Torchmetric to wrap.
             reduction (str, optional): use reduction with torchmetric directly. Defaults to None.
-        """
+        """  # noqa: E501
         super().__init__(**kwargs)
         if reduction is not None:
             raise ValueError("use reduction with torchmetric directly")
@@ -231,7 +231,8 @@ class TorchMetricWrapper(Metric):
         self.torchmetric.update(y_pred_flattened, target_flattened, **kwargs)
 
     def forward(self, y_pred, target, **kwargs):
-        # need this explicitly to avoid backpropagation errors because of sketchy caching
+        # need this explicitly to avoid backpropagation
+        # errors because of sketchy caching
         y_pred_flattened, target_flattened = self._convert(y_pred, target)
         return self.torchmetric.forward(y_pred_flattened, target_flattened, **kwargs)
 
@@ -276,7 +277,7 @@ class MultiLoss(LightningMetric):
         Args:
             metrics (List[LightningMetric], optional): list of metrics to combine.
             weights (List[float], optional): list of weights / multipliers for weights. Defaults to 1.0 for all metrics.
-        """
+        """  # noqa: E501
         assert len(metrics) > 0, "at least one metric has to be specified"
         if weights is None:
             weights = [1.0 for _ in metrics]
@@ -477,7 +478,7 @@ class MultiLoss(LightningMetric):
 
         Returns:
             attributes of this class or list of attributes of underlying class
-        """
+        """  # noqa: E501
         try:
             return super().__getattr__(name)
         except AttributeError as e:
@@ -488,7 +489,8 @@ class MultiLoss(LightningMetric):
                     n = len(self.metrics)
 
                     def func(*args, **kwargs):
-                        # if arg/kwarg is list and of length metric, then apply each part to a metric. otherwise
+                        # if arg/kwarg is list and of length metric,
+                        # then apply each part to a metric. otherwise
                         # pass it directly to all metrics
                         results = []
                         for idx, m in enumerate(self.metrics):
@@ -535,7 +537,7 @@ class CompositeMetric(LightningMetric):
         .. code-block:: python
 
             composite_metric = SMAPE() + 0.4 * MAE()
-    """
+    """  # noqa: E501
 
     full_state_update = False
     higher_is_better = False
@@ -550,7 +552,7 @@ class CompositeMetric(LightningMetric):
         Args:
             metrics (List[LightningMetric], optional): list of metrics to combine. Defaults to None.
             weights (List[float], optional): list of weights / multipliers for weights. Defaults to 1.0 for all metrics.
-        """
+        """  # noqa: E501
         self.metrics = metrics
         self.weights = weights
 
@@ -913,7 +915,7 @@ class MultiHorizonMetric(Metric):
 
         Returns:
             torch.Tensor: masked losses
-        """
+        """  # noqa: E501
         if reduction is None:
             reduction = self.reduction
         if losses.ndim > 0:
@@ -946,7 +948,7 @@ class MultiHorizonMetric(Metric):
 
         Returns:
             torch.Tensor: reduced loss
-        """
+        """  # noqa: E501
         if reduction is None:
             reduction = self.reduction
         if reduction == "none":
@@ -962,9 +964,10 @@ class MultiHorizonMetric(Metric):
             "Loss should not be nan - i.e. something went wrong "
             "in calculating the loss (e.g. log of a negative number)"
         )
-        assert torch.isfinite(
-            loss
-        ), "Loss should not be infinite - i.e. something went wrong (e.g. input is not in log space)"
+        assert torch.isfinite(loss), (
+            "Loss should not be infinite - i.e."
+            " something went wrong (e.g. input is not in log space)"
+        )
         return loss
 
 
@@ -983,7 +986,7 @@ class DistributionLoss(MultiHorizonMetric):
         distribution_arguments (List[str]): list of parameter names for the distribution
 
     Further, implement the methods :py:meth:`~map_x_to_distribution` and :py:meth:`~rescale_parameters`.
-    """
+    """  # noqa: E501
 
     distribution_class: distributions.Distribution
     distribution_arguments: List[str]
@@ -1002,7 +1005,7 @@ class DistributionLoss(MultiHorizonMetric):
             quantiles (List[float], optional): quantiles for probability range.
                 Defaults to [0.02, 0.1, 0.25, 0.5, 0.75, 0.9, 0.98].
             reduction (str, optional): Reduction, "none", "mean" or "sqrt-mean". Defaults to "mean".
-        """
+        """  # noqa: E501
         if quantiles is None:
             quantiles = [0.02, 0.1, 0.25, 0.5, 0.75, 0.9, 0.98]
         super().__init__(name=name, quantiles=quantiles, reduction=reduction)
@@ -1017,7 +1020,7 @@ class DistributionLoss(MultiHorizonMetric):
         Returns:
             distributions.Distribution: torch probability distribution as defined in the
                 class attribute ``distribution_class``
-        """
+        """  # noqa: E501
         raise NotImplementedError("implement this method")
 
     def loss(self, y_pred: torch.Tensor, y_actual: torch.Tensor) -> torch.Tensor:
@@ -1061,7 +1064,7 @@ class DistributionLoss(MultiHorizonMetric):
 
         Returns:
             torch.Tensor: tensor with samples  (shape batch_size x n_timesteps x n_samples)
-        """
+        """  # noqa: E501
         dist = self.map_x_to_distribution(y_pred)
         samples = dist.sample((n_samples,))
         if samples.ndim == 3:
@@ -1084,7 +1087,7 @@ class DistributionLoss(MultiHorizonMetric):
 
         Returns:
             torch.Tensor: prediction quantiles (last dimension)
-        """
+        """  # noqa: E501
         if quantiles is None:
             quantiles = self.quantiles
         try:
@@ -1106,7 +1109,7 @@ class MultivariateDistributionLoss(DistributionLoss):
     Class should be inherited for all multivariate distribution losses, i.e. if a batch of values
     is predicted in one go and the batch dimension is not independent, but the time dimension still
     remains independent.
-    """
+    """  # noqa: E501
 
     def sample(self, y_pred, n_samples: int) -> torch.Tensor:
         """
@@ -1118,11 +1121,11 @@ class MultivariateDistributionLoss(DistributionLoss):
 
         Returns:
             torch.Tensor: tensor with samples  (shape batch_size x n_timesteps x n_samples)
-        """
+        """  # noqa: E501
         dist = self.map_x_to_distribution(y_pred)
         samples = dist.sample((n_samples,)).permute(
             2, 1, 0
-        )  # returned as (n_samples, n_timesteps, batch_size), so reshape to (batch_size, n_timesteps, n_samples)
+        )  # returned as (n_samples, n_timesteps, batch_size), so reshape to (batch_size, n_timesteps, n_samples) # noqa: E501
         return samples
 
     def loss(self, y_pred: torch.Tensor, y_actual: torch.Tensor) -> torch.Tensor:

--- a/pytorch_forecasting/metrics/point.py
+++ b/pytorch_forecasting/metrics/point.py
@@ -30,7 +30,7 @@ class PoissonLoss(MultiHorizonMetric):
     Note that in this example, the data is log1p-transformed before normalized but not re-transformed.
     The PoissonLoss applies this "exp"-re-transformation on the network output after it has been de-normalized.
     The result is the model prediction.
-    """
+    """  # noqa: E501
 
     def loss(
         self, y_pred: Dict[str, torch.Tensor], target: torch.Tensor
@@ -145,7 +145,7 @@ class CrossEntropy(MultiHorizonMetric):
 
         Returns:
             torch.Tensor: prediction quantiles
-        """
+        """  # noqa: E501
         return y_pred
 
 
@@ -170,7 +170,7 @@ class MASE(MultiHorizonMetric):
 
     Defined as ``(y_pred - target).abs() / all_targets[:, :-1] - all_targets[:, 1:]).mean(1)``.
     ``all_targets`` are here the concatenated encoder and decoder targets
-    """
+    """  # noqa: E501
 
     def update(
         self,
@@ -191,7 +191,7 @@ class MASE(MultiHorizonMetric):
 
         Returns:
             torch.Tensor: loss as a single number for backpropagation
-        """
+        """  # noqa: E501
         # unpack weight
         if isinstance(target, (list, tuple)):
             weight = target[1]
@@ -306,7 +306,7 @@ class TweedieLoss(MultiHorizonMetric):
     Note that in this example, the data is log1p-transformed before normalized but not re-transformed.
     The TweedieLoss applies this "exp"-re-transformation on the network output after it has been de-normalized.
     The result is the model prediction.
-    """
+    """  # noqa: E501
 
     def __init__(self, reduction="mean", p: float = 1.5, **kwargs):
         """

--- a/pytorch_forecasting/metrics/quantile.py
+++ b/pytorch_forecasting/metrics/quantile.py
@@ -12,7 +12,7 @@ class QuantileLoss(MultiHorizonMetric):
     Quantile loss, i.e. a quantile of ``q=0.5`` will give half of the mean absolute error as it is calculated as
 
     Defined as ``max(q * (y-y_pred), (1-q) * (y_pred-y))``
-    """
+    """  # noqa: E501
 
     def __init__(
         self,

--- a/pytorch_forecasting/models/base_model.py
+++ b/pytorch_forecasting/models/base_model.py
@@ -1,6 +1,6 @@
 """
 Timeseries models share a number of common characteristics. This module implements these in a common base class.
-"""
+"""  # noqa: E501
 
 from collections import namedtuple
 from copy import deepcopy
@@ -119,7 +119,8 @@ def _torch_cat_na(x: List[torch.Tensor]) -> torch.Tensor:
     else:
         # make list instead but warn
         warnings.warn(
-            f"Not all dimensions are equal for tensors shapes. Example tensor {x[0].shape}. "
+            "Not all dimensions are equal for tensors shapes."
+            f" Example tensor {x[0].shape}. "
             "Returning list instead of torch.Tensor.",
             UserWarning,
         )
@@ -146,7 +147,7 @@ def _concatenate_output(
     Returns:
         Dict[str, Union[torch.Tensor, np.ndarray, List[Union[torch.Tensor, int, bool, str]]]]:
             concatenated output
-    """
+    """  # noqa: E501
     output_cat = {}
     for name in output[0].keys():
         v0 = output[0][name]
@@ -208,7 +209,7 @@ class Prediction(PredictTuple, OutputMixIn):
 
 
 class PredictCallback(BasePredictionWriter):
-    """Internally used callback to capture predictions and optionally write them to disk."""
+    """Internally used callback to capture predictions and optionally write them to disk."""  # noqa: E501
 
     # see base class predict function for documentation of parameters
     def __init__(
@@ -265,7 +266,10 @@ class PredictCallback(BasePredictionWriter):
                 out = out[self.mode[1]]
             else:
                 raise ValueError(
-                    f"If a tuple is specified, the first element must be 'raw' - got {self.mode[0]} instead"
+                    (
+                        "If a tuple is specified, the first element must be 'raw' - got"
+                        f" {self.mode[0]} instead"
+                    )
                 )
         elif self.mode == "prediction":
             out = pl_module.to_prediction(out, **self.mode_kwargs)
@@ -461,7 +465,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                     prediction = self.transform_output(prediction=normalized_prediction, target_scale=x["target_scale"])
                     return self.to_network_output(prediction=prediction)
 
-    """
+    """  # noqa: E501
 
     CHECKPOINT_HYPER_PARAMS_SPECIAL_KEY = "__special_save__"
 
@@ -517,7 +521,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                 a `lr` argument (optionally also `weight_decay`). Defaults to
                 `"ranger" <https://pytorch-optimizers.readthedocs.io/en/latest/optimizer_api.html#ranger21>`_,
                 if pytorch_optimizer is installed, otherwise "adam".
-        """
+        """  # noqa: E501
         if monotone_constaints is None:
             monotone_constaints = {}
         super().__init__()
@@ -533,9 +537,10 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                 warnings.warn(
                     "In pytorch-forecasting models, from version 1.2.0, "
                     "the default optimizer will be 'adam', in order to "
-                    "minimize the number of dependencies in default parameter settings. "
-                    "Users who wish to ensure their code continues using 'ranger' as optimizer "
-                    "should ensure that pytorch_optimizer is installed, and set the optimizer "
+                    "minimize the number of dependencies in default"
+                    " parameter settings. Users who wish to ensure their"
+                    " code continues using 'ranger' as optimizer should ensure"
+                    " that pytorch_optimizer is installed, and set the optimizer "
                     "parameter explicitly to 'ranger'.",
                     stacklevel=2,
                 )
@@ -548,9 +553,10 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                     "otherwise it defaults to 'ranger' from pytorch_optimizer. "
                     "From version 1.2.0, the default optimizer will be 'adam' "
                     "regardless of whether pytorch_optimizer is installed, in order to "
-                    "minimize the number of dependencies in default parameter settings. "
-                    "Users who wish to ensure their code continues using 'ranger' as optimizer "
-                    "should ensure that pytorch_optimizer is installed, and set the optimizer "
+                    "minimize the number of dependencies in default parameter"
+                    " settings. Users who wish to ensure their code continues"
+                    " using 'ranger' as optimizer should ensure that pytorch_optimizer"
+                    " is installed, and set the optimizer "
                     "parameter explicitly to 'ranger'.",
                     stacklevel=2,
                 )
@@ -629,7 +635,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         """
         Available inside lightning loops.
         :return: current trainer stage. One of ["train", "val", "test", "predict", "sanity_check"]
-        """
+        """  # noqa: E501
         return STAGE_STATES.get(self.trainer.state.stage, None)
 
     @property
@@ -663,14 +669,14 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
         Returns:
             torch.Tensor: rescaled prediction
-        """
+        """  # noqa: E501
         if loss is None:
             loss = self.loss
         if isinstance(loss, MultiLoss):
             out = loss.rescale_parameters(
                 prediction,
                 target_scale=target_scale,
-                encoder=self.output_transformer.normalizers,  # need to use normalizer per encoder
+                encoder=self.output_transformer.normalizers,  # need to use normalizer per encoder # noqa: E501
             )
         else:
             out = loss.rescale_parameters(
@@ -804,7 +810,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
         Returns:
             Dict[str, Any]: log dictionary to be returned by training and validation steps
-        """
+        """  # noqa: E501
 
         prediction_kwargs = (
             {} if prediction_kwargs is None else deepcopy(prediction_kwargs)
@@ -850,7 +856,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
             Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]: tuple where the first
                 entry is a dictionary to which additional logging results can be added for consumption in the
                 ``on_epoch_end`` hook and the second entry is the model's output.
-        """
+        """  # noqa: E501
         # pack y sequence if different encoder lengths exist
         if (x["decoder_lengths"] < x["decoder_lengths"].max()).any():
             if isinstance(y[0], (list, tuple)):
@@ -918,7 +924,8 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
             # add additionl loss if gradient points in wrong direction
             gradient = gradient[..., indices] * monotonicity[None, None]
             monotinicity_loss = gradient.clamp_max(0).mean()
-            # multiply monotinicity loss by large number to ensure relevance and take to the power of 2
+            # multiply monotinicity loss by large number
+            # to ensure relevance and take to the power of 2
             # for smoothness of loss function
             monotinicity_loss = 10 * torch.pow(monotinicity_loss, 2)
             if not self.predicting:
@@ -977,7 +984,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
             y (torch.Tensor): y as passed to the loss function by the dataloader
             out (Dict[str, torch.Tensor]): output of the network
             prediction_kwargs (Dict[str, Any]): parameters for ``to_prediction()`` of the loss metric.
-        """
+        """  # noqa: E501
         # logging losses - for each target
         if prediction_kwargs is None:
             prediction_kwargs = {}
@@ -1060,7 +1067,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                     # The conversion to a named tuple can be directly achieved with the `to_network_output` function.
                     return self.to_network_output(prediction=prediction)
 
-        """
+        """  # noqa: E501
         raise NotImplementedError()
 
     def on_epoch_end(self, outputs):
@@ -1182,7 +1189,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
         Returns:
             matplotlib figure
-        """
+        """  # noqa: E501
         if quantiles_kwargs is None:
             quantiles_kwargs = {}
         if prediction_kwargs is None:
@@ -1369,7 +1376,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
         Returns:
             Tuple[List]: first entry is list of optimizers and second is list of schedulers
-        """
+        """  # noqa: E501
         ptopt_in_env = "pytorch_optimizer" in _get_installed_packages()
         # either set a schedule of lrs or find it dynamically
         if self.hparams.optimizer_params is None:
@@ -1410,7 +1417,8 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
             if not ptopt_in_env:
                 raise ImportError(
                     "optimizer 'ranger' requires pytorch_optimizer in the evironment. "
-                    "Please install pytorch_optimizer with `pip install pytorch_optimizer`."
+                    "Please install pytorch_optimizer with"
+                    "`pip install pytorch_optimizer`."
                 )
             from pytorch_optimizer import Ranger21
 
@@ -1430,7 +1438,8 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                     ),
                 )
             else:
-                # if finding not limiting train batches, set iterations to dataloader length
+                # if finding not limiting train batches,
+                # set iterations to dataloader length
                 optimizer_params.setdefault(
                     "num_iterations", self.trainer.num_training_batches
                 )
@@ -1476,7 +1485,10 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                     )
             else:
                 raise ValueError(
-                    f"Optimizer of self.hparams.optimizer={self.hparams.optimizer} unknown"
+                    (
+                        f"Optimizer of self.hparams.optimizer={self.hparams.optimizer}"
+                        " unknown"
+                    )
                 )
         else:
             raise ValueError(
@@ -1527,7 +1539,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
         Returns:
             BaseModel: Model that can be trained
-        """
+        """  # noqa: E501
         if "output_transformer" not in kwargs:
             kwargs["output_transformer"] = dataset.target_normalizer
         if "dataset_parameters" not in kwargs:
@@ -1691,7 +1703,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         Returns:
             Prediction: if one of the ```return`` arguments is present,
                 prediction tuple with fields ``prediction``, ``x``, ``y``, ``index`` and ``decoder_lengths``
-        """
+        """  # noqa: E501
         # convert to dataloader
         if isinstance(data, pd.DataFrame):
             data = TimeSeriesDataSet.from_parameters(
@@ -1731,9 +1743,10 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         )
         trainer_kwargs.setdefault("enable_progress_bar", False)
         trainer_kwargs.setdefault("inference_mode", False)
-        assert (
-            "fast_dev_run" not in trainer_kwargs
-        ), "fast_dev_run should be passed as argument to predict and not in trainer_kwargs"
+        assert "fast_dev_run" not in trainer_kwargs, (
+            "fast_dev_run should be passed as"
+            " argument to predict and not in trainer_kwargs"
+        )
         log_level_lighting = logging.getLogger("lightning").getEffectiveLevel()
         log_level_pytorch_lightning = logging.getLogger(
             "pytorch_lightning"
@@ -1781,7 +1794,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
         Returns:
             Union[np.ndarray, torch.Tensor, pd.Series, pd.DataFrame]: output
-        """
+        """  # noqa: E501
         values = np.asarray(values)
         if isinstance(data, pd.DataFrame):  # convert to dataframe
             data = TimeSeriesDataSet.from_parameters(
@@ -1884,7 +1897,7 @@ class BaseModelWithCovariates(BaseModel):
         categorical_groups (Dict[str, List[str]]): dictionary of categorical variables that are grouped together and
             can also take multiple values simultaneously (e.g. holiday during octoberfest). They should be implemented
             as bag of embeddings
-    """
+    """  # noqa: E501
 
     @property
     def target_positions(self) -> torch.LongTensor:
@@ -1973,7 +1986,7 @@ class BaseModelWithCovariates(BaseModel):
 
         Returns:
             LightningModule
-        """
+        """  # noqa: E501
         # assert fixed encoder and decoder length for the moment
         if allowed_encoder_known_variable_names is None:
             allowed_encoder_known_variable_names = (
@@ -2039,7 +2052,7 @@ class BaseModelWithCovariates(BaseModel):
 
         Returns:
             torch.Tensor: tensor with selected variables
-        """
+        """  # noqa: E501
         # select period
         if period == "encoder":
             x_cat = x["encoder_cat"]
@@ -2091,7 +2104,7 @@ class BaseModelWithCovariates(BaseModel):
 
         Returns:
             dictionary that can be used to plot averages with :py:meth:`~plot_prediction_actual_by_variable`
-        """
+        """  # noqa: E501
         support = {}  # histogram
         # averages
         averages_actual = {}
@@ -2218,7 +2231,7 @@ class BaseModelWithCovariates(BaseModel):
 
         Returns:
             Union[Dict[str, plt.Figure], plt.Figure]: matplotlib figure
-        """
+        """  # noqa: E501
         _check_matplotlib("plot_prediction_actual_by_variable")
 
         from matplotlib import pyplot as plt
@@ -2278,7 +2291,8 @@ class BaseModelWithCovariates(BaseModel):
                 else:
                     scaler = self.dataset_parameters["scalers"][name]
                 x = np.linspace(-data["std"], data["std"], bins)
-                # reversing normalization for group normalizer is not possible without sample level information
+                # reversing normalization for group normalizer
+                # is not possible without sample level information
                 if not isinstance(scaler, (GroupNormalizer, EncoderNormalizer)):
                     x = scaler.inverse_transform(x.reshape(-1, 1)).reshape(-1)
                     ax.set_xlabel(f"Normalized {name}")
@@ -2353,7 +2367,7 @@ class AutoRegressiveBaseModel(BaseModel):
             Lags can be useful to indicate seasonality to the models. If you know the seasonalit(ies) of your data,
             add at least the target variables with the corresponding lags to improve performance.
             Defaults to no lags, i.e. an empty dictionary.
-    """
+    """  # noqa: E501
 
     @classmethod
     def from_dataset(
@@ -2370,7 +2384,7 @@ class AutoRegressiveBaseModel(BaseModel):
 
         Returns:
             LightningModule
-        """
+        """  # noqa: E501
         kwargs.setdefault("target", dataset.target)
         # check that lags for targets are the same
         lags = {
@@ -2411,7 +2425,7 @@ class AutoRegressiveBaseModel(BaseModel):
         Returns:
             Tuple[Union[List[torch.Tensor], torch.Tensor], torch.Tensor]: tuple of rescaled prediction and
                 normalized prediction (e.g. for input into next auto-regressive step)
-        """
+        """  # noqa: E501
         single_prediction = to_list(normalized_prediction_parameters)[0].ndim == 2
         if single_prediction:  # add time dimension as it is expected
             normalized_prediction_parameters = apply_to_list(
@@ -2574,7 +2588,7 @@ class AutoRegressiveBaseModel(BaseModel):
                         # predictions are already rescaled
                         return output
 
-        """
+        """  # noqa: E501
         # make predictions which are fed into next step
         output = []
         current_target = first_target
@@ -2597,7 +2611,8 @@ class AutoRegressiveBaseModel(BaseModel):
             )
             # save normalized output for lagged targets
             normalized_output.append(current_target)
-            # set output to unnormalized samples, append each target as n_batch_samples x n_random_samples
+            # set output to unnormalized samples, append each target as
+            # n_batch_samples x n_random_samples
 
             output.append(prediction)
         if isinstance(self.hparams.target, str):
@@ -2653,7 +2668,7 @@ class AutoRegressiveBaseModel(BaseModel):
 
         Returns:
             matplotlib figure
-        """
+        """  # noqa: E501
 
         prediction_kwargs = (
             {} if prediction_kwargs is None else deepcopy(prediction_kwargs)
@@ -2685,10 +2700,11 @@ class AutoRegressiveBaseModel(BaseModel):
 
         Returns:
             Dict[int, torch.LongTensor]: dictionary mapping integer lags to tensor of variable positions.
-        """
+        """  # noqa: E501
         raise Exception(
             "lagged targets can only be used with class inheriting "
-            "from AutoRegressiveBaseModelWithCovariates but not from AutoRegressiveBaseModel"
+            "from AutoRegressiveBaseModelWithCovariates but not"
+            " from AutoRegressiveBaseModel"
         )
 
 
@@ -2723,7 +2739,7 @@ class AutoRegressiveBaseModelWithCovariates(
         categorical_groups (Dict[str, List[str]]): dictionary of categorical variables that are grouped together and
             can also take multiple values simultaneously (e.g. holiday during octoberfest). They should be implemented
             as bag of embeddings
-    """
+    """  # noqa: E501
 
     @property
     def lagged_target_positions(self) -> Dict[int, torch.LongTensor]:
@@ -2732,7 +2748,7 @@ class AutoRegressiveBaseModelWithCovariates(
 
         Returns:
             Dict[int, torch.LongTensor]: dictionary mapping integer lags to tensor of variable positions.
-        """
+        """  # noqa: E501
         # todo: expand for categorical targets
         if len(self.hparams.target_lags) == 0:
             return {}

--- a/pytorch_forecasting/models/deepar/_deepar.py
+++ b/pytorch_forecasting/models/deepar/_deepar.py
@@ -2,7 +2,7 @@
 `DeepAR: Probabilistic forecasting with autoregressive recurrent networks
 <https://www.sciencedirect.com/science/article/pii/S0169207019301888>`_
 which is the one of the most popular forecasting algorithms and is often used as a baseline
-"""
+"""  # noqa: E501
 
 from copy import deepcopy
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
@@ -108,7 +108,7 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
                 Defaults to :py:class:`~pytorch_forecasting.metrics.NormalDistributionLoss`.
             logging_metrics (nn.ModuleList, optional): Metrics to log during training.
                 Defaults to nn.ModuleList([SMAPE(), MAE(), RMSE(), MAPE(), MASE()]).
-        """
+        """  # noqa: E501
         if loss is None:
             loss = NormalDistributionLoss()
         if logging_metrics is None:
@@ -158,9 +158,10 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
         lagged_target_names = [l for lags in target_lags.values() for l in lags]
         assert set(self.encoder_variables) - set(to_list(target)) - set(
             lagged_target_names
-        ) == set(self.decoder_variables) - set(
-            lagged_target_names
-        ), "Encoder and decoder variables have to be the same apart from target variable"
+        ) == set(self.decoder_variables) - set(lagged_target_names), (
+            "Encoder and decoder variables have to be"
+            " the same apart from target variable"
+        )
         for targeti in to_list(target):
             assert (
                 targeti in time_varying_reals_encoder
@@ -213,7 +214,7 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
 
         Returns:
             DeepAR network
-        """
+        """  # noqa: E501
         new_kwargs = {}
         if dataset.multi_target:
             new_kwargs.setdefault(
@@ -227,7 +228,7 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
                 not isinstance(normalizer, NaNLabelEncoder)
                 for normalizer in dataset.target_normalizer
             )
-        ), "target(s) should be continuous - categorical targets are not supported"  # todo: remove this restriction
+        ), "target(s) should be continuous - categorical targets are not supported"  # todo: remove this restriction # noqa: E501
         if isinstance(new_kwargs.get("loss", None), MultivariateDistributionLoss):
             assert (
                 dataset.min_prediction_length == dataset.max_prediction_length
@@ -248,7 +249,8 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
         Create input vector into RNN network
 
         Args:
-            one_off_target: tensor to insert into first position of target. If None (default), remove first time step.
+            one_off_target: tensor to insert into first position of target.
+                If None (default), remove first time step.
         """
         # create input vector
         if len(self.categoricals) > 0:
@@ -361,7 +363,8 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
                 n_samples=n_samples,
             )
             # reshape predictions for n_samples:
-            # from n_samples * batch_size x time steps to batch_size x time steps x n_samples
+            # from n_samples * batch_size x time steps
+            # to batch_size x time steps x n_samples
             output = apply_to_list(
                 output,
                 lambda x: x.reshape(-1, n_samples, input_vector.size(1)).permute(
@@ -462,7 +465,7 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
         Returns:
             Prediction: if one of the ```return`` arguments is present,
                 prediction tuple with fields ``prediction``, ``x``, ``y``, ``index`` and ``decoder_lengths``
-        """
+        """  # noqa: E501
         if isinstance(mode, str):
             if mode in ["prediction", "quantiles"]:
                 if mode_kwargs is None:

--- a/pytorch_forecasting/models/mlp/_decodermlp.py
+++ b/pytorch_forecasting/models/mlp/_decodermlp.py
@@ -85,7 +85,7 @@ class DecoderMLP(BaseModelWithCovariates):
                 Defaults to QuantileLoss.
             logging_metrics (nn.ModuleList, optional): Metrics to log during training.
                 Defaults to nn.ModuleList([SMAPE(), MAE(), RMSE(), MAPE(), MASE()]).
-        """
+        """  # noqa: E501
         if loss is None:
             loss = QuantileLoss()
         if logging_metrics is None:

--- a/pytorch_forecasting/models/nbeats/_nbeats.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats.py
@@ -90,7 +90,7 @@ class NBeats(BaseModel):
             logging_metrics (nn.ModuleList[MultiHorizonMetric]): list of metrics that are logged during training.
                 Defaults to nn.ModuleList([SMAPE(), MAE(), RMSE(), MAPE(), MASE()])
             **kwargs: additional arguments to :py:class:`~BaseModel`.
-        """
+        """  # noqa: E501
         if expansion_coefficient_lengths is None:
             expansion_coefficient_lengths = [3, 7]
         if sharing is None:
@@ -198,7 +198,7 @@ class NBeats(BaseModel):
             # update backcast and forecast
             backcast = (
                 backcast - backcast_block
-            )  # do not use backcast -= backcast_block as this signifies an inline operation
+            )  # do not use backcast -= backcast_block as this signifies an inline operation # noqa : E501
             forecast = forecast + forecast_block
 
         return self.to_network_output(
@@ -231,7 +231,7 @@ class NBeats(BaseModel):
 
         Returns:
             NBeats
-        """
+        """  # noqa: E501
         new_kwargs = {
             "prediction_length": dataset.max_prediction_length,
             "context_length": dataset.max_encoder_length,
@@ -245,13 +245,15 @@ class NBeats(BaseModel):
         assert not isinstance(
             dataset.target_normalizer, NaNLabelEncoder
         ), "only regression tasks are supported - target must not be categorical"
-        assert (
-            dataset.min_encoder_length == dataset.max_encoder_length
-        ), "only fixed encoder length is allowed, but min_encoder_length != max_encoder_length"
+        assert dataset.min_encoder_length == dataset.max_encoder_length, (
+            "only fixed encoder length is allowed,"
+            " but min_encoder_length != max_encoder_length"
+        )
 
-        assert (
-            dataset.max_prediction_length == dataset.min_prediction_length
-        ), "only fixed prediction length is allowed, but max_prediction_length != min_prediction_length"
+        assert dataset.max_prediction_length == dataset.min_prediction_length, (
+            "only fixed prediction length is allowed,"
+            " but max_prediction_length != min_prediction_length"
+        )
 
         assert (
             dataset.randomize_length is None
@@ -265,7 +267,10 @@ class NBeats(BaseModel):
             and len(dataset.reals) == 1
             and len(dataset._time_varying_unknown_reals) == 1
             and dataset._time_varying_unknown_reals[0] == dataset.target
-        ), "The only variable as input should be the target which is part of time_varying_unknown_reals"
+        ), (
+            "The only variable as input should be the"
+            " target which is part of time_varying_unknown_reals"
+        )
 
         # initialize class
         return super().from_dataset(dataset, **new_kwargs)
@@ -361,7 +366,7 @@ class NBeats(BaseModel):
 
         Returns:
             plt.Figure: matplotlib figure
-        """
+        """  # noqa: E501
         _check_matplotlib("plot_interpretation")
 
         import matplotlib.pyplot as plt

--- a/pytorch_forecasting/models/nbeats/sub_modules.py
+++ b/pytorch_forecasting/models/nbeats/sub_modules.py
@@ -111,33 +111,21 @@ class NBEATSSeasonalBlock(NBEATSBlock):
             else (thetas_dim // 2, thetas_dim // 2 + 1)
         )
         s1_b = torch.tensor(
-            [
-                np.cos(2 * np.pi * i * backcast_linspace)
-                for i in self.get_frequencies(p1)
-            ],
+            np.cos(2 * np.pi * self.get_frequencies(p1)[:, None] * backcast_linspace),
             dtype=torch.float32,
         )  # H/2-1
         s2_b = torch.tensor(
-            [
-                np.sin(2 * np.pi * i * backcast_linspace)
-                for i in self.get_frequencies(p2)
-            ],
+            np.sin(2 * np.pi * self.get_frequencies(p2)[:, None] * backcast_linspace),
             dtype=torch.float32,
         )
         self.register_buffer("S_backcast", torch.cat([s1_b, s2_b]))
 
         s1_f = torch.tensor(
-            [
-                np.cos(2 * np.pi * i * forecast_linspace)
-                for i in self.get_frequencies(p1)
-            ],
+            np.cos(2 * np.pi * self.get_frequencies(p1)[:, None] * forecast_linspace),
             dtype=torch.float32,
         )  # H/2-1
         s2_f = torch.tensor(
-            [
-                np.sin(2 * np.pi * i * forecast_linspace)
-                for i in self.get_frequencies(p2)
-            ],
+            np.sin(2 * np.pi * self.get_frequencies(p2)[:, None] * forecast_linspace),
             dtype=torch.float32,
         )
         self.register_buffer("S_forecast", torch.cat([s1_f, s2_f]))
@@ -183,14 +171,15 @@ class NBEATSTrendBlock(NBEATSBlock):
         norm = np.sqrt(
             forecast_length / thetas_dim
         )  # ensure range of predictions is comparable to input
-
+        thetas_dims_range = np.array(range(thetas_dim))
         coefficients = torch.tensor(
-            [backcast_linspace**i for i in range(thetas_dim)], dtype=torch.float32
+            backcast_linspace ** thetas_dims_range[:, None],
+            dtype=torch.float32,
         )
         self.register_buffer("T_backcast", coefficients * norm)
-
         coefficients = torch.tensor(
-            [forecast_linspace**i for i in range(thetas_dim)], dtype=torch.float32
+            forecast_linspace ** thetas_dims_range[:, None],
+            dtype=torch.float32,
         )
         self.register_buffer("T_forecast", coefficients * norm)
 

--- a/pytorch_forecasting/models/nhits/_nhits.py
+++ b/pytorch_forecasting/models/nhits/_nhits.py
@@ -148,7 +148,7 @@ class NHiTS(BaseModelWithCovariates):
             logging_metrics (nn.ModuleList[MultiHorizonMetric]): list of metrics that are logged during training.
                 Defaults to nn.ModuleList([SMAPE(), MAE(), RMSE(), MAPE(), MASE()])
             **kwargs: additional arguments to :py:class:`~BaseModel`.
-        """
+        """  # noqa: E501
         if static_categoricals is None:
             static_categoricals = []
         if static_reals is None:
@@ -389,8 +389,8 @@ class NHiTS(BaseModelWithCovariates):
             backcast=self.transform_output(
                 backcast, target_scale=x["target_scale"], loss=MultiHorizonMetric()
             ),  # (n_outputs x) n_samples x n_timesteps x 1
-            block_backcasts=block_backcasts,  # n_blocks x (n_outputs x) n_samples x n_timesteps x 1
-            block_forecasts=block_forecasts,  # n_blocks x (n_outputs x) n_samples x n_timesteps x output_size
+            block_backcasts=block_backcasts,  # n_blocks x (n_outputs x) n_samples x n_timesteps x 1 # noqa: E501
+            block_forecasts=block_forecasts,  # n_blocks x (n_outputs x) n_samples x n_timesteps x output_size # noqa: E501
         )
 
     @classmethod
@@ -404,18 +404,20 @@ class NHiTS(BaseModelWithCovariates):
 
         Returns:
             NBeats
-        """
+        """  # noqa: E501
         # validate arguments
         assert not isinstance(
             dataset.target_normalizer, NaNLabelEncoder
         ), "only regression tasks are supported - target must not be categorical"
-        assert (
-            dataset.min_encoder_length == dataset.max_encoder_length
-        ), "only fixed encoder length is allowed, but min_encoder_length != max_encoder_length"
+        assert dataset.min_encoder_length == dataset.max_encoder_length, (
+            "only fixed encoder length is allowed,"
+            " but min_encoder_length != max_encoder_length"
+        )
 
-        assert (
-            dataset.max_prediction_length == dataset.min_prediction_length
-        ), "only fixed prediction length is allowed, but max_prediction_length != min_prediction_length"
+        assert dataset.max_prediction_length == dataset.min_prediction_length, (
+            "only fixed prediction length is allowed,"
+            " but max_prediction_length != min_prediction_length"
+        )
 
         assert (
             dataset.randomize_length is None
@@ -436,9 +438,10 @@ class NHiTS(BaseModelWithCovariates):
         assert (new_kwargs.get("backcast_loss_ratio", 0) == 0) | (
             isinstance(new_kwargs["output_size"], int)
             and new_kwargs["output_size"] == 1
-        ) or all(
-            o == 1 for o in new_kwargs["output_size"]
-        ), "output sizes can only be of size 1, i.e. point forecasts if backcast_loss_ratio > 0"
+        ) or all(o == 1 for o in new_kwargs["output_size"]), (
+            "output sizes can only be of size 1, i.e."
+            " point forecasts if backcast_loss_ratio > 0"
+        )
 
         # initialize class
         return super().from_dataset(dataset, **new_kwargs)
@@ -517,7 +520,7 @@ class NHiTS(BaseModelWithCovariates):
 
         Returns:
             plt.Figure: matplotlib figure
-        """
+        """  # noqa: E501
         _check_matplotlib("plot_interpretation")
 
         from matplotlib import pyplot as plt

--- a/pytorch_forecasting/models/nhits/sub_modules.py
+++ b/pytorch_forecasting/models/nhits/sub_modules.py
@@ -85,7 +85,7 @@ def init_weights(module, initialization):
         elif initialization == "glorot_normal":
             torch.nn.init.xavier_normal_(module.weight)
         elif initialization == "lecun_normal":
-            pass  # torch.nn.init.normal_(module.weight, 0.0, std=1/np.sqrt(module.weight.numel()))
+            pass  # torch.nn.init.normal_(module.weight, 0.0, std=1/np.sqrt(module.weight.numel())) # noqa: E501
         else:
             assert 1 < 0, f"Initialization {initialization} not found"
 
@@ -188,7 +188,8 @@ class NHiTSBlock(nn.Module):
         ]
         layers = hidden_layers + output_layer
 
-        # static_size is computed with data, static_hidden_size is provided by user, if 0 no statics are used
+        # static_size is computed with data, static_hidden_size is provided by user,
+        # if 0 no statics are used
         if (self.static_size > 0) and (self.static_hidden_size > 0):
             self.static_encoder = StaticFeaturesEncoder(
                 in_features=static_size, out_features=static_hidden_size
@@ -387,7 +388,7 @@ class NHiTS(nn.Module):
         decoder_x_t,
         x_s,
     ):
-        residuals = encoder_y  # .flip(dims=(1,))  # todo: check if flip is required or should be rather replaced by scatter
+        residuals = encoder_y  # .flip(dims=(1,))  # todo: check if flip is required or should be rather replaced by scatter # noqa: E501
         # encoder_x_t = encoder_x_t.flip(dims=(-1,))
         # encoder_mask = encoder_mask.flip(dims=(-1,))
         encoder_mask = encoder_mask.unsqueeze(-1)

--- a/pytorch_forecasting/models/nn/embeddings.py
+++ b/pytorch_forecasting/models/nn/embeddings.py
@@ -75,7 +75,7 @@ class MultiEmbedding(nn.Module):
                 embedding vector. Defaults to empty list.
             max_embedding_size (int, optional): if embedding size defined by ``embedding_sizes`` is larger than
                 ``max_embedding_size``, it will be constrained. Defaults to None.
-        """
+        """  # noqa: E501
         if categorical_groups is None:
             categorical_groups = {}
         if embedding_paddings is None:
@@ -94,7 +94,10 @@ class MultiEmbedding(nn.Module):
                 ), "categorical_groups must be in embedding_sizes."
                 assert not any(
                     name in embedding_sizes for name in categorical_group_variables
-                ), "group variables in categorical_groups must not be in embedding_sizes."
+                ), (
+                    "group variables in categorical_groups"
+                    " must not be in embedding_sizes."
+                )
                 assert all(
                     name in x_categoricals for name in categorical_group_variables
                 ), "group variables in categorical_groups must be in x_categoricals."
@@ -103,13 +106,13 @@ class MultiEmbedding(nn.Module):
                 for name in embedding_sizes
                 if name not in categorical_group_variables
             ), (
-                "all variables in embedding_sizes must be in x_categoricals - but only if"
-                "not already in categorical_groups."
+                "all variables in embedding_sizes must be in x_categoricals - "
+                "but only if not already in categorical_groups."
             )
         else:
             assert (
                 x_categoricals is None and len(categorical_groups) == 0
-            ), "If embedding_sizes is not a dictionary, categorical_groups and x_categoricals must be empty."
+            ), "If embedding_sizes is not a dictionary, categorical_groups and x_categoricals must be empty."  # noqa: E501
             # number embeddings based on order
             embedding_sizes = {
                 str(name): size for name, size in enumerate(embedding_sizes)
@@ -193,7 +196,7 @@ class MultiEmbedding(nn.Module):
                 of shape batch x (optional) time x embedding_size if ``embedding_size`` is given as dictionary.
                 Otherwise, returns the embedding of shape batch x (optional) time x sum(embedding_sizes).
                 Query attribute ``output_size`` to get the size of the output(s).
-        """
+        """  # noqa: E501
         input_vectors = {}
         for name, emb in self.embeddings.items():
             if name in self.categorical_groups:

--- a/pytorch_forecasting/models/nn/rnn.py
+++ b/pytorch_forecasting/models/nn/rnn.py
@@ -36,7 +36,7 @@ class RNN(ABC, nn.RNNBase):
 
         Returns:
             HiddenState: hidden state with propagated initial hidden state where appropriate
-        """
+        """  # noqa: E501
         pass
 
     @abstractmethod
@@ -92,7 +92,7 @@ class RNN(ABC, nn.RNNBase):
         Returns:
             Tuple[Union[rnn.PackedSequence, torch.Tensor], HiddenState]: output and hidden state.
                 Output is packed sequence if input has been a packed sequence.
-        """
+        """  # noqa: E501
         if isinstance(x, rnn.PackedSequence) or lengths is None:
             assert (
                 lengths is None
@@ -133,7 +133,8 @@ class RNN(ABC, nn.RNNBase):
                     ),
                     hx=hx,
                 )
-                # replace hidden cell with initial input if encoder_length is zero to determine correct initial state
+                # replace hidden cell with initial input if encoder_length
+                # is zero to determine correct initial state
                 if min_length == 0:
                     no_encoding = (lengths == 0)[
                         None, :, None

--- a/pytorch_forecasting/models/rnn/_rnn.py
+++ b/pytorch_forecasting/models/rnn/_rnn.py
@@ -89,7 +89,7 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
             loss (MultiHorizonMetric, optional): loss: loss function taking prediction and targets.
             logging_metrics (nn.ModuleList, optional): Metrics to log during training.
                 Defaults to nn.ModuleList([SMAPE(), MAE(), RMSE(), MAPE(), MASE()]).
-        """
+        """  # noqa : E501
         if static_categoricals is None:
             static_categoricals = []
         if static_reals is None:
@@ -134,9 +134,10 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
         lagged_target_names = [l for lags in target_lags.values() for l in lags]
         assert set(self.encoder_variables) - set(to_list(target)) - set(
             lagged_target_names
-        ) == set(self.decoder_variables) - set(
-            lagged_target_names
-        ), "Encoder and decoder variables have to be the same apart from target variable"
+        ) == set(self.decoder_variables) - set(lagged_target_names), (
+            "Encoder and decoder variables have to"
+            " be the same apart from target variable"
+        )
         for targeti in to_list(target):
             assert (
                 targeti in time_varying_reals_encoder
@@ -196,7 +197,7 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
 
         Returns:
             Recurrent network
-        """
+        """  # noqa: E501
         new_kwargs = copy(kwargs)
         new_kwargs.update(
             cls.deduce_default_output_parameters(
@@ -209,7 +210,7 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
                 not isinstance(normalizer, NaNLabelEncoder)
                 for normalizer in dataset.target_normalizer
             )
-        ), "target(s) should be continuous - categorical targets are not supported"  # todo: remove this restriction
+        ), "target(s) should be continuous - categorical targets are not supported"  # todo: remove this restriction # noqa: E501
         return super().from_dataset(
             dataset,
             allowed_encoder_known_variable_names=allowed_encoder_known_variable_names,
@@ -227,7 +228,7 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
 
         Args:
             one_off_target: tensor to insert into first position of target. If None (default), remove first time step.
-        """
+        """  # noqa : E501
         # create input vector
         if len(self.categoricals) > 0:
             embeddings = self.embeddings(x_cat)

--- a/pytorch_forecasting/models/temporal_fusion_transformer/_tft.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/_tft.py
@@ -1,6 +1,6 @@
 """
 The temporal fusion transformer is a powerful predictive model for forecasting timeseries
-"""
+"""  # noqa: E501
 
 from copy import copy
 from typing import Dict, List, Optional, Tuple, Union
@@ -146,7 +146,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
             logging_metrics (nn.ModuleList[LightningMetric]): list of metrics that are logged during training.
                 Defaults to nn.ModuleList([SMAPE(), MAE(), RMSE(), MAPE()]).
             **kwargs: additional arguments to :py:class:`~BaseModel`.
-        """
+        """  # noqa: E501
         if monotone_constaints is None:
             monotone_constaints = {}
         if embedding_labels is None:
@@ -366,11 +366,13 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
             self.hparams.hidden_size, dropout=self.hparams.dropout
         )
         self.post_lstm_gate_decoder = self.post_lstm_gate_encoder
-        # self.post_lstm_gate_decoder = GatedLinearUnit(self.hparams.hidden_size, dropout=self.hparams.dropout)
+        # self.post_lstm_gate_decoder = GatedLinearUnit(
+        #           self.hparams.hidden_size, dropout=self.hparams.dropout)
         self.post_lstm_add_norm_encoder = AddNorm(
             self.hparams.hidden_size, trainable_add=False
         )
-        # self.post_lstm_add_norm_decoder = AddNorm(self.hparams.hidden_size, trainable_add=True)
+        # self.post_lstm_add_norm_decoder = AddNorm(
+        #                               self.hparams.hidden_size, trainable_add=True)
         self.post_lstm_add_norm_decoder = self.post_lstm_add_norm_encoder
 
         # static enrichment and processing past LSTM
@@ -432,7 +434,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
 
         Returns:
             TemporalFusionTransformer
-        """
+        """  # noqa: E501
         # add maximum encoder length
         # update defaults
         new_kwargs = copy(kwargs)
@@ -473,12 +475,14 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
                 .expand(encoder_lengths.size(0), -1, -1)
             )
         else:
-            # there is value in attending to future forecasts if they are made with knowledge currently
-            #   available
-            #   one possibility is here to use a second attention layer for future attention (assuming different effects
-            #   matter in the future than the past)
-            #   or alternatively using the same layer but allowing forward attention - i.e. only
-            #   masking out non-available data and self
+            # there is value in attending to future forecasts if
+            # they are made with knowledge currently available
+            #   one possibility is here to use a second attention layer
+            # for future attention
+            # (assuming different effects matter in the future than the past)
+            #  or alternatively using the same layer but
+            # allowing forward attention - i.e. only
+            #  masking out non-available data and self
             decoder_mask = (
                 create_mask(decoder_length, decoder_lengths)
                 .unsqueeze(1)
@@ -630,7 +634,8 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
 
         output = self.pos_wise_ff(attn_output)
 
-        # skip connection over temporal fusion decoder (not LSTM decoder despite the LSTM output contains
+        # skip connection over temporal fusion decoder (not LSTM decoder
+        # despite the LSTM output contains
         # a skip from the variable selection network)
         output = self.pre_output_gate_norm(output, lstm_output[:, max_encoder_length:])
         if self.n_targets > 1:  # if to use multi-target architecture
@@ -664,7 +669,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         interpretation = self.interpret_output(
             detach(out),
             reduction="sum",
-            attention_prediction_horizon=0,  # attention only for first prediction horizon
+            attention_prediction_horizon=0,  # attention only for first prediction horizon # noqa: E501
         )
         return interpretation
 
@@ -692,7 +697,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
 
         Returns:
             interpretations that can be plotted with ``plot_interpretation()``
-        """
+        """  # noqa: E501
         # take attention and concatenate if a list to proper attention object
         batch_size = len(out["decoder_attention"])
         if isinstance(out["decoder_attention"], (list, tuple)):
@@ -778,7 +783,8 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
             out["decoder_lengths"], min=1, max=out["decoder_variables"].size(1)
         )
 
-        # mask where decoder and encoder where not applied when averaging variable selection weights
+        # mask where decoder and encoder where not applied
+        # when averaging variable selection weights
         encoder_variables = out["encoder_variables"].squeeze(-2).clone()
         encode_mask = create_mask(encoder_variables.size(1), out["encoder_lengths"])
         encoder_variables = encoder_variables.masked_fill(
@@ -800,7 +806,8 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         # static variables need no masking
         static_variables = out["static_variables"].squeeze(1)
         # attention is batch x time x heads x time_to_attend
-        # average over heads + only keep prediction attention and attention on observed timesteps
+        # average over heads + only keep prediction attention and
+        # attention on observed timesteps
         attention = masked_op(
             attention[
                 :,
@@ -961,7 +968,8 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         """
         # extract interpretations
         interpretation = {
-            # use padded_stack because decoder length histogram can be of different length
+            # use padded_stack because decoder
+            # length histogram can be of different length
             name: padded_stack(
                 [x["interpretation"][name].detach() for x in outputs],
                 side="right",
@@ -969,7 +977,8 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
             ).sum(0)
             for name in outputs[0]["interpretation"].keys()
         }
-        # normalize attention with length histogram squared to account for: 1. zeros in attention and
+        # normalize attention with length histogram squared to account for:
+        # 1. zeros in attention and
         # 2. higher attention due to less values
         attention_occurances = (
             interpretation["encoder_length_histogram"][1:].flip(0).float().cumsum(0)

--- a/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
@@ -285,7 +285,7 @@ class VariableSelectionNetwork(nn.Module):
     ):
         """
         Calculate weights for ``num_inputs`` variables  which are each of size ``input_size``
-        """
+        """  # noqa: E501
         super().__init__()
 
         self.hidden_size = hidden_size

--- a/pytorch_forecasting/models/temporal_fusion_transformer/tuning.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/tuning.py
@@ -86,7 +86,7 @@ def optimize_hyperparameters(
 
     Returns:
         optuna.Study: optuna study results
-    """
+    """  # noqa : E501
     pkgs = _get_installed_packages()
 
     if "optuna" not in pkgs or "statsmodels" not in pkgs:
@@ -125,11 +125,12 @@ def optimize_hyperparameters(
 
     loss = kwargs.get(
         "loss", QuantileLoss()
-    )  # need a deepcopy of loss as it will otherwise propagate from one trial to the next
+    )  # need a deepcopy of loss as it will otherwise propagate from one trial to the next # noqa : E501
 
     # create objective function
     def objective(trial: optuna.Trial) -> float:
-        # Filenames for each trial must be made unique in order to access each checkpoint.
+        # Filenames for each trial must be made unique
+        # in order to access each checkpoint.
         checkpoint_callback = ModelCheckpoint(
             dirpath=os.path.join(model_path, "trial_{}".format(trial.number)),
             filename="{epoch}",

--- a/pytorch_forecasting/models/tide/_tide.py
+++ b/pytorch_forecasting/models/tide/_tide.py
@@ -98,7 +98,7 @@ class TiDEModel(BaseModelWithCovariates):
         **kwargs
             Allows optional arguments to configure pytorch_lightning.Module, pytorch_lightning.Trainer, and
             pytorch-forecasting's :class:BaseModelWithCovariates.
-        """
+        """  # noqa: E501
 
         if static_categoricals is None:
             static_categoricals = []
@@ -127,7 +127,8 @@ class TiDEModel(BaseModelWithCovariates):
         if logging_metrics is None:
             logging_metrics = nn.ModuleList([SMAPE(), MAE(), RMSE(), MAPE(), MASE()])
 
-        # loss and logging_metrics are ignored as they are modules and stored before calling save_hyperparameters
+        # loss and logging_metrics are ignored as they are modules
+        # and stored before calling save_hyperparameters
         self.save_hyperparameters(ignore=["loss", "logging_metrics"])
         super().__init__(logging_metrics=logging_metrics, **kwargs)
         self.output_dim = len(self.target_names)
@@ -207,20 +208,22 @@ class TiDEModel(BaseModelWithCovariates):
 
         Returns:
             TiDE
-        """
+        """  # noqa: E501
 
         # validate arguments
         assert not isinstance(
             dataset.target_normalizer, NaNLabelEncoder
         ), "only regression tasks are supported - target must not be categorical"
 
-        assert (
-            dataset.min_encoder_length == dataset.max_encoder_length
-        ), "only fixed encoder length is allowed, but min_encoder_length != max_encoder_length"
+        assert dataset.min_encoder_length == dataset.max_encoder_length, (
+            "only fixed encoder length is allowed,"
+            " but min_encoder_length != max_encoder_length"
+        )
 
-        assert (
-            dataset.max_prediction_length == dataset.min_prediction_length
-        ), "only fixed prediction length is allowed, but max_prediction_length != min_prediction_length"
+        assert dataset.max_prediction_length == dataset.min_prediction_length, (
+            "only fixed prediction length is allowed,"
+            " but max_prediction_length != min_prediction_length"
+        )
 
         assert (
             dataset.randomize_length is None
@@ -258,7 +261,8 @@ class TiDEModel(BaseModelWithCovariates):
         encoder_features = self.extract_features(x, self.embeddings, period="encoder")
 
         if self.encoder_covariate_size > 0:
-            # encoder_features = self.extract_features(x, self.embeddings, period="encoder")
+            # encoder_features = self.extract_features(
+            #                   x, self.embeddings, period="encoder")
             encoder_x_t = torch.concat(
                 [
                     encoder_features[name]
@@ -295,8 +299,10 @@ class TiDEModel(BaseModelWithCovariates):
         prediction = self.model(x_in)
 
         if self.output_dim > 1:  # for multivariate targets
-            # adjust prefictions dimensions according to format required for consequent processes
-            # from (batch size, seq len, output_dim) to (output_dim, batch size, seq len)
+            # adjust prefictions dimensions according
+            # to format required for consequent processes
+            # from (batch size, seq len, output_dim) to
+            # (output_dim, batch size, seq len)
             prediction = prediction.permute(2, 0, 1)
             prediction = [i.clone().detach().requires_grad_(True) for i in prediction]
 

--- a/pytorch_forecasting/models/tide/sub_modules.py
+++ b/pytorch_forecasting/models/tide/sub_modules.py
@@ -76,7 +76,8 @@ class _TideModule(nn.Module):
         Parameters
         ----------
         input_dim
-            The total number of input features, including the target and optional covariates.
+            The total number of input features, including the target
+            and optional covariates.
         output_dim
             The number of output features in the target.
         future_cov_dim
@@ -96,7 +97,8 @@ class _TideModule(nn.Module):
         temporal_width_future
             The dimensionality of the embedding space for future covariates.
         temporal_hidden_size_future
-            The size of the hidden layers in the Residual Block projecting future covariates.
+            The size of the hidden layers in the Residual Block projecting
+            future covariates.
         use_layer_norm
             Indicates whether to apply layer normalization in the Residual Blocks.
         dropout
@@ -105,13 +107,15 @@ class _TideModule(nn.Module):
         Inputs
         ------
         x
-            A tuple of Tensors (x_past, x_future, x_static) where x_past represents the input/past sequence,
+            A tuple of Tensors (x_past, x_future, x_static)
+            where x_past represents the input/past sequence,
             and x_future represents the output/future sequence. The input dimensions are
             (batch_size, time_steps, components).
         Outputs
         -------
         y
-            A Tensor with dimensions (batch_size, output_chunk_length, output_dim) representing the model's output.
+            A Tensor with dimensions (batch_size, output_chunk_length, output_dim)
+            epresenting the model's output.
         """
         super().__init__()
 
@@ -130,7 +134,8 @@ class _TideModule(nn.Module):
         self.temporal_width_future = temporal_width_future
         self.temporal_hidden_size_future = temporal_hidden_size_future or hidden_size
 
-        # future covariates handling: either feature projection, raw features, or no features
+        # future covariates handling: either feature projection,
+        # raw features, or no features
         self.future_cov_projection = None
         if future_cov_dim > 0 and self.temporal_width_future:
             # residual block for future covariates feature projection
@@ -224,8 +229,10 @@ class _TideModule(nn.Module):
         Parameters
         ----------
         x_in
-            comes as tuple (x_past, x_future, x_static) where x_past is the input/past chunk and x_future
-            is the output/future chunk. Input dimensions are (batch_size, time_steps, components)
+            comes as tuple (x_past, x_future, x_static)
+            where x_past is the input/past chunk and x_future
+            is the output/future chunk. Input dimensions are
+            (batch_size, time_steps, components)
         Returns
         -------
         torch.Tensor
@@ -240,7 +247,8 @@ class _TideModule(nn.Module):
         x_lookback = x[:, :, : self.output_dim]
 
         # future covariates: feature projection or raw features
-        # historical future covariates need to be extracted from x and stacked with part of future covariates
+        # historical future covariates need to be extracted from x and
+        # stacked with part of future covariates
         if self.future_cov_dim > 0:
             x_dynamic_future_covariates = torch.cat(
                 [
@@ -292,8 +300,8 @@ class _TideModule(nn.Module):
         temporal_decoded = self.temporal_decoder(temporal_decoder_input)
 
         # pass x_lookback through self.lookback_skip but swap the last two dimensions
-        # this is needed because the skip connection is applied across the input time steps
-        # and not across the output time steps
+        # this is needed because the skip connection is applied across
+        # the input time steps and not across the output time steps
         skip = self.lookback_skip(x_lookback.transpose(1, 2)).transpose(1, 2)
 
         # add skip connection

--- a/pytorch_forecasting/utils/_dependencies.py
+++ b/pytorch_forecasting/utils/_dependencies.py
@@ -58,7 +58,10 @@ def _check_matplotlib(ref="This feature", raise_error=True):
 
     if raise_error and "matplotlib" not in pkgs:
         raise ImportError(
-            f"{ref} requires matplotlib. Please install matplotlib with `pip install matplotlib`."
+            (
+                f"{ref} requires matplotlib."
+                " Please install matplotlib with `pip install matplotlib`."
+            )
         )
 
     return "matplotlib" in pkgs

--- a/pytorch_forecasting/utils/_utils.py
+++ b/pytorch_forecasting/utils/_utils.py
@@ -59,7 +59,8 @@ def groupby_apply(
         return_histogram: if to return histogram on top
 
     Returns:
-        tensor of size ``bins`` with aggregated values and optionally with counts of values
+        tensor of size ``bins`` with aggregated values
+        and optionally with counts of values
     """
     if reduction == "mean":
         reduce = torch.mean
@@ -94,7 +95,7 @@ def profile(
         profile_fname (str): path where to save profile (`.txt` file will be saved with line profile)
         filter (str, optional): filter name (e.g. module name) to filter profile. Defaults to "".
         period (float, optional): frequency of calling profiler in seconds. Defaults to 0.0001.
-    """
+    """  # noqa : E501
     import vmprof
     from vmprof.show import LinesPrinter
 
@@ -243,7 +244,7 @@ def unpack_sequence(
 
     Returns:
         Tuple[torch.Tensor, torch.Tensor]: tuple of unpacked sequence and length of samples
-    """
+    """  # noqa : E501
     if isinstance(sequence, rnn.PackedSequence):
         sequence, lengths = rnn.pad_packed_sequence(sequence, batch_first=True)
         # batch sizes reside on the CPU by default -> we need to bring them to GPU
@@ -267,7 +268,7 @@ def concat_sequences(
 
     Returns:
         Union[torch.Tensor, rnn.PackedSequence]: concatenated sequence
-    """
+    """  # noqa : E501
     if isinstance(sequences[0], rnn.PackedSequence):
         return rnn.pack_sequence(sequences, enforce_sorted=False)
     elif isinstance(sequences[0], torch.Tensor):
@@ -298,7 +299,7 @@ def padded_stack(
 
     Returns:
         torch.Tensor: stacked tensor
-    """
+    """  # noqa : E501
     full_size = max([x.size(-1) for x in tensors])
 
     def make_padding(pad):
@@ -370,8 +371,8 @@ def apply_to_list(obj: Union[List[Any], Any], func: Callable) -> Union[List[Any]
         func (Callable): function to apply
 
     Returns:
-        Union[List[Any], Any]: list of objects or object depending on function output and
-            if input ``obj`` is of type list/tuple
+        Union[List[Any], Any]: list of objects or object depending on function output
+            and if input ``obj`` is of type list/tuple
     """
     if isinstance(obj, (list, tuple)) and not isinstance(obj, rnn.PackedSequence):
         return [func(o) for o in obj]
@@ -412,7 +413,7 @@ class OutputMixIn:
 
 
 class TupleOutputMixIn:
-    """MixIn to give output a namedtuple-like access capabilities with ``to_network_output() function``."""
+    """MixIn to give output a namedtuple-like access capabilitieswith ``to_network_output() function``."""  # noqa : E501
 
     def to_network_output(self, **results):
         """
@@ -459,7 +460,7 @@ def move_to_device(
 
     Returns:
         x on targeted device
-    """
+    """  # noqa: E501
     if isinstance(device, str):
         if device == "mps":
             if hasattr(torch.backends, device):
@@ -531,7 +532,7 @@ def masked_op(
 
     Returns:
         torch.Tensor: tensor with averaged out dimension
-    """
+    """  # noqa : E501
     if mask is None:
         mask = ~torch.isnan(tensor)
     masked = tensor.masked_fill(~mask, 0.0)
@@ -560,7 +561,7 @@ def repr_class(
 
     Returns:
         str
-    """
+    """  # noqa E501
     if extra_attributes is None:
         extra_attributes = {}
     # get attributes

--- a/tests/test_data/test_encoders.py
+++ b/tests/test_data/test_encoders.py
@@ -176,7 +176,7 @@ def test_TorchNormalizer_dtype_consistency():
     """
     - Ensures that even for float64 `target_scale`, the transformation will not change the prediction dtype.
     - Ensure that target_scale will be of type float32 if method is 'identity'
-    """
+    """  # noqa: E501
     parameters = torch.tensor([[[366.4587]]])
     target_scale = torch.tensor([[427875.7500, 80367.4766]], dtype=torch.float64)
     assert (

--- a/tests/test_data/test_timeseries.py
+++ b/tests/test_data/test_timeseries.py
@@ -248,7 +248,8 @@ def test_from_dataset_equivalence(test_data):
         test_data[lambda x: x.time_idx > x.time_idx.min() + 2],
         predict=True,
     )
-    # ensure validation1 and validation2 datasets are exactly the same despite different data inputs
+    # ensure validation1 and validation2 datasets are exactly
+    # the same despite different data inputs
     for v1, v2 in zip(
         iter(validation1.to_dataloader(train=False)),
         iter(validation2.to_dataloader(train=False)),
@@ -564,7 +565,7 @@ def test_graph_sampler(test_dataset):
                     != indices["sequence_id"].iloc[sub_group_idx]
                 ]
                 # filter duplicate timeseries
-                # indices = indices.sort_values("sequence_length").drop_duplicates("sequence_id", keep="last")
+                # indices = indices.sort_values("sequence_length").drop_duplicates("sequence_id", keep="last") # noqa : E501
 
                 # calculate distances for corresponding groups
                 group_distances = torch.cdist(

--- a/tests/test_models/test_deepar.py
+++ b/tests/test_models/test_deepar.py
@@ -234,4 +234,4 @@ def test_pickle(dataloaders_with_covariates, loss):
         loss=loss,
     )
     pkl = pickle.dumps(model)
-    pickle.loads(pkl)
+    pickle.loads(pkl)  # noqa: S301

--- a/tests/test_models/test_mlp.py
+++ b/tests/test_models/test_mlp.py
@@ -141,4 +141,4 @@ def model(dataloaders_with_covariates):
 
 def test_pickle(model):
     pkl = pickle.dumps(model)
-    pickle.loads(pkl)
+    pickle.loads(pkl)  # noqa: S301

--- a/tests/test_models/test_nbeats.py
+++ b/tests/test_models/test_nbeats.py
@@ -86,7 +86,7 @@ def model(dataloaders_fixed_window_without_covariates):
 
 def test_pickle(model):
     pkl = pickle.dumps(model)
-    pickle.loads(pkl)
+    pickle.loads(pkl)  # noqa: S301
 
 
 @pytest.mark.skipif(

--- a/tests/test_models/test_nhits.py
+++ b/tests/test_models/test_nhits.py
@@ -59,7 +59,8 @@ def _integration(dataloader, tmp_path, trainer_kwargs=None, **kwargs):
             train_dataloaders=train_dataloader,
             val_dataloaders=val_dataloader,
         )
-        # todo: testing somehow disables grad computation even though it is explicitly turned on
+        # todo: testing somehow disables grad computation even though
+        # it is explicitly turned on
         #       loss is calculated as "grad" for MQF2
         if not isinstance(net.loss, MQF2DistributionLoss):
             test_outputs = trainer.test(net, dataloaders=test_dataloader)
@@ -153,7 +154,7 @@ def model(dataloaders_with_covariates):
 
 def test_pickle(model):
     pkl = pickle.dumps(model)
-    pickle.loads(pkl)
+    pickle.loads(pkl)  # noqa : S301
 
 
 @pytest.mark.skipif(

--- a/tests/test_models/test_rnn_model.py
+++ b/tests/test_models/test_rnn_model.py
@@ -145,4 +145,4 @@ def model(dataloaders_with_covariates):
 
 def test_pickle(model):
     pkl = pickle.dumps(model)
-    pickle.loads(pkl)
+    pickle.loads(pkl)  # noqa: S301

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -159,7 +159,7 @@ def _integration(dataloader, tmp_path, loss=None, trainer_kwargs=None, **kwargs)
                         if isinstance(normalizer, NaNLabelEncoder)
                         else QuantileLoss()
                     )
-                    for normalizer in train_dataloader.dataset.target_normalizer.normalizers
+                    for normalizer in train_dataloader.dataset.target_normalizer.normalizers  # noqa : E501
                 ]
             )
         else:
@@ -184,7 +184,8 @@ def _integration(dataloader, tmp_path, loss=None, trainer_kwargs=None, **kwargs)
                 train_dataloaders=train_dataloader,
                 val_dataloaders=val_dataloader,
             )
-            # todo: testing somehow disables grad computation even though it is explicitly turned on -
+            # todo: testing somehow disables grad computation
+            # even though it is explicitly turned on -
             #       loss is calculated as "grad" for MQF2
             if not isinstance(net.loss, MQF2DistributionLoss):
                 test_outputs = trainer.test(net, dataloaders=test_dataloader)
@@ -312,7 +313,7 @@ def test_distribution(dataloaders_with_covariates, tmp_path, strategy):
 
 def test_pickle(model):
     pkl = pickle.dumps(model)
-    pickle.loads(pkl)
+    pickle.loads(pkl)  # noqa: S301
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

This PR fixes the linting errors after the lint rules were updated recently.

Initially added a lot of `noqa` to have a baseline that passes the lint check going to work on removing all `noqa` to the minimal value. This is still a work in progress.

This temporary fix is for allowing PRs to be in mergeable states given that they pass code quality checks.
The exhaustive refactoring is being done in #1749 to ensure the code quality.
