### PR TITLE
[BUG] pytorch-forecasting#1752 Fixing

### DIFF
--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -2513,7 +2513,7 @@ class TimeSeriesDataSet(Dataset):
 
         Parameters
         ----------
-        train : bool, optional, default=Trze
+        train : bool, optional, default=True
             whether dataloader is used for training (True) or prediction (False).
             Will shuffle and drop last batch if True. Defaults to True.
         batch_size : int, optional, default=64

--- a/pytorch_forecasting/models/base/_base_model.py
+++ b/pytorch_forecasting/models/base/_base_model.py
@@ -387,7 +387,7 @@ class PredictCallback(BasePredictionWriter):
             if self.return_decoder_lengths:
                 output["decoder_lengths"] = torch.cat(self._decode_lengths, dim=0)
             if self.return_y:
-                y = concat_sequences([yi[0] for yi in self._y])
+                y = _torch_cat_na([yi[0] for yi in self._y])
                 if self._y[-1][1] is None:
                     weight = None
                 else:


### PR DESCRIPTION
### Description

This PR is towards the issue #1752 . concat_sequences concat the timesteps of each batch. But our goal is to not concat time_stamps but to concat the batches. So while concat, the same function is used, which concat output, to concat y also.

### Checklist

- [x] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

