### PR TITLE
[ENH] EXPERIMENTAL PR: make the `data_module` dataclass-like

### DIFF
--- a/pytorch_forecasting/data/data_module.py
+++ b/pytorch_forecasting/data/data_module.py
@@ -165,11 +165,11 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
         # overwrite __init__ params for upwards compatibility with AS PRs
         # todo: should we avoid this and ensure classes are dataclass-like?
-        self.min_prediction_length = self._min_prediction_length
-        self.min_encoder_length = self._min_encoder_length
-        self.categorical_encoders = self._categorical_encoders
-        self.scalers = self._scalers
-        self.target_normalizer = self._target_normalizer
+        # self.min_prediction_length = self._min_prediction_length
+        # self.min_encoder_length = self._min_encoder_length
+        # self.categorical_encoders = self._categorical_encoders
+        # self.scalers = self._scalers
+        # self.target_normalizer = self._target_normalizer
 
     def _prepare_metadata(self):
         """Prepare metadata for model initialisation.

--- a/pytorch_forecasting/data/data_module.py
+++ b/pytorch_forecasting/data/data_module.py
@@ -163,14 +163,6 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             else:
                 self.continuous_indices.append(idx)
 
-        # overwrite __init__ params for upwards compatibility with AS PRs
-        # todo: should we avoid this and ensure classes are dataclass-like?
-        # self.min_prediction_length = self._min_prediction_length
-        # self.min_encoder_length = self._min_encoder_length
-        # self.categorical_encoders = self._categorical_encoders
-        # self.scalers = self._scalers
-        # self.target_normalizer = self._target_normalizer
-
     def _prepare_metadata(self):
         """Prepare metadata for model initialisation.
 

--- a/tests/test_data/test_data_module.py
+++ b/tests/test_data/test_data_module.py
@@ -86,8 +86,8 @@ def test_init(sample_timeseries_data):
 
     assert dm.max_encoder_length == 24
     assert dm.max_prediction_length == 12
-    assert dm.min_encoder_length == 24
-    assert dm.min_prediction_length == 12
+    assert dm._min_encoder_length == 24
+    assert dm._min_prediction_length == 12
     assert dm.batch_size == 8
     assert dm.train_val_test_split == (0.7, 0.15, 0.15)
 


### PR DESCRIPTION
This PR makes the `data_modulel` dataclass-like
See discussion in #1829 