### PR TITLE
[BUG] pytorch-forecasting#1752 Fixing

### DIFF
--- a/pytorch_forecasting/data/timeseries.py
+++ b/pytorch_forecasting/data/timeseries.py
@@ -2513,7 +2513,7 @@ class TimeSeriesDataSet(Dataset):
 
         Parameters
         ----------
-        train : bool, optional, default=Trze
+        train : bool, optional, default=True
             whether dataloader is used for training (True) or prediction (False).
             Will shuffle and drop last batch if True. Defaults to True.
         batch_size : int, optional, default=64

--- a/pytorch_forecasting/models/base/_base_model.py
+++ b/pytorch_forecasting/models/base/_base_model.py
@@ -387,7 +387,7 @@ class PredictCallback(BasePredictionWriter):
             if self.return_decoder_lengths:
                 output["decoder_lengths"] = torch.cat(self._decode_lengths, dim=0)
             if self.return_y:
-                y = concat_sequences([yi[0] for yi in self._y])
+                y = _torch_cat_na([yi[0] for yi in self._y])
                 if self._y[-1][1] is None:
                     weight = None
                 else:

--- a/pytorch_forecasting/models/base/_base_model.py
+++ b/pytorch_forecasting/models/base/_base_model.py
@@ -387,7 +387,7 @@ class PredictCallback(BasePredictionWriter):
             if self.return_decoder_lengths:
                 output["decoder_lengths"] = torch.cat(self._decode_lengths, dim=0)
             if self.return_y:
-                y = _torch_cat_na([yi[0] for yi in self._y])
+                y = concat_sequences([yi[0] for yi in self._y])
                 if self._y[-1][1] is None:
                     weight = None
                 else:

--- a/pytorch_forecasting/utils/_utils.py
+++ b/pytorch_forecasting/utils/_utils.py
@@ -272,7 +272,33 @@ def concat_sequences(
     if isinstance(sequences[0], rnn.PackedSequence):
         return rnn.pack_sequence(sequences, enforce_sorted=False)
     elif isinstance(sequences[0], torch.Tensor):
-        return torch.cat(sequences, dim=1)
+        if sequences[0].ndim > 1:
+            first_lens = [xi.shape[1] for xi in sequences]
+            max_first_len = max(first_lens)
+            if max_first_len > min(first_lens):
+                sequences = [
+                    (
+                        xi
+                        if xi.shape[1] == max_first_len
+                        else torch.cat(
+                            [
+                                xi,
+                                torch.full(
+                                    (
+                                        xi.shape[0],
+                                        max_first_len - xi.shape[1],
+                                        *xi.shape[2:],
+                                    ),
+                                    float("nan"),
+                                    device=xi.device,
+                                ),
+                            ],
+                            dim=1,
+                        )
+                    )
+                    for xi in sequences
+                ]
+        return torch.cat(sequences, dim=0)
     elif isinstance(sequences[0], (tuple, list)):
         return tuple(
             concat_sequences([sequences[ii][i] for ii in range(len(sequences))])


### PR DESCRIPTION
### Description

This PR is towards the issue #1752 . concat_sequences concat the timesteps of each batch. But our goal is to not concat time_stamps but to concat the batches. 
### Checklist

- [x] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [ ] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

