### PR TITLE
[MNT] move release to trusted publishers

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -72,6 +72,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [pytest-nosoftdeps]
 
+    permissions:
+      id-token: write
+
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -81,5 +84,4 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           packages-dir: wheelhouse/


### PR DESCRIPTION
Moves the release to trusted publishers.

All secrets have been removed from the repo.