### PR TITLE
[MNT] Add 'UP' to extend-select for pyupgrade python syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ target-version = "py39"
 select = ["E", "F", "W", "C4", "S"]
 extend-select = [
   "I", # isort
+  "UP", # pyupgrade
   "C4", # https://pypi.org/project/flake8-comprehensions
 ]
 extend-ignore = [

--- a/pytorch_forecasting/data/data_module.py
+++ b/pytorch_forecasting/data/data_module.py
@@ -7,7 +7,7 @@
 # into the memory.
 #######################################################################################
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 from warnings import warn
 
 from lightning.pytorch import LightningDataModule
@@ -94,16 +94,16 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         add_target_scales: bool = False,
         add_encoder_length: Union[bool, str] = "auto",
         target_normalizer: Union[
-            NORMALIZER, str, List[NORMALIZER], Tuple[NORMALIZER], None
+            NORMALIZER, str, list[NORMALIZER], tuple[NORMALIZER], None
         ] = "auto",
-        categorical_encoders: Optional[Dict[str, NaNLabelEncoder]] = None,
+        categorical_encoders: Optional[dict[str, NaNLabelEncoder]] = None,
         scalers: Optional[
-            Dict[
+            dict[
                 str,
                 Union[StandardScaler, RobustScaler, TorchNormalizer, EncoderNormalizer],
             ]
         ] = None,
-        randomize_length: Union[None, Tuple[float, float], bool] = False,
+        randomize_length: Union[None, tuple[float, float], bool] = False,
         batch_size: int = 32,
         num_workers: int = 0,
         train_val_test_split: tuple = (0.7, 0.15, 0.15),
@@ -292,7 +292,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             self._metadata = self._prepare_metadata()
         return self._metadata
 
-    def _preprocess_data(self, series_idx: torch.Tensor) -> List[Dict[str, Any]]:
+    def _preprocess_data(self, series_idx: torch.Tensor) -> list[dict[str, Any]]:
         """Preprocess the data before feeding it into _ProcessedEncoderDecoderDataset.
 
         Preprocessing steps
@@ -369,7 +369,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             self,
             dataset: TimeSeries,
             data_module: "EncoderDecoderTimeSeriesDataModule",
-            windows: List[Tuple[int, int, int, int]],
+            windows: list[tuple[int, int, int, int]],
             add_relative_time_idx: bool = False,
         ):
             self.dataset = dataset
@@ -552,7 +552,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
             return x, y
 
-    def _create_windows(self, indices: torch.Tensor) -> List[Tuple[int, int, int, int]]:
+    def _create_windows(self, indices: torch.Tensor) -> list[tuple[int, int, int, int]]:
         """Generate sliding windows for training, validation, and testing.
 
         Returns

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -2,8 +2,9 @@
 Encoders for encoding categorical variables and scaling continuous data.
 """
 
+from collections.abc import Iterable
 from copy import deepcopy
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Optional, Union
 import warnings
 
 import numpy as np
@@ -177,8 +178,8 @@ class TransformMixIn:
 
     @classmethod
     def get_transform(
-        cls, transformation: Union[str, Dict[str, Callable]]
-    ) -> Dict[str, Callable]:
+        cls, transformation: Union[str, dict[str, Callable]]
+    ) -> dict[str, Callable]:
         """Return transformation functions.
 
         Parameters
@@ -501,8 +502,8 @@ class TorchNormalizer(
         self,
         method: str = "standard",
         center: bool = True,
-        transformation: Union[str, Tuple[Callable, Callable]] = None,
-        method_kwargs: Optional[Dict[str, Any]] = None,
+        transformation: Union[str, tuple[Callable, Callable]] = None,
+        method_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         Parameters
@@ -682,7 +683,7 @@ class TorchNormalizer(
         return_norm: bool = False,
         target_scale: torch.Tensor = None,
     ) -> Union[
-        Tuple[Union[np.ndarray, torch.Tensor], np.ndarray],
+        tuple[Union[np.ndarray, torch.Tensor], np.ndarray],
         Union[np.ndarray, torch.Tensor],
     ]:
         """
@@ -742,7 +743,7 @@ class TorchNormalizer(
         """
         return self(dict(prediction=y, target_scale=self.get_parameters().unsqueeze(0)))
 
-    def __call__(self, data: Dict[str, torch.Tensor]) -> torch.Tensor:
+    def __call__(self, data: dict[str, torch.Tensor]) -> torch.Tensor:
         """
         Inverse transformation but with network output as input.
 
@@ -792,9 +793,9 @@ class EncoderNormalizer(TorchNormalizer):
         self,
         method: str = "standard",
         center: bool = True,
-        max_length: Union[int, List[int]] = None,
-        transformation: Union[str, Tuple[Callable, Callable]] = None,
-        method_kwargs: Dict[str, Any] = None,
+        max_length: Union[int, list[int]] = None,
+        transformation: Union[str, tuple[Callable, Callable]] = None,
+        method_kwargs: dict[str, Any] = None,
     ):
         """
         Initialize
@@ -922,11 +923,11 @@ class GroupNormalizer(TorchNormalizer):
     def __init__(
         self,
         method: str = "standard",
-        groups: Optional[List[str]] = None,
+        groups: Optional[list[str]] = None,
         center: bool = True,
         scale_by_group: bool = False,
-        transformation: Optional[Union[str, Tuple[Callable, Callable]]] = None,
-        method_kwargs: Optional[Dict[str, Any]] = None,
+        transformation: Optional[Union[str, tuple[Callable, Callable]]] = None,
+        method_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         Group normalizer to normalize a given entry by groups. Can be used as target normalizer.
@@ -1137,7 +1138,7 @@ class GroupNormalizer(TorchNormalizer):
         return self
 
     @property
-    def names(self) -> List[str]:
+    def names(self) -> list[str]:
         """
         Names of determined scales.
 
@@ -1150,7 +1151,7 @@ class GroupNormalizer(TorchNormalizer):
 
     def fit_transform(
         self, y: pd.Series, X: pd.DataFrame, return_norm: bool = False
-    ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+    ) -> Union[np.ndarray, tuple[np.ndarray, np.ndarray]]:
         """
         Fit normalizer and scale input data.
 
@@ -1182,7 +1183,7 @@ class GroupNormalizer(TorchNormalizer):
         X: pd.DataFrame = None,
         return_norm: bool = False,
         target_scale: torch.Tensor = None,
-    ) -> Union[np.ndarray, Tuple[np.ndarray, np.ndarray]]:
+    ) -> Union[np.ndarray, tuple[np.ndarray, np.ndarray]]:
         """
         Scale input data.
 
@@ -1211,7 +1212,7 @@ class GroupNormalizer(TorchNormalizer):
         return super().transform(y, return_norm=return_norm, target_scale=target_scale)
 
     def get_parameters(
-        self, groups: Union[torch.Tensor, list, tuple], group_names: List[str] = None
+        self, groups: Union[torch.Tensor, list, tuple], group_names: list[str] = None
     ) -> np.ndarray:
         """
         Get fitted scaling parameters for a given group.
@@ -1314,7 +1315,7 @@ class MultiNormalizer(TorchNormalizer):
     This normalizers wraps multiple other normalizers.
     """
 
-    def __init__(self, normalizers: List[TorchNormalizer]):
+    def __init__(self, normalizers: list[TorchNormalizer]):
         """
         Parameters
         ----------
@@ -1378,10 +1379,10 @@ class MultiNormalizer(TorchNormalizer):
         y: Union[pd.DataFrame, np.ndarray, torch.Tensor],
         X: pd.DataFrame = None,
         return_norm: bool = False,
-        target_scale: List[torch.Tensor] = None,
+        target_scale: list[torch.Tensor] = None,
     ) -> Union[
-        List[Tuple[Union[np.ndarray, torch.Tensor], np.ndarray]],
-        List[Union[np.ndarray, torch.Tensor]],
+        list[tuple[Union[np.ndarray, torch.Tensor], np.ndarray]],
+        list[Union[np.ndarray, torch.Tensor]],
     ]:
         """
         Scale input data.
@@ -1428,8 +1429,8 @@ class MultiNormalizer(TorchNormalizer):
             return res
 
     def __call__(
-        self, data: Dict[str, Union[List[torch.Tensor], torch.Tensor]]
-    ) -> List[torch.Tensor]:
+        self, data: dict[str, Union[list[torch.Tensor], torch.Tensor]]
+    ) -> list[torch.Tensor]:
         """
         Inverse transformation but with network output as input.
 
@@ -1457,7 +1458,7 @@ class MultiNormalizer(TorchNormalizer):
         ]
         return denormalized
 
-    def get_parameters(self, *args, **kwargs) -> List[torch.Tensor]:
+    def get_parameters(self, *args, **kwargs) -> list[torch.Tensor]:
         """
         Returns parameters that were used for encoding.
 

--- a/pytorch_forecasting/data/samplers.py
+++ b/pytorch_forecasting/data/samplers.py
@@ -47,12 +47,11 @@ class GroupedSampler(Sampler):
         ):
             raise ValueError(
                 "batch_size should be a positive integer value, "
-                "but got batch_size={}".format(batch_size)
+                f"but got batch_size={batch_size}"
             )
         if not isinstance(drop_last, bool):
             raise ValueError(
-                "drop_last should be a boolean value, but got "
-                "drop_last={}".format(drop_last)
+                f"drop_last should be a boolean value, but got drop_last={drop_last}"
             )
         self.sampler = sampler
         self.batch_size = batch_size

--- a/pytorch_forecasting/data/timeseries/_timeseries.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries.py
@@ -9,7 +9,7 @@ a class that is able to handle a wide variety of timeseries data problems.
 from copy import copy as _copy, deepcopy
 from functools import lru_cache
 import inspect
-from typing import Any, Callable, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Optional, TypeVar, Union
 import warnings
 
 import numpy as np
@@ -1056,7 +1056,7 @@ class TimeSeriesDataSet(Dataset):
         torch.save(self, fname)
 
     @classmethod
-    def load(cls: Type[TimeSeriesDataType], fname: str) -> TimeSeriesDataType:
+    def load(cls: type[TimeSeriesDataType], fname: str) -> TimeSeriesDataType:
         """
         Load dataset from disk
 
@@ -1627,7 +1627,7 @@ class TimeSeriesDataSet(Dataset):
 
     @classmethod
     def from_dataset(
-        cls: Type[TimeSeriesDataType],
+        cls: type[TimeSeriesDataType],
         dataset: TimeSeriesDataType,
         data: pd.DataFrame,
         stop_randomization: bool = False,
@@ -1670,7 +1670,7 @@ class TimeSeriesDataSet(Dataset):
 
     @classmethod
     def from_parameters(
-        cls: Type[TimeSeriesDataType],
+        cls: type[TimeSeriesDataType],
         parameters: dict[str, Any],
         data: pd.DataFrame,
         stop_randomization: bool = None,

--- a/pytorch_forecasting/data/timeseries/_timeseries_v2.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries_v2.py
@@ -4,7 +4,7 @@ Timeseries dataset - v2 prototype.
 Beta version, experimental - use for testing but not in production.
 """
 
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 from warnings import warn
 
 import numpy as np
@@ -81,14 +81,14 @@ class TimeSeries(Dataset):
         data: pd.DataFrame,
         data_future: Optional[pd.DataFrame] = None,
         time: Optional[str] = None,
-        target: Optional[Union[str, List[str]]] = None,
-        group: Optional[List[str]] = None,
+        target: Optional[Union[str, list[str]]] = None,
+        group: Optional[list[str]] = None,
         weight: Optional[str] = None,
-        num: Optional[List[Union[str, List[str]]]] = None,
-        cat: Optional[List[Union[str, List[str]]]] = None,
-        known: Optional[List[Union[str, List[str]]]] = None,
-        unknown: Optional[List[Union[str, List[str]]]] = None,
-        static: Optional[List[Union[str, List[str]]]] = None,
+        num: Optional[list[Union[str, list[str]]]] = None,
+        cat: Optional[list[Union[str, list[str]]]] = None,
+        known: Optional[list[Union[str, list[str]]]] = None,
+        unknown: Optional[list[Union[str, list[str]]]] = None,
+        static: Optional[list[Union[str, list[str]]]] = None,
     ):
 
         self.data = data
@@ -187,7 +187,7 @@ class TimeSeries(Dataset):
         """Return number of time series in the dataset."""
         return len(self._group_ids)
 
-    def __getitem__(self, index: int) -> Dict[str, torch.Tensor]:
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
         """Get time series data for given index.
 
         Returns
@@ -309,7 +309,7 @@ class TimeSeries(Dataset):
 
         return result
 
-    def get_metadata(self) -> Dict:
+    def get_metadata(self) -> dict:
         """Return metadata about the dataset.
 
         Returns

--- a/pytorch_forecasting/metrics/_mqf2_utils.py
+++ b/pytorch_forecasting/metrics/_mqf2_utils.py
@@ -1,6 +1,6 @@
 """Classes and functions for the MQF2 metric."""
 
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import torch
 from torch.distributions import (
@@ -96,7 +96,7 @@ class DeepConvexNet(DeepConvexFlow):
         logdet: Optional[torch.Tensor] = 0,
         context: Optional[torch.Tensor] = None,
         extra: Optional[torch.Tensor] = None,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         if self.estimate_logdet:
             return self.forward_transform_stochastic(
                 x, logdet, context=context, extra=extra
@@ -118,7 +118,7 @@ class SequentialNet(SequentialFlow):
         list of DeepConvexNet and/or ActNorm instances
     """
 
-    def __init__(self, networks: List[torch.nn.Module]) -> None:
+    def __init__(self, networks: list[torch.nn.Module]) -> None:
         super().__init__(networks)
         self.networks = self.flows
 
@@ -491,7 +491,7 @@ class MQF2Distribution(Distribution):
         return self.hidden_state.shape[:-1]
 
     @property
-    def event_shape(self) -> Tuple:
+    def event_shape(self) -> tuple:
         return (self.prediction_length,)
 
     @property
@@ -503,12 +503,12 @@ class TransformedMQF2Distribution(TransformedDistribution):
     def __init__(
         self,
         base_distribution: MQF2Distribution,
-        transforms: List[AffineTransform],
+        transforms: list[AffineTransform],
         validate_args: bool = False,
     ) -> None:
         super().__init__(base_distribution, transforms, validate_args=validate_args)
 
-    def scale_input(self, y: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def scale_input(self, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         # Auxiliary function to scale the observations
         scale = torch.tensor(1.0, device=y.device)
         for t in self.transforms[::-1]:

--- a/pytorch_forecasting/metrics/base_metrics.py
+++ b/pytorch_forecasting/metrics/base_metrics.py
@@ -3,7 +3,7 @@ Base classes for metrics - only for inheritance.
 """
 
 import inspect
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Optional
 import warnings
 
 from sklearn.base import BaseEstimator
@@ -31,7 +31,7 @@ class Metric(LightningMetric):
     def __init__(
         self,
         name: str = None,
-        quantiles: List[float] = None,
+        quantiles: list[float] = None,
         reduction="mean",
         **kwargs,
     ):
@@ -108,7 +108,7 @@ class Metric(LightningMetric):
         return y_pred
 
     def to_quantiles(
-        self, y_pred: torch.Tensor, quantiles: List[float] = None
+        self, y_pred: torch.Tensor, quantiles: list[float] = None
     ) -> torch.Tensor:
         """
         Convert network prediction into a quantile prediction.
@@ -194,7 +194,7 @@ class TorchMetricWrapper(Metric):
 
     def _convert(
         self, y_pred: torch.Tensor, target: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         # unpack target into target and weights
         if isinstance(target, (list, tuple)) and not isinstance(
             target, rnn.PackedSequence
@@ -272,7 +272,7 @@ class MultiLoss(LightningMetric):
     higher_is_better = False
     is_differentiable = True
 
-    def __init__(self, metrics: List[LightningMetric], weights: List[float] = None):
+    def __init__(self, metrics: list[LightningMetric], weights: list[float] = None):
         """
         Args:
             metrics (List[LightningMetric], optional): list of metrics to combine.
@@ -545,8 +545,8 @@ class CompositeMetric(LightningMetric):
 
     def __init__(
         self,
-        metrics: Optional[List[LightningMetric]] = None,
-        weights: Optional[List[float]] = None,
+        metrics: Optional[list[LightningMetric]] = None,
+        weights: Optional[list[float]] = None,
     ):
         """
         Args:
@@ -737,7 +737,7 @@ class AggregationMetric(Metric):
     @staticmethod
     def _calculate_mean(
         y_pred: torch.Tensor, y_actual: torch.Tensor
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         # extract target and weight
         if isinstance(y_actual, (tuple, list)) and not isinstance(
             y_actual, rnn.PackedSequence
@@ -829,7 +829,7 @@ class MultiHorizonMetric(Metric):
         )
 
     def loss(
-        self, y_pred: Dict[str, torch.Tensor], target: torch.Tensor
+        self, y_pred: dict[str, torch.Tensor], target: torch.Tensor
     ) -> torch.Tensor:
         """
         Calculate loss without reduction. Override in derived classes
@@ -989,12 +989,12 @@ class DistributionLoss(MultiHorizonMetric):
     """  # noqa: E501
 
     distribution_class: distributions.Distribution
-    distribution_arguments: List[str]
+    distribution_arguments: list[str]
 
     def __init__(
         self,
         name: str = None,
-        quantiles: Optional[List[float]] = None,
+        quantiles: Optional[list[float]] = None,
         reduction="mean",
     ):
         """
@@ -1074,7 +1074,7 @@ class DistributionLoss(MultiHorizonMetric):
         return samples
 
     def to_quantiles(
-        self, y_pred: torch.Tensor, quantiles: List[float] = None, n_samples: int = 100
+        self, y_pred: torch.Tensor, quantiles: list[float] = None, n_samples: int = 100
     ) -> torch.Tensor:
         """
         Convert network prediction into a quantile prediction.

--- a/pytorch_forecasting/metrics/distributions.py
+++ b/pytorch_forecasting/metrics/distributions.py
@@ -1,6 +1,6 @@
 """Metrics that allow the parametric forecast of parameters of uni- and multivariate distributions."""  # noqa: E501
 
-from typing import List, Optional
+from typing import Optional
 
 import numpy as np
 from sklearn.base import BaseEstimator
@@ -70,7 +70,7 @@ class MultivariateNormalDistributionLoss(MultivariateDistributionLoss):
     def __init__(
         self,
         name: str = None,
-        quantiles: Optional[List[float]] = None,
+        quantiles: Optional[list[float]] = None,
         reduction: str = "mean",
         rank: int = 10,
         sigma_init: float = 1.0,
@@ -351,7 +351,7 @@ class MQF2DistributionLoss(DistributionLoss):
     def __init__(
         self,
         prediction_length: int,
-        quantiles: Optional[List[float]] = None,
+        quantiles: Optional[list[float]] = None,
         hidden_size: Optional[int] = 4,
         es_num_samples: int = 50,
         beta: float = 1.0,
@@ -481,7 +481,7 @@ class MQF2DistributionLoss(DistributionLoss):
         )
 
     def to_quantiles(
-        self, y_pred: torch.Tensor, quantiles: List[float] = None
+        self, y_pred: torch.Tensor, quantiles: list[float] = None
     ) -> torch.Tensor:
         """
         Convert network prediction into a quantile prediction.
@@ -557,7 +557,7 @@ class ImplicitQuantileNetworkDistributionLoss(DistributionLoss):
 
     def __init__(
         self,
-        quantiles: Optional[List[float]] = None,
+        quantiles: Optional[list[float]] = None,
         input_size: Optional[int] = 16,
         hidden_size: Optional[int] = 32,
         n_loss_samples: Optional[int] = 64,
@@ -638,7 +638,7 @@ class ImplicitQuantileNetworkDistributionLoss(DistributionLoss):
             return self.sample(y_pred, n_samples=n_samples).mean(-1)
 
     def to_quantiles(
-        self, y_pred: torch.Tensor, quantiles: List[float] = None
+        self, y_pred: torch.Tensor, quantiles: list[float] = None
     ) -> torch.Tensor:
         """
         Convert network prediction into a quantile prediction.

--- a/pytorch_forecasting/metrics/point.py
+++ b/pytorch_forecasting/metrics/point.py
@@ -1,7 +1,5 @@
 """Point metrics for forecasting a single point per time step."""
 
-from typing import Dict, List
-
 import scipy.stats
 import torch
 import torch.nn.functional as F
@@ -33,7 +31,7 @@ class PoissonLoss(MultiHorizonMetric):
     """  # noqa: E501
 
     def loss(
-        self, y_pred: Dict[str, torch.Tensor], target: torch.Tensor
+        self, y_pred: dict[str, torch.Tensor], target: torch.Tensor
     ) -> torch.Tensor:
         return F.poisson_nll_loss(
             super().to_prediction(y_pred),
@@ -44,11 +42,11 @@ class PoissonLoss(MultiHorizonMetric):
             reduction="none",
         )
 
-    def to_prediction(self, out: Dict[str, torch.Tensor]):
+    def to_prediction(self, out: dict[str, torch.Tensor]):
         rate = torch.exp(super().to_prediction(out))
         return rate
 
-    def to_quantiles(self, out: Dict[str, torch.Tensor], quantiles=None):
+    def to_quantiles(self, out: dict[str, torch.Tensor], quantiles=None):
         if quantiles is None:
             if self.quantiles is None:
                 quantiles = [0.5]
@@ -133,7 +131,7 @@ class CrossEntropy(MultiHorizonMetric):
         return y_pred.argmax(dim=-1)
 
     def to_quantiles(
-        self, y_pred: torch.Tensor, quantiles: List[float] = None
+        self, y_pred: torch.Tensor, quantiles: list[float] = None
     ) -> torch.Tensor:
         """
         Convert network prediction into a quantile prediction.
@@ -159,7 +157,7 @@ class RMSE(MultiHorizonMetric):
     def __init__(self, reduction="sqrt-mean", **kwargs):
         super().__init__(reduction=reduction, **kwargs)
 
-    def loss(self, y_pred: Dict[str, torch.Tensor], target):
+    def loss(self, y_pred: dict[str, torch.Tensor], target):
         loss = torch.pow(self.to_prediction(y_pred) - target, 2)
         return loss
 
@@ -321,7 +319,7 @@ class TweedieLoss(MultiHorizonMetric):
         assert 1 <= p < 2, "p must be in range [1, 2]"
         self.p = p
 
-    def to_prediction(self, out: Dict[str, torch.Tensor]):
+    def to_prediction(self, out: dict[str, torch.Tensor]):
         rate = torch.exp(super().to_prediction(out))
         return rate
 

--- a/pytorch_forecasting/metrics/quantile.py
+++ b/pytorch_forecasting/metrics/quantile.py
@@ -1,6 +1,6 @@
 """Quantile metrics for forecasting multiple quantiles per time step."""
 
-from typing import List, Optional
+from typing import Optional
 
 import torch
 
@@ -16,7 +16,7 @@ class QuantileLoss(MultiHorizonMetric):
 
     def __init__(
         self,
-        quantiles: Optional[List[float]] = None,
+        quantiles: Optional[list[float]] = None,
         **kwargs,
     ):
         """

--- a/pytorch_forecasting/models/base/_base_model.py
+++ b/pytorch_forecasting/models/base/_base_model.py
@@ -3,11 +3,12 @@ Timeseries models share a number of common characteristics. This module implemen
 """  # noqa: E501
 
 from collections import namedtuple
+from collections.abc import Iterable
 from copy import deepcopy
 import inspect
 import logging
 import os
-from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple, Union
+from typing import Any, Callable, Literal, Optional, Union
 import warnings
 
 import lightning.pytorch as pl
@@ -65,7 +66,7 @@ from pytorch_forecasting.utils._dependencies import (
 # todo: compile models
 
 
-def _torch_cat_na(x: List[torch.Tensor]) -> torch.Tensor:
+def _torch_cat_na(x: list[torch.Tensor]) -> torch.Tensor:
     """
     Concatenate tensor along ``dim=0`` and add nans along ``dim=1`` if necessary.
 
@@ -128,14 +129,14 @@ def _torch_cat_na(x: List[torch.Tensor]) -> torch.Tensor:
 
 
 def _concatenate_output(
-    output: List[
-        Dict[
+    output: list[
+        dict[
             str,
-            List[Union[List[torch.Tensor], torch.Tensor, bool, int, str, np.ndarray]],
+            list[Union[list[torch.Tensor], torch.Tensor, bool, int, str, np.ndarray]],
         ]
     ],
-) -> Dict[
-    str, Union[torch.Tensor, np.ndarray, List[Union[torch.Tensor, int, bool, str]]]
+) -> dict[
+    str, Union[torch.Tensor, np.ndarray, list[Union[torch.Tensor, int, bool, str]]]
 ]:
     """
     Concatenate multiple batches of output dictionary.
@@ -214,15 +215,15 @@ class PredictCallback(BasePredictionWriter):
     # see base class predict function for documentation of parameters
     def __init__(
         self,
-        mode: Union[str, Tuple[str, str]] = "prediction",
+        mode: Union[str, tuple[str, str]] = "prediction",
         return_index: bool = False,
         return_decoder_lengths: bool = False,
         return_y: bool = False,
         write_interval: Literal["batch", "epoch", "batch_and_epoch"] = "batch",
         return_x: bool = False,
-        mode_kwargs: Dict[str, Any] = None,
+        mode_kwargs: dict[str, Any] = None,
         output_dir: Optional[str] = None,
-        predict_kwargs: Dict[str, Any] = None,
+        predict_kwargs: dict[str, Any] = None,
     ) -> None:
         super().__init__(write_interval=write_interval)
         self.mode = mode
@@ -266,10 +267,8 @@ class PredictCallback(BasePredictionWriter):
                 out = out[self.mode[1]]
             else:
                 raise ValueError(
-                    (
-                        "If a tuple is specified, the first element must be 'raw' - got"
-                        f" {self.mode[0]} instead"
-                    )
+                    "If a tuple is specified, the first element must be 'raw' - got"
+                    f" {self.mode[0]} instead"
                 )
         elif self.mode == "prediction":
             out = pl_module.to_prediction(out, **self.mode_kwargs)
@@ -471,10 +470,10 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
     def __init__(
         self,
-        dataset_parameters: Dict[str, Any] = None,
+        dataset_parameters: dict[str, Any] = None,
         log_interval: Union[int, float] = -1,
         log_val_interval: Union[int, float] = None,
-        learning_rate: Union[float, List[float]] = 1e-3,
+        learning_rate: Union[float, list[float]] = 1e-3,
         log_gradient_flow: bool = False,
         loss: Metric = SMAPE(),
         logging_metrics: nn.ModuleList = nn.ModuleList([]),
@@ -482,8 +481,8 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         reduce_on_plateau_reduction: float = 2.0,
         reduce_on_plateau_min_lr: float = 1e-5,
         weight_decay: float = 0.0,
-        optimizer_params: Dict[str, Any] = None,
-        monotone_constraints: Dict[str, int] = {},
+        optimizer_params: dict[str, Any] = None,
+        monotone_constraints: dict[str, int] = {},
         output_transformer: Callable = None,
         optimizer="adam",
     ):
@@ -621,8 +620,8 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
     def transform_output(
         self,
-        prediction: Union[torch.Tensor, List[torch.Tensor]],
-        target_scale: Union[torch.Tensor, List[torch.Tensor]],
+        prediction: Union[torch.Tensor, list[torch.Tensor]],
+        target_scale: Union[torch.Tensor, list[torch.Tensor]],
         loss: Optional[Metric] = None,
     ) -> torch.Tensor:
         """
@@ -653,9 +652,9 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
     @staticmethod
     def deduce_default_output_parameters(
         dataset: TimeSeriesDataSet,
-        kwargs: Dict[str, Any],
+        kwargs: dict[str, Any],
         default_loss: MultiHorizonMetric = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Deduce default parameters for output for `from_dataset()` method.
 
@@ -754,13 +753,13 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
     def create_log(
         self,
-        x: Dict[str, torch.Tensor],
-        y: Tuple[torch.Tensor, torch.Tensor],
-        out: Dict[str, torch.Tensor],
+        x: dict[str, torch.Tensor],
+        y: tuple[torch.Tensor, torch.Tensor],
+        out: dict[str, torch.Tensor],
         batch_idx: int,
-        prediction_kwargs: Optional[Dict[str, Any]] = None,
-        quantiles_kwargs: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+        prediction_kwargs: Optional[dict[str, Any]] = None,
+        quantiles_kwargs: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
         """
         Create the log used in the training and validation step.
 
@@ -804,11 +803,11 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
     def step(
         self,
-        x: Dict[str, torch.Tensor],
-        y: Tuple[torch.Tensor, torch.Tensor],
+        x: dict[str, torch.Tensor],
+        y: tuple[torch.Tensor, torch.Tensor],
         batch_idx: int,
         **kwargs,
-    ) -> Tuple[Dict[str, torch.Tensor], Dict[str, torch.Tensor]]:
+    ) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
         """
         Run for each train/val step.
 
@@ -940,10 +939,10 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
     def log_metrics(
         self,
-        x: Dict[str, torch.Tensor],
+        x: dict[str, torch.Tensor],
         y: torch.Tensor,
-        out: Dict[str, torch.Tensor],
-        prediction_kwargs: Dict[str, Any] = None,
+        out: dict[str, torch.Tensor],
+        prediction_kwargs: dict[str, Any] = None,
     ) -> None:
         """
         Log metrics every training/validation step.
@@ -993,8 +992,8 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                 )
 
     def forward(
-        self, x: Dict[str, Union[torch.Tensor, List[torch.Tensor]]]
-    ) -> Dict[str, Union[torch.Tensor, List[torch.Tensor]]]:
+        self, x: dict[str, Union[torch.Tensor, list[torch.Tensor]]]
+    ) -> dict[str, Union[torch.Tensor, list[torch.Tensor]]]:
         """
         Network forward pass.
 
@@ -1071,8 +1070,8 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
     def log_prediction(
         self,
-        x: Dict[str, torch.Tensor],
-        out: Dict[str, torch.Tensor],
+        x: dict[str, torch.Tensor],
+        out: dict[str, torch.Tensor],
         batch_idx: int,
         **kwargs,
     ) -> None:
@@ -1132,14 +1131,14 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
     def plot_prediction(
         self,
-        x: Dict[str, torch.Tensor],
-        out: Dict[str, torch.Tensor],
+        x: dict[str, torch.Tensor],
+        out: dict[str, torch.Tensor],
         idx: int = 0,
         add_loss_to_title: Union[Metric, torch.Tensor, bool] = False,
         show_future_observed: bool = True,
         ax=None,
-        quantiles_kwargs: Optional[Dict[str, Any]] = None,
-        prediction_kwargs: Optional[Dict[str, Any]] = None,
+        quantiles_kwargs: Optional[dict[str, Any]] = None,
+        prediction_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         Plot prediction of prediction vs actuals
@@ -1293,7 +1292,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         else:
             return fig
 
-    def log_gradient_flow(self, named_parameters: Dict[str, torch.Tensor]) -> None:
+    def log_gradient_flow(self, named_parameters: dict[str, torch.Tensor]) -> None:
         """
         log distribution of gradients to identify exploding / vanishing gradients
         """
@@ -1454,10 +1453,8 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                     )
             else:
                 raise ValueError(
-                    (
-                        f"Optimizer of self.hparams.optimizer={self.hparams.optimizer}"
-                        " unknown"
-                    )
+                    f"Optimizer of self.hparams.optimizer={self.hparams.optimizer}"
+                    " unknown"
                 )
         else:
             raise ValueError(
@@ -1525,7 +1522,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
 
         return net
 
-    def on_save_checkpoint(self, checkpoint: Dict[str, Any]) -> None:
+    def on_save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
         checkpoint["dataset_parameters"] = getattr(
             self, "dataset_parameters", None
         )  # add dataset parameters for making fast predictions
@@ -1541,7 +1538,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         )
 
     @property
-    def target_names(self) -> List[str]:
+    def target_names(self) -> list[str]:
         """
         List of targets that are predicted.
 
@@ -1553,13 +1550,13 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         else:
             return [f"Target {idx + 1}" for idx in range(self.n_targets)]
 
-    def on_load_checkpoint(self, checkpoint: Dict[str, Any]) -> None:
+    def on_load_checkpoint(self, checkpoint: dict[str, Any]) -> None:
         self.dataset_parameters = checkpoint.get("dataset_parameters", None)
         # load specials
         for k, v in checkpoint[self.CHECKPOINT_HYPER_PARAMS_SPECIAL_KEY].items():
             setattr(self, k, v)
 
-    def to_prediction(self, out: Dict[str, Any], use_metric: bool = True, **kwargs):
+    def to_prediction(self, out: dict[str, Any], use_metric: bool = True, **kwargs):
         """
         Convert output to prediction using the loss metric.
 
@@ -1590,7 +1587,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
                 out = self.loss.to_prediction(out["prediction"])
         return out
 
-    def to_quantiles(self, out: Dict[str, Any], use_metric: bool = True, **kwargs):
+    def to_quantiles(self, out: dict[str, Any], use_metric: bool = True, **kwargs):
         """
         Convert output to quantiles using the loss metric.
 
@@ -1632,7 +1629,7 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
     def predict(
         self,
         data: Union[DataLoader, pd.DataFrame, TimeSeriesDataSet],
-        mode: Union[str, Tuple[str, str]] = "prediction",
+        mode: Union[str, tuple[str, str]] = "prediction",
         return_index: bool = False,
         return_decoder_lengths: bool = False,
         batch_size: int = 64,
@@ -1640,8 +1637,8 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         fast_dev_run: bool = False,
         return_x: bool = False,
         return_y: bool = False,
-        mode_kwargs: Dict[str, Any] = None,
-        trainer_kwargs: Optional[Dict[str, Any]] = None,
+        mode_kwargs: dict[str, Any] = None,
+        trainer_kwargs: Optional[dict[str, Any]] = None,
         write_interval: Literal["batch", "epoch", "batch_and_epoch"] = "batch",
         output_dir: Optional[str] = None,
         **kwargs,
@@ -1888,7 +1885,7 @@ class BaseModelWithCovariates(BaseModel):
         )
 
     @property
-    def reals(self) -> List[str]:
+    def reals(self) -> list[str]:
         """List of all continuous variables in model"""
         return list(
             dict.fromkeys(
@@ -1899,7 +1896,7 @@ class BaseModelWithCovariates(BaseModel):
         )
 
     @property
-    def categoricals(self) -> List[str]:
+    def categoricals(self) -> list[str]:
         """List of all categorical variables in model"""
         return list(
             dict.fromkeys(
@@ -1910,12 +1907,12 @@ class BaseModelWithCovariates(BaseModel):
         )
 
     @property
-    def static_variables(self) -> List[str]:
+    def static_variables(self) -> list[str]:
         """List of all static variables in model"""
         return self.hparams.static_categoricals + self.hparams.static_reals
 
     @property
-    def encoder_variables(self) -> List[str]:
+    def encoder_variables(self) -> list[str]:
         """List of all encoder variables in model (excluding static variables)"""
         return (
             self.hparams.time_varying_categoricals_encoder
@@ -1923,7 +1920,7 @@ class BaseModelWithCovariates(BaseModel):
         )
 
     @property
-    def decoder_variables(self) -> List[str]:
+    def decoder_variables(self) -> list[str]:
         """List of all decoder variables in model (excluding static variables)"""
         return (
             self.hparams.time_varying_categoricals_decoder
@@ -1931,7 +1928,7 @@ class BaseModelWithCovariates(BaseModel):
         )
 
     @property
-    def categorical_groups_mapping(self) -> Dict[str, str]:
+    def categorical_groups_mapping(self) -> dict[str, str]:
         """Mapping of categorical variables to categorical groups"""
         groups = {}
         for group_name, sublist in self.hparams.categorical_groups.items():
@@ -1942,7 +1939,7 @@ class BaseModelWithCovariates(BaseModel):
     def from_dataset(
         cls,
         dataset: TimeSeriesDataSet,
-        allowed_encoder_known_variable_names: List[str] = None,
+        allowed_encoder_known_variable_names: list[str] = None,
         **kwargs,
     ) -> LightningModule:
         """
@@ -2052,13 +2049,13 @@ class BaseModelWithCovariates(BaseModel):
 
     def calculate_prediction_actual_by_variable(
         self,
-        x: Dict[str, torch.Tensor],
+        x: dict[str, torch.Tensor],
         y_pred: torch.Tensor,
         normalize: bool = True,
         bins: int = 95,
         std: float = 2.0,
         log_scale: bool = None,
-    ) -> Dict[str, Dict[str, torch.Tensor]]:
+    ) -> dict[str, dict[str, torch.Tensor]]:
         """
         Calculate predictions and actuals by variable averaged by ``bins`` bins spanning from ``-std`` to ``+std``
 
@@ -2179,7 +2176,7 @@ class BaseModelWithCovariates(BaseModel):
 
     def plot_prediction_actual_by_variable(
         self,
-        data: Dict[str, Dict[str, torch.Tensor]],
+        data: dict[str, dict[str, torch.Tensor]],
         name: str = None,
         ax=None,
         log_scale: bool = None,
@@ -2376,10 +2373,10 @@ class AutoRegressiveBaseModel(BaseModel):
     def output_to_prediction(
         self,
         normalized_prediction_parameters: torch.Tensor,
-        target_scale: Union[List[torch.Tensor], torch.Tensor],
+        target_scale: Union[list[torch.Tensor], torch.Tensor],
         n_samples: int = 1,
         **kwargs,
-    ) -> Tuple[Union[List[torch.Tensor], torch.Tensor], torch.Tensor]:
+    ) -> tuple[Union[list[torch.Tensor], torch.Tensor], torch.Tensor]:
         """
         Convert network output to rescaled and normalized prediction.
 
@@ -2447,13 +2444,13 @@ class AutoRegressiveBaseModel(BaseModel):
     def decode_autoregressive(
         self,
         decode_one: Callable,
-        first_target: Union[List[torch.Tensor], torch.Tensor],
+        first_target: Union[list[torch.Tensor], torch.Tensor],
         first_hidden_state: Any,
-        target_scale: Union[List[torch.Tensor], torch.Tensor],
+        target_scale: Union[list[torch.Tensor], torch.Tensor],
         n_decoder_steps: int,
         n_samples: int = 1,
         **kwargs,
-    ) -> Union[List[torch.Tensor], torch.Tensor]:
+    ) -> Union[list[torch.Tensor], torch.Tensor]:
         """
         Make predictions in auto-regressive manner.
 
@@ -2611,14 +2608,14 @@ class AutoRegressiveBaseModel(BaseModel):
 
     def plot_prediction(
         self,
-        x: Dict[str, torch.Tensor],
-        out: Dict[str, torch.Tensor],
+        x: dict[str, torch.Tensor],
+        out: dict[str, torch.Tensor],
         idx: int = 0,
         add_loss_to_title: Union[Metric, torch.Tensor, bool] = False,
         show_future_observed: bool = True,
         ax=None,
-        quantiles_kwargs: Optional[Dict[str, Any]] = None,
-        prediction_kwargs: Optional[Dict[str, Any]] = None,
+        quantiles_kwargs: Optional[dict[str, Any]] = None,
+        prediction_kwargs: Optional[dict[str, Any]] = None,
     ):
         """
         Plot prediction of prediction vs actuals
@@ -2663,7 +2660,7 @@ class AutoRegressiveBaseModel(BaseModel):
         )
 
     @property
-    def lagged_target_positions(self) -> Dict[int, torch.LongTensor]:
+    def lagged_target_positions(self) -> dict[int, torch.LongTensor]:
         """
         Positions of lagged target variable(s) in covariates.
 
@@ -2711,7 +2708,7 @@ class AutoRegressiveBaseModelWithCovariates(
     """  # noqa: E501
 
     @property
-    def lagged_target_positions(self) -> Dict[int, torch.LongTensor]:
+    def lagged_target_positions(self) -> dict[int, torch.LongTensor]:
         """
         Positions of lagged target variable(s) in covariates.
 

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -5,7 +5,7 @@
 ########################################################################################
 
 
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 from warnings import warn
 
 from lightning.pytorch import LightningModule
@@ -19,11 +19,11 @@ class BaseModel(LightningModule):
     def __init__(
         self,
         loss: nn.Module,
-        logging_metrics: Optional[List[nn.Module]] = None,
+        logging_metrics: Optional[list[nn.Module]] = None,
         optimizer: Optional[Union[Optimizer, str]] = "adam",
-        optimizer_params: Optional[Dict] = None,
+        optimizer_params: Optional[dict] = None,
         lr_scheduler: Optional[str] = None,
-        lr_scheduler_params: Optional[Dict] = None,
+        lr_scheduler_params: Optional[dict] = None,
     ):
         """
         Base model for time series forecasting.
@@ -67,7 +67,7 @@ class BaseModel(LightningModule):
             UserWarning,
         )
 
-    def forward(self, x: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    def forward(self, x: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Forward pass of the model.
 
@@ -84,7 +84,7 @@ class BaseModel(LightningModule):
         raise NotImplementedError("Forward method must be implemented by subclass.")
 
     def training_step(
-        self, batch: Tuple[Dict[str, torch.Tensor]], batch_idx: int
+        self, batch: tuple[dict[str, torch.Tensor]], batch_idx: int
     ) -> STEP_OUTPUT:
         """
         Training step for the model.
@@ -112,7 +112,7 @@ class BaseModel(LightningModule):
         return {"loss": loss}
 
     def validation_step(
-        self, batch: Tuple[Dict[str, torch.Tensor]], batch_idx: int
+        self, batch: tuple[dict[str, torch.Tensor]], batch_idx: int
     ) -> STEP_OUTPUT:
         """
         Validation step for the model.
@@ -140,7 +140,7 @@ class BaseModel(LightningModule):
         return {"val_loss": loss}
 
     def test_step(
-        self, batch: Tuple[Dict[str, torch.Tensor]], batch_idx: int
+        self, batch: tuple[dict[str, torch.Tensor]], batch_idx: int
     ) -> STEP_OUTPUT:
         """
         Test step for the model.
@@ -169,7 +169,7 @@ class BaseModel(LightningModule):
 
     def predict_step(
         self,
-        batch: Tuple[Dict[str, torch.Tensor]],
+        batch: tuple[dict[str, torch.Tensor]],
         batch_idx: int,
         dataloader_idx: int = 0,
     ) -> torch.Tensor:
@@ -194,7 +194,7 @@ class BaseModel(LightningModule):
         y_hat = self(x)
         return y_hat
 
-    def configure_optimizers(self) -> Dict:
+    def configure_optimizers(self) -> dict:
         """
         Configure the optimizer and learning rate scheduler.
 

--- a/pytorch_forecasting/models/baseline.py
+++ b/pytorch_forecasting/models/baseline.py
@@ -2,7 +2,7 @@
 Baseline model.
 """
 
-from typing import Any, Dict
+from typing import Any
 
 import torch
 
@@ -31,7 +31,7 @@ class Baseline(BaseModel):
         metric.compute()
     """
 
-    def forward(self, x: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    def forward(self, x: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Network forward pass.
 
@@ -74,8 +74,8 @@ class Baseline(BaseModel):
         prediction = last_values[:, None].expand(-1, max_prediction_length)
         return prediction
 
-    def to_prediction(self, out: Dict[str, Any], use_metric: bool = True, **kwargs):
+    def to_prediction(self, out: dict[str, Any], use_metric: bool = True, **kwargs):
         return out.prediction
 
-    def to_quantiles(self, out: Dict[str, Any], use_metric: bool = True, **kwargs):
+    def to_quantiles(self, out: dict[str, Any], use_metric: bool = True, **kwargs):
         return out.prediction[..., None]

--- a/pytorch_forecasting/models/deepar/_deepar.py
+++ b/pytorch_forecasting/models/deepar/_deepar.py
@@ -5,7 +5,7 @@ which is the one of the most popular forecasting algorithms and is often used as
 """  # noqa: E501
 
 from copy import deepcopy
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -41,22 +41,22 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
         hidden_size: int = 10,
         rnn_layers: int = 2,
         dropout: float = 0.1,
-        static_categoricals: Optional[List[str]] = None,
-        static_reals: Optional[List[str]] = None,
-        time_varying_categoricals_encoder: Optional[List[str]] = None,
-        time_varying_categoricals_decoder: Optional[List[str]] = None,
-        categorical_groups: Optional[Dict[str, List[str]]] = None,
-        time_varying_reals_encoder: Optional[List[str]] = None,
-        time_varying_reals_decoder: Optional[List[str]] = None,
-        embedding_sizes: Optional[Dict[str, Tuple[int, int]]] = None,
-        embedding_paddings: Optional[List[str]] = None,
-        embedding_labels: Optional[Dict[str, np.ndarray]] = None,
-        x_reals: Optional[List[str]] = None,
-        x_categoricals: Optional[List[str]] = None,
+        static_categoricals: Optional[list[str]] = None,
+        static_reals: Optional[list[str]] = None,
+        time_varying_categoricals_encoder: Optional[list[str]] = None,
+        time_varying_categoricals_decoder: Optional[list[str]] = None,
+        categorical_groups: Optional[dict[str, list[str]]] = None,
+        time_varying_reals_encoder: Optional[list[str]] = None,
+        time_varying_reals_decoder: Optional[list[str]] = None,
+        embedding_sizes: Optional[dict[str, tuple[int, int]]] = None,
+        embedding_paddings: Optional[list[str]] = None,
+        embedding_labels: Optional[dict[str, np.ndarray]] = None,
+        x_reals: Optional[list[str]] = None,
+        x_categoricals: Optional[list[str]] = None,
         n_validation_samples: int = None,
         n_plotting_samples: int = None,
-        target: Union[str, List[str]] = None,
-        target_lags: Optional[Dict[str, List[int]]] = None,
+        target: Union[str, list[str]] = None,
+        target_lags: Optional[dict[str, list[int]]] = None,
         loss: DistributionLoss = None,
         logging_metrics: nn.ModuleList = None,
         **kwargs,
@@ -201,7 +201,7 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
     def from_dataset(
         cls,
         dataset: TimeSeriesDataSet,
-        allowed_encoder_known_variable_names: List[str] = None,
+        allowed_encoder_known_variable_names: list[str] = None,
         **kwargs,
     ):
         """
@@ -277,7 +277,7 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
         # shift target
         return input_vector
 
-    def encode(self, x: Dict[str, torch.Tensor]) -> HiddenState:
+    def encode(self, x: dict[str, torch.Tensor]) -> HiddenState:
         """
         Encode sequence into hidden state
         """
@@ -314,7 +314,7 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
         decoder_lengths: torch.Tensor,
         hidden_state: HiddenState,
         n_samples: int = None,
-    ) -> Tuple[torch.Tensor, bool]:
+    ) -> tuple[torch.Tensor, bool]:
         """
         Decode hidden state of RNN into prediction. If n_smaples is given,
         decode not by using actual values but rather by
@@ -374,8 +374,8 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
         return output
 
     def forward(
-        self, x: Dict[str, torch.Tensor], n_samples: int = None
-    ) -> Dict[str, torch.Tensor]:
+        self, x: dict[str, torch.Tensor], n_samples: int = None
+    ) -> dict[str, torch.Tensor]:
         """
         Forward network
         """
@@ -423,7 +423,7 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
     def predict(
         self,
         data: Union[DataLoader, pd.DataFrame, TimeSeriesDataSet],
-        mode: Union[str, Tuple[str, str]] = "prediction",
+        mode: Union[str, tuple[str, str]] = "prediction",
         return_index: bool = False,
         return_decoder_lengths: bool = False,
         batch_size: int = 64,
@@ -431,8 +431,8 @@ class DeepAR(AutoRegressiveBaseModelWithCovariates):
         fast_dev_run: bool = False,
         return_x: bool = False,
         return_y: bool = False,
-        mode_kwargs: Dict[str, Any] = None,
-        trainer_kwargs: Optional[Dict[str, Any]] = None,
+        mode_kwargs: dict[str, Any] = None,
+        trainer_kwargs: Optional[dict[str, Any]] = None,
         write_interval: Literal["batch", "epoch", "batch_and_epoch"] = "batch",
         output_dir: Optional[str] = None,
         n_samples: int = 100,

--- a/pytorch_forecasting/models/mlp/_decodermlp.py
+++ b/pytorch_forecasting/models/mlp/_decodermlp.py
@@ -2,7 +2,7 @@
 Simple models based on fully connected networks
 """
 
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -37,20 +37,20 @@ class DecoderMLP(BaseModelWithCovariates):
         n_hidden_layers: int = 3,
         dropout: float = 0.1,
         norm: bool = True,
-        static_categoricals: Optional[List[str]] = None,
-        static_reals: Optional[List[str]] = None,
-        time_varying_categoricals_encoder: Optional[List[str]] = None,
-        time_varying_categoricals_decoder: Optional[List[str]] = None,
-        categorical_groups: Optional[Dict[str, List[str]]] = None,
-        time_varying_reals_encoder: Optional[List[str]] = None,
-        time_varying_reals_decoder: Optional[List[str]] = None,
-        embedding_sizes: Optional[Dict[str, Tuple[int, int]]] = None,
-        embedding_paddings: Optional[List[str]] = None,
-        embedding_labels: Optional[Dict[str, np.ndarray]] = None,
-        x_reals: Optional[List[str]] = None,
-        x_categoricals: Optional[List[str]] = None,
-        output_size: Union[int, List[int]] = 1,
-        target: Union[str, List[str]] = None,
+        static_categoricals: Optional[list[str]] = None,
+        static_reals: Optional[list[str]] = None,
+        time_varying_categoricals_encoder: Optional[list[str]] = None,
+        time_varying_categoricals_decoder: Optional[list[str]] = None,
+        categorical_groups: Optional[dict[str, list[str]]] = None,
+        time_varying_reals_encoder: Optional[list[str]] = None,
+        time_varying_reals_decoder: Optional[list[str]] = None,
+        embedding_sizes: Optional[dict[str, tuple[int, int]]] = None,
+        embedding_paddings: Optional[list[str]] = None,
+        embedding_labels: Optional[dict[str, np.ndarray]] = None,
+        x_reals: Optional[list[str]] = None,
+        x_categoricals: Optional[list[str]] = None,
+        output_size: Union[int, list[int]] = 1,
+        target: Union[str, list[str]] = None,
         loss: MultiHorizonMetric = None,
         logging_metrics: nn.ModuleList = None,
         **kwargs,
@@ -149,7 +149,7 @@ class DecoderMLP(BaseModelWithCovariates):
         )
 
     @property
-    def decoder_reals_positions(self) -> List[int]:
+    def decoder_reals_positions(self) -> list[int]:
         return [
             self.hparams.x_reals.index(name)
             for name in self.reals
@@ -157,8 +157,8 @@ class DecoderMLP(BaseModelWithCovariates):
         ]
 
     def forward(
-        self, x: Dict[str, torch.Tensor], n_samples: int = None
-    ) -> Dict[str, torch.Tensor]:
+        self, x: dict[str, torch.Tensor], n_samples: int = None
+    ) -> dict[str, torch.Tensor]:
         """
         Forward network
         """

--- a/pytorch_forecasting/models/nbeats/_nbeats.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats.py
@@ -2,7 +2,7 @@
 N-Beats model for timeseries forecasting without covariates.
 """
 
-from typing import Dict, List, Optional
+from typing import Optional
 
 import torch
 from torch import nn
@@ -22,12 +22,12 @@ from pytorch_forecasting.utils._dependencies import _check_matplotlib
 class NBeats(BaseModel):
     def __init__(
         self,
-        stack_types: Optional[List[str]] = None,
-        num_blocks: Optional[List[int]] = None,
-        num_block_layers: Optional[List[int]] = None,
-        widths: Optional[List[int]] = None,
-        sharing: Optional[List[bool]] = None,
-        expansion_coefficient_lengths: Optional[List[int]] = None,
+        stack_types: Optional[list[str]] = None,
+        num_blocks: Optional[list[int]] = None,
+        num_block_layers: Optional[list[int]] = None,
+        widths: Optional[list[int]] = None,
+        sharing: Optional[list[bool]] = None,
+        expansion_coefficient_lengths: Optional[list[int]] = None,
         prediction_length: int = 1,
         context_length: int = 1,
         dropout: float = 0.1,
@@ -146,7 +146,7 @@ class NBeats(BaseModel):
 
                 self.net_blocks.append(net_block)
 
-    def forward(self, x: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    def forward(self, x: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Pass forward of network.
 
@@ -275,7 +275,7 @@ class NBeats(BaseModel):
         # initialize class
         return super().from_dataset(dataset, **new_kwargs)
 
-    def step(self, x, y, batch_idx) -> Dict[str, torch.Tensor]:
+    def step(self, x, y, batch_idx) -> dict[str, torch.Tensor]:
         """
         Take training / validation step.
         """
@@ -343,8 +343,8 @@ class NBeats(BaseModel):
 
     def plot_interpretation(
         self,
-        x: Dict[str, torch.Tensor],
-        output: Dict[str, torch.Tensor],
+        x: dict[str, torch.Tensor],
+        output: dict[str, torch.Tensor],
         idx: int,
         ax=None,
         plot_seasonality_and_generic_on_secondary_axis: bool = False,

--- a/pytorch_forecasting/models/nbeats/sub_modules.py
+++ b/pytorch_forecasting/models/nbeats/sub_modules.py
@@ -2,8 +2,6 @@
 Implementation of ``nn.Modules`` for N-Beats model.
 """
 
-from typing import Tuple
-
 import numpy as np
 import torch
 import torch.nn as nn
@@ -20,7 +18,7 @@ def linear(input_size, output_size, bias=True, dropout: int = None):
 
 def linspace(
     backcast_length: int, forecast_length: int, centered: bool = False
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     if centered:
         norm = max(backcast_length, forecast_length)
         start = -backcast_length
@@ -130,7 +128,7 @@ class NBEATSSeasonalBlock(NBEATSBlock):
         )
         self.register_buffer("S_forecast", torch.cat([s1_f, s2_f]))
 
-    def forward(self, x) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, x) -> tuple[torch.Tensor, torch.Tensor]:
         x = super().forward(x)
         amplitudes_backward = self.theta_b_fc(x)
         backcast = amplitudes_backward.mm(self.S_backcast)
@@ -183,7 +181,7 @@ class NBEATSTrendBlock(NBEATSBlock):
         )
         self.register_buffer("T_forecast", coefficients * norm)
 
-    def forward(self, x) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, x) -> tuple[torch.Tensor, torch.Tensor]:
         x = super().forward(x)
         backcast = self.theta_b_fc(x).mm(self.T_backcast)
         forecast = self.theta_f_fc(x).mm(self.T_forecast)

--- a/pytorch_forecasting/models/nhits/_nhits.py
+++ b/pytorch_forecasting/models/nhits/_nhits.py
@@ -3,7 +3,7 @@ N-HiTS model for timeseries forecasting with covariates.
 """
 
 from copy import copy
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -30,19 +30,19 @@ from pytorch_forecasting.utils._dependencies import _check_matplotlib
 class NHiTS(BaseModelWithCovariates):
     def __init__(
         self,
-        output_size: Union[int, List[int]] = 1,
-        static_categoricals: Optional[List[str]] = None,
-        static_reals: Optional[List[str]] = None,
-        time_varying_categoricals_encoder: Optional[List[str]] = None,
-        time_varying_categoricals_decoder: Optional[List[str]] = None,
-        categorical_groups: Optional[Dict[str, List[str]]] = None,
-        time_varying_reals_encoder: Optional[List[str]] = None,
-        time_varying_reals_decoder: Optional[List[str]] = None,
-        embedding_sizes: Optional[Dict[str, Tuple[int, int]]] = None,
-        embedding_paddings: Optional[List[str]] = None,
-        embedding_labels: Optional[List[str]] = None,
-        x_reals: Optional[List[str]] = None,
-        x_categoricals: Optional[List[str]] = None,
+        output_size: Union[int, list[int]] = 1,
+        static_categoricals: Optional[list[str]] = None,
+        static_reals: Optional[list[str]] = None,
+        time_varying_categoricals_encoder: Optional[list[str]] = None,
+        time_varying_categoricals_decoder: Optional[list[str]] = None,
+        categorical_groups: Optional[dict[str, list[str]]] = None,
+        time_varying_reals_encoder: Optional[list[str]] = None,
+        time_varying_reals_decoder: Optional[list[str]] = None,
+        embedding_sizes: Optional[dict[str, tuple[int, int]]] = None,
+        embedding_paddings: Optional[list[str]] = None,
+        embedding_labels: Optional[list[str]] = None,
+        x_reals: Optional[list[str]] = None,
+        x_categoricals: Optional[list[str]] = None,
         context_length: int = 1,
         prediction_length: int = 1,
         static_hidden_size: Optional[int] = None,
@@ -50,11 +50,11 @@ class NHiTS(BaseModelWithCovariates):
         shared_weights: bool = True,
         activation: str = "ReLU",
         initialization: str = "lecun_normal",
-        n_blocks: Optional[List[str]] = None,
-        n_layers: Union[int, List[int]] = 2,
+        n_blocks: Optional[list[str]] = None,
+        n_layers: Union[int, list[int]] = 2,
         hidden_size: int = 512,
-        pooling_sizes: Optional[List[int]] = None,
-        downsample_frequencies: Optional[List[int]] = None,
+        pooling_sizes: Optional[list[int]] = None,
+        downsample_frequencies: Optional[list[int]] = None,
         pooling_mode: str = "max",
         interpolation_mode: str = "linear",
         batch_normalization: bool = False,
@@ -291,7 +291,7 @@ class NHiTS(BaseModelWithCovariates):
         """
         return len(self.hparams.n_blocks)
 
-    def forward(self, x: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    def forward(self, x: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Pass forward of network.
 
@@ -446,7 +446,7 @@ class NHiTS(BaseModelWithCovariates):
         # initialize class
         return super().from_dataset(dataset, **new_kwargs)
 
-    def step(self, x, y, batch_idx) -> Dict[str, torch.Tensor]:
+    def step(self, x, y, batch_idx) -> dict[str, torch.Tensor]:
         """
         Take training / validation step.
         """
@@ -500,8 +500,8 @@ class NHiTS(BaseModelWithCovariates):
 
     def plot_interpretation(
         self,
-        x: Dict[str, torch.Tensor],
-        output: Dict[str, torch.Tensor],
+        x: dict[str, torch.Tensor],
+        output: dict[str, torch.Tensor],
         idx: int,
         ax=None,
     ):

--- a/pytorch_forecasting/models/nhits/sub_modules.py
+++ b/pytorch_forecasting/models/nhits/sub_modules.py
@@ -1,5 +1,4 @@
 from functools import partial
-from typing import List, Tuple
 
 import numpy as np
 import torch
@@ -38,7 +37,7 @@ class IdentityBasis(nn.Module):
         forecast_theta: torch.Tensor,
         encoder_x_t: torch.Tensor,
         decoder_x_t: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         backcast = backcast_theta
         knots = forecast_theta
 
@@ -108,7 +107,7 @@ class NHiTSBlock(nn.Module):
         static_size: int,
         static_hidden_size: int,
         n_theta: int,
-        hidden_size: List[int],
+        hidden_size: list[int],
         pooling_sizes: int,
         pooling_mode: str,
         basis: nn.Module,
@@ -203,7 +202,7 @@ class NHiTSBlock(nn.Module):
         encoder_x_t: torch.Tensor,
         decoder_x_t: torch.Tensor,
         x_s: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         batch_size = len(encoder_y)
 
         encoder_y = encoder_y.transpose(1, 2)

--- a/pytorch_forecasting/models/nn/embeddings.py
+++ b/pytorch_forecasting/models/nn/embeddings.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -38,11 +38,11 @@ class MultiEmbedding(nn.Module):
     def __init__(
         self,
         embedding_sizes: Union[
-            Dict[str, Tuple[int, int]], Dict[str, int], List[int], List[Tuple[int, int]]
+            dict[str, tuple[int, int]], dict[str, int], list[int], list[tuple[int, int]]
         ],
-        x_categoricals: List[str] = None,
-        categorical_groups: Optional[Dict[str, List[str]]] = None,
-        embedding_paddings: Optional[List[str]] = None,
+        x_categoricals: list[str] = None,
+        categorical_groups: Optional[dict[str, list[str]]] = None,
+        embedding_paddings: Optional[list[str]] = None,
         max_embedding_size: int = None,
     ):
         """Embedding layer for categorical variables including groups of categorical variables.
@@ -179,13 +179,13 @@ class MultiEmbedding(nn.Module):
         return len(self.x_categoricals)
 
     @property
-    def output_size(self) -> Union[Dict[str, int], int]:
+    def output_size(self) -> Union[dict[str, int], int]:
         if self.concat_output:
             return sum([s[1] for s in self.embedding_sizes.values()])
         else:
             return {name: s[1] for name, s in self.embedding_sizes.items()}
 
-    def forward(self, x: torch.Tensor) -> Dict[str, torch.Tensor]:
+    def forward(self, x: torch.Tensor) -> dict[str, torch.Tensor]:
         """
         Args:
             x (torch.Tensor): input tensor of shape batch x (optional) time x categoricals in the order of

--- a/pytorch_forecasting/models/nn/rnn.py
+++ b/pytorch_forecasting/models/nn/rnn.py
@@ -3,13 +3,13 @@ Implementations of flexible GRU and LSTM that can handle sequences of length 0.
 """
 
 from abc import ABC, abstractmethod
-from typing import Tuple, Type, Union
+from typing import Union
 
 import torch
 from torch import nn
 from torch.nn.utils import rnn
 
-HiddenState = Union[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]
+HiddenState = Union[tuple[torch.Tensor, torch.Tensor], torch.Tensor]
 
 
 class RNN(ABC, nn.RNNBase):
@@ -74,7 +74,7 @@ class RNN(ABC, nn.RNNBase):
         hx: HiddenState = None,
         lengths: torch.LongTensor = None,
         enforce_sorted: bool = True,
-    ) -> Tuple[Union[rnn.PackedSequence, torch.Tensor], HiddenState]:
+    ) -> tuple[Union[rnn.PackedSequence, torch.Tensor], HiddenState]:
         """
         Forward function of rnn that allows zero-length sequences.
 
@@ -226,7 +226,7 @@ class GRU(RNN, nn.GRU):
         return hidden_state.repeat_interleave(n_samples, 1)
 
 
-def get_rnn(cell_type: Union[Type[RNN], str]) -> Type[RNN]:
+def get_rnn(cell_type: Union[type[RNN], str]) -> type[RNN]:
     """
     Get LSTM or GRU.
 

--- a/pytorch_forecasting/models/rnn/_rnn.py
+++ b/pytorch_forecasting/models/rnn/_rnn.py
@@ -3,7 +3,7 @@ Simple recurrent model - either with LSTM or GRU cells.
 """
 
 from copy import copy
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -33,21 +33,21 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
         hidden_size: int = 10,
         rnn_layers: int = 2,
         dropout: float = 0.1,
-        static_categoricals: Optional[List[str]] = None,
-        static_reals: Optional[List[str]] = None,
-        time_varying_categoricals_encoder: Optional[List[str]] = None,
-        time_varying_categoricals_decoder: Optional[List[str]] = None,
-        categorical_groups: Optional[Dict[str, List[str]]] = None,
-        time_varying_reals_encoder: Optional[List[str]] = None,
-        time_varying_reals_decoder: Optional[List[str]] = None,
-        embedding_sizes: Optional[Dict[str, Tuple[int, int]]] = None,
-        embedding_paddings: Optional[List[str]] = None,
-        embedding_labels: Optional[Dict[str, np.ndarray]] = None,
-        x_reals: Optional[List[str]] = None,
-        x_categoricals: Optional[List[str]] = None,
-        output_size: Union[int, List[int]] = 1,
-        target: Union[str, List[str]] = None,
-        target_lags: Optional[Dict[str, List[int]]] = None,
+        static_categoricals: Optional[list[str]] = None,
+        static_reals: Optional[list[str]] = None,
+        time_varying_categoricals_encoder: Optional[list[str]] = None,
+        time_varying_categoricals_decoder: Optional[list[str]] = None,
+        categorical_groups: Optional[dict[str, list[str]]] = None,
+        time_varying_reals_encoder: Optional[list[str]] = None,
+        time_varying_reals_decoder: Optional[list[str]] = None,
+        embedding_sizes: Optional[dict[str, tuple[int, int]]] = None,
+        embedding_paddings: Optional[list[str]] = None,
+        embedding_labels: Optional[dict[str, np.ndarray]] = None,
+        x_reals: Optional[list[str]] = None,
+        x_categoricals: Optional[list[str]] = None,
+        output_size: Union[int, list[int]] = 1,
+        target: Union[str, list[str]] = None,
+        target_lags: Optional[dict[str, list[int]]] = None,
         loss: MultiHorizonMetric = None,
         logging_metrics: nn.ModuleList = None,
         **kwargs,
@@ -184,7 +184,7 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
     def from_dataset(
         cls,
         dataset: TimeSeriesDataSet,
-        allowed_encoder_known_variable_names: List[str] = None,
+        allowed_encoder_known_variable_names: list[str] = None,
         **kwargs,
     ):
         """
@@ -254,7 +254,7 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
         # shift target
         return input_vector
 
-    def encode(self, x: Dict[str, torch.Tensor]) -> HiddenState:
+    def encode(self, x: dict[str, torch.Tensor]) -> HiddenState:
         """
         Encode sequence into hidden state
         """
@@ -289,7 +289,7 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
         decoder_lengths: torch.Tensor,
         hidden_state: HiddenState,
         n_samples: int = None,
-    ) -> Tuple[torch.Tensor, bool]:
+    ) -> tuple[torch.Tensor, bool]:
         """
         Decode hidden state of RNN into prediction. If n_smaples is given,
         decode not by using actual values but rather by
@@ -333,8 +333,8 @@ class RecurrentNetwork(AutoRegressiveBaseModelWithCovariates):
         return output
 
     def forward(
-        self, x: Dict[str, torch.Tensor], n_samples: int = None
-    ) -> Dict[str, torch.Tensor]:
+        self, x: dict[str, torch.Tensor], n_samples: int = None
+    ) -> dict[str, torch.Tensor]:
         """
         Forward network
         """

--- a/pytorch_forecasting/models/temporal_fusion_transformer/_tft.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/_tft.py
@@ -3,7 +3,7 @@ The temporal fusion transformer is a powerful predictive model for forecasting t
 """  # noqa: E501
 
 from copy import copy
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -132,30 +132,30 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         hidden_size: int = 16,
         lstm_layers: int = 1,
         dropout: float = 0.1,
-        output_size: Union[int, List[int]] = 7,
+        output_size: Union[int, list[int]] = 7,
         loss: MultiHorizonMetric = None,
         attention_head_size: int = 4,
         max_encoder_length: int = 10,
-        static_categoricals: Optional[List[str]] = None,
-        static_reals: Optional[List[str]] = None,
-        time_varying_categoricals_encoder: Optional[List[str]] = None,
-        time_varying_categoricals_decoder: Optional[List[str]] = None,
-        categorical_groups: Optional[Union[Dict, List[str]]] = None,
-        time_varying_reals_encoder: Optional[List[str]] = None,
-        time_varying_reals_decoder: Optional[List[str]] = None,
-        x_reals: Optional[List[str]] = None,
-        x_categoricals: Optional[List[str]] = None,
+        static_categoricals: Optional[list[str]] = None,
+        static_reals: Optional[list[str]] = None,
+        time_varying_categoricals_encoder: Optional[list[str]] = None,
+        time_varying_categoricals_decoder: Optional[list[str]] = None,
+        categorical_groups: Optional[Union[dict, list[str]]] = None,
+        time_varying_reals_encoder: Optional[list[str]] = None,
+        time_varying_reals_decoder: Optional[list[str]] = None,
+        x_reals: Optional[list[str]] = None,
+        x_categoricals: Optional[list[str]] = None,
         hidden_continuous_size: int = 8,
-        hidden_continuous_sizes: Optional[Dict[str, int]] = None,
-        embedding_sizes: Optional[Dict[str, Tuple[int, int]]] = None,
-        embedding_paddings: Optional[List[str]] = None,
-        embedding_labels: Optional[Dict[str, np.ndarray]] = None,
+        hidden_continuous_sizes: Optional[dict[str, int]] = None,
+        embedding_sizes: Optional[dict[str, tuple[int, int]]] = None,
+        embedding_paddings: Optional[list[str]] = None,
+        embedding_labels: Optional[dict[str, np.ndarray]] = None,
         learning_rate: float = 1e-3,
         log_interval: Union[int, float] = -1,
         log_val_interval: Union[int, float] = None,
         log_gradient_flow: bool = False,
         reduce_on_plateau_patience: int = 1000,
-        monotone_constaints: Optional[Dict[str, int]] = None,
+        monotone_constaints: Optional[dict[str, int]] = None,
         share_single_variable_networks: bool = False,
         causal_attention: bool = True,
         logging_metrics: nn.ModuleList = None,
@@ -437,7 +437,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
     def from_dataset(
         cls,
         dataset: TimeSeriesDataSet,
-        allowed_encoder_known_variable_names: List[str] = None,
+        allowed_encoder_known_variable_names: list[str] = None,
         **kwargs,
     ):
         """
@@ -520,7 +520,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
         )
         return mask
 
-    def forward(self, x: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    def forward(self, x: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         input dimensions: n_samples x time x variables
         """
@@ -698,10 +698,10 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
 
     def interpret_output(
         self,
-        out: Dict[str, torch.Tensor],
+        out: dict[str, torch.Tensor],
         reduction: str = "none",
         attention_prediction_horizon: int = 0,
-    ) -> Dict[str, torch.Tensor]:
+    ) -> dict[str, torch.Tensor]:
         """
         interpret output of model
 
@@ -858,8 +858,8 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
 
     def plot_prediction(
         self,
-        x: Dict[str, torch.Tensor],
-        out: Dict[str, torch.Tensor],
+        x: dict[str, torch.Tensor],
+        out: dict[str, torch.Tensor],
         idx: int,
         plot_attention: bool = True,
         add_loss_to_title: bool = False,
@@ -910,7 +910,7 @@ class TemporalFusionTransformer(BaseModelWithCovariates):
                 f.tight_layout()
         return fig
 
-    def plot_interpretation(self, interpretation: Dict[str, torch.Tensor]):
+    def plot_interpretation(self, interpretation: dict[str, torch.Tensor]):
         """
         Make figures that interpret model.
 

--- a/pytorch_forecasting/models/temporal_fusion_transformer/_tft_v2.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/_tft_v2.py
@@ -3,7 +3,7 @@
 # experimental, please use with care.
 ########################################################################################
 
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -16,16 +16,16 @@ class TFT(BaseModel):
     def __init__(
         self,
         loss: nn.Module,
-        logging_metrics: Optional[List[nn.Module]] = None,
+        logging_metrics: Optional[list[nn.Module]] = None,
         optimizer: Optional[Union[Optimizer, str]] = "adam",
-        optimizer_params: Optional[Dict] = None,
+        optimizer_params: Optional[dict] = None,
         lr_scheduler: Optional[str] = None,
-        lr_scheduler_params: Optional[Dict] = None,
+        lr_scheduler_params: Optional[dict] = None,
         hidden_size: int = 64,
         num_layers: int = 2,
         attention_head_size: int = 4,
         dropout: float = 0.1,
-        metadata: Optional[Dict] = None,
+        metadata: Optional[dict] = None,
         output_size: int = 1,
     ):
         super().__init__(
@@ -110,7 +110,7 @@ class TFT(BaseModel):
         self.pre_output = nn.Linear(hidden_size, hidden_size)
         self.output_layer = nn.Linear(hidden_size, self.output_size)
 
-    def forward(self, x: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    def forward(self, x: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Forward pass of the TFT model.
 

--- a/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/sub_modules.py
@@ -4,7 +4,6 @@ Implementation of ``nn.Modules`` for temporal fusion transformer.
 
 from copy import deepcopy
 import math
-from typing import Dict, Tuple
 
 import torch
 import torch.nn as nn
@@ -282,13 +281,13 @@ class GatedResidualNetwork(nn.Module):
 class VariableSelectionNetwork(nn.Module):
     def __init__(
         self,
-        input_sizes: Dict[str, int],
+        input_sizes: dict[str, int],
         hidden_size: int,
-        input_embedding_flags: Dict[str, bool] = None,
+        input_embedding_flags: dict[str, bool] = None,
         dropout: float = 0.1,
         context_size: int = None,
-        single_variable_grns: Dict[str, GatedResidualNetwork] = None,
-        prescalers: Dict[str, nn.Linear] = None,
+        single_variable_grns: dict[str, GatedResidualNetwork] = None,
+        prescalers: dict[str, nn.Linear] = None,
     ):
         """
         Calculate weights for ``num_inputs`` variables  which are each of size
@@ -361,7 +360,7 @@ class VariableSelectionNetwork(nn.Module):
     def num_inputs(self):
         return len(self.input_sizes)
 
-    def forward(self, x: Dict[str, torch.Tensor], context: torch.Tensor = None):
+    def forward(self, x: dict[str, torch.Tensor], context: torch.Tensor = None):
         if self.num_inputs > 1:
             # transform single variables
             var_outputs = []
@@ -451,7 +450,7 @@ class ScaledDotProductAttention(nn.Module):
     """
 
     def __init__(self, dropout: float = None, scale: bool = True, mask_bias=-1e9):
-        super(ScaledDotProductAttention, self).__init__()
+        super().__init__()
         if dropout is not None:
             self.dropout = nn.Dropout(p=dropout)
         else:
@@ -496,7 +495,7 @@ class InterpretableMultiHeadAttention(nn.Module):
     """
 
     def __init__(self, n_head: int, d_model: int, dropout: float = 0.0, mask_bias=-1e9):
-        super(InterpretableMultiHeadAttention, self).__init__()
+        super().__init__()
 
         self.n_head = n_head
         self.d_model = d_model
@@ -523,7 +522,7 @@ class InterpretableMultiHeadAttention(nn.Module):
             else:
                 torch.nn.init.zeros_(p)
 
-    def forward(self, q, k, v, mask=None) -> Tuple[torch.Tensor, torch.Tensor]:
+    def forward(self, q, k, v, mask=None) -> tuple[torch.Tensor, torch.Tensor]:
         heads = []
         attns = []
         vs = self.v_layer(v)

--- a/pytorch_forecasting/models/temporal_fusion_transformer/tuning.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/tuning.py
@@ -5,7 +5,7 @@ Hyperparameters can be efficiently tuned with `optuna <https://optuna.readthedoc
 import copy
 import logging
 import os
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Union
 
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks import LearningRateMonitor, ModelCheckpoint
@@ -29,14 +29,14 @@ def optimize_hyperparameters(
     max_epochs: int = 20,
     n_trials: int = 100,
     timeout: float = 3600 * 8.0,  # 8 hours
-    gradient_clip_val_range: Tuple[float, float] = (0.01, 100.0),
-    hidden_size_range: Tuple[int, int] = (16, 265),
-    hidden_continuous_size_range: Tuple[int, int] = (8, 64),
-    attention_head_size_range: Tuple[int, int] = (1, 4),
-    dropout_range: Tuple[float, float] = (0.1, 0.3),
-    learning_rate_range: Tuple[float, float] = (1e-5, 1.0),
+    gradient_clip_val_range: tuple[float, float] = (0.01, 100.0),
+    hidden_size_range: tuple[int, int] = (16, 265),
+    hidden_continuous_size_range: tuple[int, int] = (8, 64),
+    attention_head_size_range: tuple[int, int] = (1, 4),
+    dropout_range: tuple[float, float] = (0.1, 0.3),
+    learning_rate_range: tuple[float, float] = (1e-5, 1.0),
     use_learning_rate_finder: bool = True,
-    trainer_kwargs: Dict[str, Any] = {},
+    trainer_kwargs: dict[str, Any] = {},
     log_dir: str = "lightning_logs",
     study=None,
     verbose: Union[int, bool] = None,
@@ -132,7 +132,7 @@ def optimize_hyperparameters(
         # Filenames for each trial must be made unique
         # in order to access each checkpoint.
         checkpoint_callback = ModelCheckpoint(
-            dirpath=os.path.join(model_path, "trial_{}".format(trial.number)),
+            dirpath=os.path.join(model_path, f"trial_{trial.number}"),
             filename="{epoch}",
             monitor="val_loss",
         )

--- a/pytorch_forecasting/models/tide/_tide.py
+++ b/pytorch_forecasting/models/tide/_tide.py
@@ -4,7 +4,7 @@ long-term time-series forecasting.
 """
 
 from copy import copy
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import torch
 from torch import nn
@@ -31,19 +31,19 @@ class TiDEModel(BaseModelWithCovariates):
         temporal_decoder_hidden: int = 32,
         use_layer_norm: bool = False,
         dropout: float = 0.1,
-        output_size: Union[int, List[int]] = 1,
-        static_categoricals: Optional[List[str]] = None,
-        static_reals: Optional[List[str]] = None,
-        time_varying_categoricals_encoder: Optional[List[str]] = None,
-        time_varying_categoricals_decoder: Optional[List[str]] = None,
-        categorical_groups: Optional[Dict[str, List[str]]] = None,
-        time_varying_reals_encoder: Optional[List[str]] = None,
-        time_varying_reals_decoder: Optional[List[str]] = None,
-        embedding_sizes: Optional[Dict[str, Tuple[int, int]]] = None,
-        embedding_paddings: Optional[List[str]] = None,
-        embedding_labels: Optional[List[str]] = None,
-        x_reals: Optional[List[str]] = None,
-        x_categoricals: Optional[List[str]] = None,
+        output_size: Union[int, list[int]] = 1,
+        static_categoricals: Optional[list[str]] = None,
+        static_reals: Optional[list[str]] = None,
+        time_varying_categoricals_encoder: Optional[list[str]] = None,
+        time_varying_categoricals_decoder: Optional[list[str]] = None,
+        categorical_groups: Optional[dict[str, list[str]]] = None,
+        time_varying_reals_encoder: Optional[list[str]] = None,
+        time_varying_reals_decoder: Optional[list[str]] = None,
+        embedding_sizes: Optional[dict[str, tuple[int, int]]] = None,
+        embedding_paddings: Optional[list[str]] = None,
+        embedding_labels: Optional[list[str]] = None,
+        x_reals: Optional[list[str]] = None,
+        x_categoricals: Optional[list[str]] = None,
         logging_metrics: nn.ModuleList = None,
         **kwargs,
     ):
@@ -260,7 +260,7 @@ class TiDEModel(BaseModelWithCovariates):
         # initialize class
         return super().from_dataset(dataset, **new_kwargs)
 
-    def forward(self, x: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+    def forward(self, x: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """
         Pass forward of network.
 

--- a/pytorch_forecasting/models/tide/sub_modules.py
+++ b/pytorch_forecasting/models/tide/sub_modules.py
@@ -3,12 +3,12 @@ Time-series Dense Encoder (TiDE)
 --------------------------------
 """
 
-from typing import Optional, Tuple
+from typing import Optional
 
 import torch
 import torch.nn as nn
 
-MixedCovariatesTrainTensorType = Tuple[
+MixedCovariatesTrainTensorType = tuple[
     torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
 ]
 
@@ -223,7 +223,7 @@ class _TideModule(nn.Module):
         )
 
     def forward(
-        self, x_in: Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]
+        self, x_in: tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]
     ) -> torch.Tensor:
         """TiDE model forward pass.
 

--- a/pytorch_forecasting/utils/_dependencies/_dependencies.py
+++ b/pytorch_forecasting/utils/_dependencies/_dependencies.py
@@ -58,10 +58,8 @@ def _check_matplotlib(ref="This feature", raise_error=True):
 
     if raise_error and "matplotlib" not in pkgs:
         raise ImportError(
-            (
-                f"{ref} requires matplotlib."
-                " Please install matplotlib with `pip install matplotlib`."
-            )
+            f"{ref} requires matplotlib."
+            " Please install matplotlib with `pip install matplotlib`."
         )
 
     return "matplotlib" in pkgs

--- a/pytorch_forecasting/utils/_utils.py
+++ b/pytorch_forecasting/utils/_utils.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 from contextlib import redirect_stdout
 import inspect
 import os
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Union
 
 import lightning.pytorch as pl
 import torch
@@ -47,7 +47,7 @@ def groupby_apply(
     bins: int = 95,
     reduction: str = "mean",
     return_histogram: bool = False,
-) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
     """
     Groupby apply for torch tensors
 
@@ -234,7 +234,7 @@ def autocorrelation(input, dim=0):
 
 def unpack_sequence(
     sequence: Union[torch.Tensor, rnn.PackedSequence],
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Unpack RNN sequence.
 
@@ -257,7 +257,7 @@ def unpack_sequence(
 
 
 def concat_sequences(
-    sequences: Union[List[torch.Tensor], List[rnn.PackedSequence]],
+    sequences: Union[list[torch.Tensor], list[rnn.PackedSequence]],
 ) -> Union[torch.Tensor, rnn.PackedSequence]:
     """
     Concatenate RNN sequences.
@@ -283,7 +283,7 @@ def concat_sequences(
 
 
 def padded_stack(
-    tensors: List[torch.Tensor],
+    tensors: list[torch.Tensor],
     side: str = "right",
     mode: str = "constant",
     value: Union[int, float] = 0,
@@ -324,7 +324,7 @@ def padded_stack(
     return out
 
 
-def to_list(value: Any) -> List[Any]:
+def to_list(value: Any) -> list[Any]:
     """
     Convert value or list to list of values.
     If already list, return object directly
@@ -358,7 +358,7 @@ def unsqueeze_like(tensor: torch.Tensor, like: torch.Tensor):
         return tensor[(...,) + (None,) * n_unsqueezes]
 
 
-def apply_to_list(obj: Union[List[Any], Any], func: Callable) -> Union[List[Any], Any]:
+def apply_to_list(obj: Union[list[Any], Any], func: Callable) -> Union[list[Any], Any]:
     """
     Apply function to a list of objects or directly if passed value is not a list.
 
@@ -439,17 +439,17 @@ class TupleOutputMixIn:
 
 def move_to_device(
     x: Union[
-        Dict[str, Union[torch.Tensor, List[torch.Tensor], Tuple[torch.Tensor]]],
+        dict[str, Union[torch.Tensor, list[torch.Tensor], tuple[torch.Tensor]]],
         torch.Tensor,
-        List[torch.Tensor],
-        Tuple[torch.Tensor],
+        list[torch.Tensor],
+        tuple[torch.Tensor],
     ],
     device: Union[str, torch.DeviceObjType],
 ) -> Union[
-    Dict[str, Union[torch.Tensor, List[torch.Tensor], Tuple[torch.Tensor]]],
+    dict[str, Union[torch.Tensor, list[torch.Tensor], tuple[torch.Tensor]]],
     torch.Tensor,
-    List[torch.Tensor],
-    Tuple[torch.Tensor],
+    list[torch.Tensor],
+    tuple[torch.Tensor],
 ]:
     """
     Move object to device.
@@ -486,16 +486,16 @@ def move_to_device(
 
 def detach(
     x: Union[
-        Dict[str, Union[torch.Tensor, List[torch.Tensor], Tuple[torch.Tensor]]],
+        dict[str, Union[torch.Tensor, list[torch.Tensor], tuple[torch.Tensor]]],
         torch.Tensor,
-        List[torch.Tensor],
-        Tuple[torch.Tensor],
+        list[torch.Tensor],
+        tuple[torch.Tensor],
     ],
 ) -> Union[
-    Dict[str, Union[torch.Tensor, List[torch.Tensor], Tuple[torch.Tensor]]],
+    dict[str, Union[torch.Tensor, list[torch.Tensor], tuple[torch.Tensor]]],
     torch.Tensor,
-    List[torch.Tensor],
-    Tuple[torch.Tensor],
+    list[torch.Tensor],
+    tuple[torch.Tensor],
 ]:
     """
     Detach object
@@ -547,9 +547,9 @@ def masked_op(
 
 def repr_class(
     obj,
-    attributes: Union[List[str], Dict[str, Any]],
+    attributes: Union[list[str], dict[str, Any]],
     max_characters_before_break: int = 100,
-    extra_attributes: Dict[str, Any] = None,
+    extra_attributes: dict[str, Any] = None,
 ) -> str:
     """Print class name and parameters.
 

--- a/tests/test_data/test_timeseries.py
+++ b/tests/test_data/test_timeseries.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 import pickle
-from typing import Dict
 
 import numpy as np
 import pandas as pd
@@ -97,7 +96,7 @@ def test_pickle(test_dataset):
     pickle.dumps(test_dataset.to_dataloader())
 
 
-def check_dataloader_output(dataset: TimeSeriesDataSet, out: Dict[str, torch.Tensor]):
+def check_dataloader_output(dataset: TimeSeriesDataSet, out: dict[str, torch.Tensor]):
     x, y = out
 
     assert isinstance(y, tuple), "y output should be tuple of wegith and target"


### PR DESCRIPTION
### Description

This PR updates the ruff hook in ./pre-commit-config.yaml to include the --extend-select=UP argument, adding the UP rule group so that PyUpgrade’s syntax checks (codes starting with UP) are enforced; this enables Ruff to detect and auto-fix PyUpgrade suggestions—such as modernizing f-strings and removing deprecated syntax.

### Checklist

- [ ] Linked issues (if existing)
- [ ] Amended changelog for large changes (and added myself there as contributor)
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
      To run hooks independent of commit, execute `pre-commit run --all-files`

Make sure to have fun coding!
