### PR TITLE
[ENH] refactor test metadata container to include data loader configs

### DIFF
--- a/pytorch_forecasting/models/deepar/_deepar_metadata.py
+++ b/pytorch_forecasting/models/deepar/_deepar_metadata.py
@@ -153,11 +153,9 @@ class DeepARMetadata(_BasePtForecaster):
         if "loss" in trainer_kwargs and isinstance(
             trainer_kwargs["loss"], NegativeBinomialDistributionLoss
         ):
-            data_with_covariates = data_with_covariates.assign(
-                volume=lambda x: x.volume.round()
-            )
+            dwc = dwc.assign(volume=lambda x: x.volume.round())
 
-        data_with_covariates = data_with_covariates.copy()
+        dwc = dwc.copy()
         if clip_target:
             dwc["target"] = dwc["volume"].clip(1e-3, 1.0)
         else:

--- a/pytorch_forecasting/models/deepar/_deepar_metadata.py
+++ b/pytorch_forecasting/models/deepar/_deepar_metadata.py
@@ -136,9 +136,9 @@ class DeepARMetadata(_BasePtForecaster):
 
         Returns
         -------
-        dataloaders : tuple of three torch.utils.data.DataLoader
-            List of dataloaders created from the parameters.
-            Train, validation, and test dataloaders, in this order.
+        dataloaders : dict with keys "train", "val", "test", values torch DataLoader
+            Dict of dataloaders created from the parameters.
+            Train, validation, and test dataloaders.
         """
         trainer_kwargs = params.get("trainer_kwargs", {})
         clip_target = params.get("clip_target", False)

--- a/pytorch_forecasting/models/deepar/_deepar_metadata.py
+++ b/pytorch_forecasting/models/deepar/_deepar_metadata.py
@@ -157,7 +157,6 @@ class DeepARMetadata(_BasePtForecaster):
                 volume=lambda x: x.volume.round()
             )
 
-
         data_with_covariates = data_with_covariates.copy()
         if clip_target:
             dwc["target"] = dwc["volume"].clip(1e-3, 1.0)

--- a/pytorch_forecasting/models/deepar/_deepar_metadata.py
+++ b/pytorch_forecasting/models/deepar/_deepar_metadata.py
@@ -140,7 +140,7 @@ class DeepARMetadata(_BasePtForecaster):
             Dict of dataloaders created from the parameters.
             Train, validation, and test dataloaders.
         """
-        trainer_kwargs = params.get("trainer_kwargs", {})
+        loss = params.get("loss", None)
         clip_target = params.get("clip_target", False)
         data_loader_kwargs = params.get("data_loader_kwargs", {})
 
@@ -150,9 +150,7 @@ class DeepARMetadata(_BasePtForecaster):
 
         dwc = data_with_covariates()
 
-        if "loss" in trainer_kwargs and isinstance(
-            trainer_kwargs["loss"], NegativeBinomialDistributionLoss
-        ):
+        if isinstance(loss, NegativeBinomialDistributionLoss):
             dwc = dwc.assign(volume=lambda x: x.volume.round())
 
         dwc = dwc.copy()

--- a/pytorch_forecasting/models/deepar/_deepar_metadata.py
+++ b/pytorch_forecasting/models/deepar/_deepar_metadata.py
@@ -45,9 +45,9 @@ class DeepARMetadata(_BasePtForecaster):
             NegativeBinomialDistributionLoss,
         )
 
-        return [
+        params = [
             {},
-            {"cell_type": "GRU", "n_plotting_samples": 100},
+            {"cell_type": "GRU"},
             dict(
                 loss=LogNormalDistributionLoss(),
                 clip_target=True,
@@ -56,8 +56,6 @@ class DeepARMetadata(_BasePtForecaster):
                         groups=["agency", "sku"], transformation="log"
                     )
                 ),
-                cell_type="LSTM",
-                n_plotting_samples=100,
             ),
             dict(
                 loss=NegativeBinomialDistributionLoss(),
@@ -67,8 +65,6 @@ class DeepARMetadata(_BasePtForecaster):
                         groups=["agency", "sku"], center=False
                     )
                 ),
-                cell_type="LSTM",
-                n_plotting_samples=100,
             ),
             dict(
                 loss=BetaDistributionLoss(),
@@ -78,8 +74,6 @@ class DeepARMetadata(_BasePtForecaster):
                         groups=["agency", "sku"], transformation="logit"
                     )
                 ),
-                cell_type="LSTM",
-                n_plotting_samples=100,
             ),
             dict(
                 data_loader_kwargs=dict(
@@ -88,8 +82,6 @@ class DeepARMetadata(_BasePtForecaster):
                     time_varying_unknown_reals=["volume"],
                     min_encoder_length=2,
                 ),
-                cell_type="LSTM",
-                n_plotting_samples=100,
             ),
             dict(
                 data_loader_kwargs=dict(
@@ -97,18 +89,12 @@ class DeepARMetadata(_BasePtForecaster):
                     target=["volume", "discount"],
                     lags={"volume": [2], "discount": [2]},
                 ),
-                cell_type="LSTM",
-                n_plotting_samples=100,
             ),
             dict(
                 loss=ImplicitQuantileNetworkDistributionLoss(hidden_size=8),
-                cell_type="LSTM",
-                n_plotting_samples=100,
             ),
             dict(
                 loss=MultivariateNormalDistributionLoss(),
-                cell_type="LSTM",
-                n_plotting_samples=100,
                 trainer_kwargs=dict(accelerator="cpu"),
             ),
             dict(
@@ -118,11 +104,17 @@ class DeepARMetadata(_BasePtForecaster):
                         groups=["agency", "sku"], transformation="log1p"
                     )
                 ),
-                cell_type="LSTM",
-                n_plotting_samples=100,
                 trainer_kwargs=dict(accelerator="cpu"),
             ),
         ]
+        defaults = {
+            "hidden_size": 5,
+            "cell_type": "LSTM",
+            "n_plotting_samples": 100,
+        }
+        for param in params:
+            param.update(defaults)
+        return params
 
     @classmethod
     def _get_test_dataloaders_from(cls, params):

--- a/pytorch_forecasting/models/nbeats/__init__.py
+++ b/pytorch_forecasting/models/nbeats/__init__.py
@@ -1,10 +1,17 @@
 """N-Beats model for timeseries forecasting without covariates."""
 
 from pytorch_forecasting.models.nbeats._nbeats import NBeats
+from pytorch_forecasting.models.nbeats._nbeats_metadata import NBeatsMetadata
 from pytorch_forecasting.models.nbeats.sub_modules import (
     NBEATSGenericBlock,
     NBEATSSeasonalBlock,
     NBEATSTrendBlock,
 )
 
-__all__ = ["NBeats", "NBEATSGenericBlock", "NBEATSSeasonalBlock", "NBEATSTrendBlock"]
+__all__ = [
+    "NBeats",
+    "NBEATSGenericBlock",
+    "NBeatsMetadata",
+    "NBEATSSeasonalBlock",
+    "NBEATSTrendBlock",
+]

--- a/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
@@ -39,6 +39,6 @@ class NBeatsMetadata(_BasePtForecaster):
         return [
             {
                 "backcast_loss_ratio": 1.0,
-                "add_relative_time_idx": True,
+                "add_relative_time_idx": False,
             }
         ]

--- a/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
@@ -55,7 +55,7 @@ class NBeatsMetadata(_BasePtForecaster):
             Train, validation, and test dataloaders, in this order.
         """
         from pytorch_forecasting.tests._conftest import (
-            dataloaders_fixed_window_without_covariates,
+            _dataloaders_fixed_window_without_covariates,
         )
 
-        return dataloaders_fixed_window_without_covariates()
+        return _dataloaders_fixed_window_without_covariates()

--- a/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
@@ -1,0 +1,39 @@
+"""NBeats metadata container."""
+
+from pytorch_forecasting.models.base._base_object import _BasePtForecaster
+
+
+class NBeatsMetadata(_BasePtForecaster):
+    """NBeats metadata container."""
+
+    _tags = {
+        "info:name": "NBeats",
+        "info:compute": 1,
+        "authors": ["jdb78"],
+        "capability:exogenous": False,
+        "capability:multivariate": False,
+        "capability:pred_int": False,
+        "capability:flexible_history_length": False,
+        "capability:cold_start": False,
+    }
+
+    @classmethod
+    def get_model_cls(cls):
+        """Get model class."""
+        from pytorch_forecasting.models import NBeats
+
+        return NBeats
+
+    @classmethod
+    def get_test_train_params(cls):
+        """Return testing parameter settings for the trainer.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        return [{"backcast_loss_ratio": 1.0}]

--- a/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
@@ -55,6 +55,7 @@ class NBeatsMetadata(_BasePtForecaster):
             Train, validation, and test dataloaders, in this order.
         """
         from pytorch_forecasting.tests._conftest import (
-            dataloaders_fixed_window_without_covariates
+            dataloaders_fixed_window_without_covariates,
         )
+
         return dataloaders_fixed_window_without_covariates

--- a/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
@@ -36,9 +36,25 @@ class NBeatsMetadata(_BasePtForecaster):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        return [
-            {
-                "backcast_loss_ratio": 1.0,
-                "add_relative_time_idx": False,
-            }
-        ]
+        return [{"backcast_loss_ratio": 1.0}]
+
+    @classmethod
+    def _get_test_dataloaders_from(cls, params):
+        """Get dataloaders from parameters.
+
+        Parameters
+        ----------
+        params : dict
+            Parameters to create dataloaders.
+            One of the elements in the list returned by ``get_test_train_params``.
+
+        Returns
+        -------
+        dataloaders : tuple of three torch.utils.data.DataLoader
+            List of dataloaders created from the parameters.
+            Train, validation, and test dataloaders, in this order.
+        """
+        from pytorch_forecasting.tests._conftest import (
+            dataloaders_fixed_window_without_covariates
+        )
+        return dataloaders_fixed_window_without_covariates

--- a/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
@@ -36,4 +36,9 @@ class NBeatsMetadata(_BasePtForecaster):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        return [{"backcast_loss_ratio": 1.0}]
+        return [
+            {
+                "backcast_loss_ratio": 1.0,
+                "add_relative_time_idx" : True,
+            }
+        ]

--- a/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
@@ -58,4 +58,4 @@ class NBeatsMetadata(_BasePtForecaster):
             dataloaders_fixed_window_without_covariates,
         )
 
-        return dataloaders_fixed_window_without_covariates
+        return dataloaders_fixed_window_without_covariates()

--- a/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
@@ -39,6 +39,6 @@ class NBeatsMetadata(_BasePtForecaster):
         return [
             {
                 "backcast_loss_ratio": 1.0,
-                "add_relative_time_idx" : True,
+                "add_relative_time_idx": True,
             }
         ]

--- a/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_metadata.py
@@ -50,8 +50,8 @@ class NBeatsMetadata(_BasePtForecaster):
 
         Returns
         -------
-        dataloaders : tuple of three torch.utils.data.DataLoader
-            List of dataloaders created from the parameters.
+        dataloaders : dict with keys "train", "val", "test", values torch DataLoader
+            Dict of dataloaders created from the parameters.
             Train, validation, and test dataloaders, in this order.
         """
         from pytorch_forecasting.tests._conftest import (

--- a/pytorch_forecasting/models/tide/_tide_metadata.py
+++ b/pytorch_forecasting/models/tide/_tide_metadata.py
@@ -37,7 +37,7 @@ class TiDEModelMetadata(_BasePtForecaster):
         from pytorch_forecasting.data.encoders import GroupNormalizer
         from pytorch_forecasting.metrics import SMAPE
 
-        return [
+        params = [
             {
                 "data_loader_kwargs": dict(
                     add_relative_time_idx=False,
@@ -61,6 +61,10 @@ class TiDEModelMetadata(_BasePtForecaster):
                 ),
             },
         ]
+        defaults = {"hidden_size": 5}
+        for param in params:
+            param.update(defaults)
+        return params
 
     @classmethod
     def _get_test_dataloaders_from(cls, params):

--- a/pytorch_forecasting/models/tide/_tide_metadata.py
+++ b/pytorch_forecasting/models/tide/_tide_metadata.py
@@ -74,9 +74,9 @@ class TiDEModelMetadata(_BasePtForecaster):
 
         Returns
         -------
-        dataloaders : tuple of three torch.utils.data.DataLoader
-            List of dataloaders created from the parameters.
-            Train, validation, and test dataloaders, in this order.
+        dataloaders : dict with keys "train", "val", "test", values torch DataLoader
+            Dict of dataloaders created from the parameters.
+            Train, validation, and test dataloaders.
         """
         trainer_kwargs = params.get("trainer_kwargs", {})
         clip_target = params.get("clip_target", False)

--- a/pytorch_forecasting/models/tide/_tide_metadata.py
+++ b/pytorch_forecasting/models/tide/_tide_metadata.py
@@ -61,3 +61,50 @@ class TiDEModelMetadata(_BasePtForecaster):
                 ),
             },
         ]
+
+    @classmethod
+    def _get_test_dataloaders_from(cls, params):
+        """Get dataloaders from parameters.
+
+        Parameters
+        ----------
+        params : dict
+            Parameters to create dataloaders.
+            One of the elements in the list returned by ``get_test_train_params``.
+
+        Returns
+        -------
+        dataloaders : tuple of three torch.utils.data.DataLoader
+            List of dataloaders created from the parameters.
+            Train, validation, and test dataloaders, in this order.
+        """
+        trainer_kwargs = params.get("trainer_kwargs", {})
+        clip_target = params.get("clip_target", False)
+        data_loader_kwargs = params.get("data_loader_kwargs", {})
+
+        from pytorch_forecasting.metrics import NegativeBinomialDistributionLoss
+        from pytorch_forecasting.tests._conftest import make_dataloaders
+        from pytorch_forecasting.tests._data_scenarios import data_with_covariates
+
+        dwc = data_with_covariates()
+
+        if "loss" in trainer_kwargs and isinstance(
+            trainer_kwargs["loss"], NegativeBinomialDistributionLoss
+        ):
+            dwc = dwc.assign(volume=lambda x: x.volume.round())
+
+        dwc = dwc.copy()
+        if clip_target:
+            dwc["target"] = dwc["volume"].clip(1e-3, 1.0)
+        else:
+            dwc["target"] = dwc["volume"]
+        data_loader_default_kwargs = dict(
+            target="target",
+            time_varying_known_reals=["price_actual"],
+            time_varying_unknown_reals=["target"],
+            static_categoricals=["agency"],
+            add_relative_time_idx=True,
+        )
+        data_loader_default_kwargs.update(data_loader_kwargs)
+        dataloaders_w_covariates = make_dataloaders(dwc, **data_loader_default_kwargs)
+        return dataloaders_w_covariates

--- a/pytorch_forecasting/tests/_conftest.py
+++ b/pytorch_forecasting/tests/_conftest.py
@@ -224,6 +224,10 @@ def dataloaders_multi_target(data_with_covariates):
 
 @pytest.fixture(scope="session")
 def dataloaders_fixed_window_without_covariates():
+    return _dataloaders_fixed_window_without_covariates()
+
+
+def _dataloaders_fixed_window_without_covariates():
     data = generate_ar_data(seasonality=10.0, timesteps=50, n_series=2)
     validation = data.series.iloc[:2]
 

--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -166,7 +166,16 @@ class BaseFixtureGenerator(_BaseFixtureGenerator):
         return all_train_kwargs, train_kwargs_names
 
 
-def _integration(estimator_cls, dataloaders, tmp_path, trainer_kwargs=None, **kwargs):
+def _integration(
+    estimator_cls,
+    dataloaders,
+    tmp_path,
+    trainer_kwargs=None,
+    data_loader_kwargs={},  # only present to capture and pop these from kwargs
+    clip_target: bool = False,  # only present to capture and pop these from kwargs
+    # todo: refactor this more cleanly to metadata class
+    **kwargs,
+):
     """Unified integration test for all estimators."""
     train_dataloader = dataloaders["train"]
     val_dataloader = dataloaders["val"]

--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -203,7 +203,6 @@ def _integration(
 
     net = estimator_cls.from_dataset(
         train_dataloader.dataset,
-        hidden_size=5,
         learning_rate=0.01,
         log_gradient_flow=True,
         log_interval=1000,

--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -10,7 +10,6 @@ from skbase.testing import BaseFixtureGenerator as _BaseFixtureGenerator
 
 from pytorch_forecasting._registry import all_objects
 from pytorch_forecasting.tests._config import EXCLUDE_ESTIMATORS, EXCLUDED_TESTS
-from pytorch_forecasting.tests._conftest import make_dataloaders
 
 # whether to test only estimators from modules that are changed w.r.t. main
 # default is False, can be set to True by pytest --only_changed_modules True flag
@@ -167,35 +166,11 @@ class BaseFixtureGenerator(_BaseFixtureGenerator):
         return all_train_kwargs, train_kwargs_names
 
 
-def _integration(
-    estimator_cls,
-    data_with_covariates,
-    tmp_path,
-    data_loader_kwargs={},
-    clip_target: bool = False,
-    trainer_kwargs=None,
-    **kwargs,
-):
-    data_with_covariates = data_with_covariates.copy()
-    if clip_target:
-        data_with_covariates["target"] = data_with_covariates["volume"].clip(1e-3, 1.0)
-    else:
-        data_with_covariates["target"] = data_with_covariates["volume"]
-    data_loader_default_kwargs = dict(
-        target="target",
-        time_varying_known_reals=["price_actual"],
-        time_varying_unknown_reals=["target"],
-        static_categoricals=["agency"],
-        add_relative_time_idx=True,
-    )
-    data_loader_default_kwargs.update(data_loader_kwargs)
-    dataloaders_with_covariates = make_dataloaders(
-        data_with_covariates, **data_loader_default_kwargs
-    )
-
-    train_dataloader = dataloaders_with_covariates["train"]
-    val_dataloader = dataloaders_with_covariates["val"]
-    test_dataloader = dataloaders_with_covariates["test"]
+def _integration(estimator_cls, dataloaders, tmp_path, trainer_kwargs=None, **kwargs):
+    """Unified integration test for all estimators."""
+    train_dataloader = dataloaders["train"]
+    val_dataloader = dataloaders["val"]
+    test_dataloader = dataloaders["test"]
 
     early_stop_callback = EarlyStopping(
         monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min"
@@ -275,17 +250,8 @@ class TestAllPtForecasters(PackageConfig, BaseFixtureGenerator):
         tmp_path,
     ):
         """Fails for certain, for testing."""
-        from pytorch_forecasting.metrics import NegativeBinomialDistributionLoss
-        from pytorch_forecasting.tests._data_scenarios import data_with_covariates
-
-        data_with_covariates = data_with_covariates()
 
         object_class = object_metadata.get_model_cls()
+        dataloaders = object_metadata._get_test_dataloaders_from(trainer_kwargs)
 
-        if "loss" in trainer_kwargs and isinstance(
-            trainer_kwargs["loss"], NegativeBinomialDistributionLoss
-        ):
-            data_with_covariates = data_with_covariates.assign(
-                volume=lambda x: x.volume.round()
-            )
-        _integration(object_class, data_with_covariates, tmp_path, **trainer_kwargs)
+        _integration(object_class, dataloaders, tmp_path, **trainer_kwargs)

--- a/tests/test_models/test_tide.py
+++ b/tests/test_models/test_tide.py
@@ -9,10 +9,102 @@ import pandas as pd
 import pytest
 
 from pytorch_forecasting.data.timeseries import TimeSeriesDataSet
-from pytorch_forecasting.metrics import MAE, SMAPE, QuantileLoss
+from pytorch_forecasting.metrics import SMAPE
 from pytorch_forecasting.models import TiDEModel
-from pytorch_forecasting.tests.test_all_estimators import _integration
+from pytorch_forecasting.tests._conftest import make_dataloaders
 from pytorch_forecasting.utils._dependencies import _get_installed_packages
+
+
+def _integration(
+    estimator_cls,
+    data_with_covariates,
+    tmp_path,
+    data_loader_kwargs={},
+    clip_target: bool = False,
+    trainer_kwargs=None,
+    **kwargs,
+):
+    data_with_covariates = data_with_covariates.copy()
+    if clip_target:
+        data_with_covariates["target"] = data_with_covariates["volume"].clip(1e-3, 1.0)
+    else:
+        data_with_covariates["target"] = data_with_covariates["volume"]
+    data_loader_default_kwargs = dict(
+        target="target",
+        time_varying_known_reals=["price_actual"],
+        time_varying_unknown_reals=["target"],
+        static_categoricals=["agency"],
+        add_relative_time_idx=True,
+    )
+    data_loader_default_kwargs.update(data_loader_kwargs)
+    dataloaders_with_covariates = make_dataloaders(
+        data_with_covariates, **data_loader_default_kwargs
+    )
+
+    train_dataloader = dataloaders_with_covariates["train"]
+    val_dataloader = dataloaders_with_covariates["val"]
+    test_dataloader = dataloaders_with_covariates["test"]
+
+    early_stop_callback = EarlyStopping(
+        monitor="val_loss", min_delta=1e-4, patience=1, verbose=False, mode="min"
+    )
+
+    logger = TensorBoardLogger(tmp_path)
+    if trainer_kwargs is None:
+        trainer_kwargs = {}
+    trainer = pl.Trainer(
+        max_epochs=3,
+        gradient_clip_val=0.1,
+        callbacks=[early_stop_callback],
+        enable_checkpointing=True,
+        default_root_dir=tmp_path,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        limit_test_batches=2,
+        logger=logger,
+        **trainer_kwargs,
+    )
+
+    net = estimator_cls.from_dataset(
+        train_dataloader.dataset,
+        hidden_size=5,
+        learning_rate=0.01,
+        log_gradient_flow=True,
+        log_interval=1000,
+        **kwargs,
+    )
+    net.size()
+    try:
+        trainer.fit(
+            net,
+            train_dataloaders=train_dataloader,
+            val_dataloaders=val_dataloader,
+        )
+        test_outputs = trainer.test(net, dataloaders=test_dataloader)
+        assert len(test_outputs) > 0
+        # check loading
+        net = estimator_cls.load_from_checkpoint(
+            trainer.checkpoint_callback.best_model_path
+        )
+
+        # check prediction
+        net.predict(
+            val_dataloader,
+            fast_dev_run=True,
+            return_index=True,
+            return_decoder_lengths=True,
+            trainer_kwargs=trainer_kwargs,
+        )
+    finally:
+        shutil.rmtree(tmp_path, ignore_errors=True)
+
+    net.predict(
+        val_dataloader,
+        fast_dev_run=True,
+        return_index=True,
+        return_decoder_lengths=True,
+        trainer_kwargs=trainer_kwargs,
+    )
 
 
 def _tide_integration(dataloaders, tmp_path, trainer_kwargs=None, **kwargs):


### PR DESCRIPTION
Refactors the test metadata container to include data loader configs which may vary, adds this in a private class method `_get_test_dataloaders_from`. Also refactors the `_integration` method in `TestAllEstimators` accordingly.

Also:

* Adds `NBeats` metadata container for v1 tests.
* Removes the private import from `test_tide`, of `_integration` from `test_all_estimators`