### PR TITLE
Model pkgs rename

### DIFF
--- a/pytorch_forecasting/models/base/_base_model.py
+++ b/pytorch_forecasting/models/base/_base_model.py
@@ -58,7 +58,6 @@ from pytorch_forecasting.utils import (
     groupby_apply,
     to_list,
 )
-from pytorch_forecasting.utils._classproperty import classproperty
 from pytorch_forecasting.utils._dependencies import (
     _check_matplotlib,
     _get_installed_packages,
@@ -591,11 +590,6 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         # never log for prediction
         if not self.predicting:
             super().log(*args, **kwargs)
-
-    @classproperty
-    def pkg(cls):
-        """Package class for the model."""
-        return cls._pkg()
 
     @property
     def predicting(self) -> bool:

--- a/pytorch_forecasting/models/base/_base_model.py
+++ b/pytorch_forecasting/models/base/_base_model.py
@@ -58,6 +58,7 @@ from pytorch_forecasting.utils import (
     groupby_apply,
     to_list,
 )
+from pytorch_forecasting.utils._classproperty import classproperty
 from pytorch_forecasting.utils._dependencies import (
     _check_matplotlib,
     _get_installed_packages,
@@ -590,6 +591,11 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         # never log for prediction
         if not self.predicting:
             super().log(*args, **kwargs)
+
+    @classproperty
+    def pkg(cls):
+        """Package class for the model."""
+        return cls._pkg()
 
     @property
     def predicting(self) -> bool:

--- a/pytorch_forecasting/models/base/_base_object.py
+++ b/pytorch_forecasting/models/base/_base_object.py
@@ -12,7 +12,7 @@ class _BaseObject(_SkbaseBaseObject):
 
 
 class _BasePtForecaster(_BaseObject):
-    """Base class for all PyTorch Forecasting forecaster metadata.
+    """Base class for all PyTorch Forecasting forecaster packages.
 
     This class points to model objects and contains metadata as tags.
     """

--- a/pytorch_forecasting/models/deepar/__init__.py
+++ b/pytorch_forecasting/models/deepar/__init__.py
@@ -1,6 +1,6 @@
 """DeepAR: Probabilistic forecasting with autoregressive recurrent networks."""
 
 from pytorch_forecasting.models.deepar._deepar import DeepAR
-from pytorch_forecasting.models.deepar._deepar_metadata import DeepARMetadata
+from pytorch_forecasting.models.deepar._deepar_pkg import DeepAR_pkg
 
-__all__ = ["DeepAR", "DeepARMetadata"]
+__all__ = ["DeepAR", "DeepAR_pkg"]

--- a/pytorch_forecasting/models/deepar/_deepar.py
+++ b/pytorch_forecasting/models/deepar/_deepar.py
@@ -37,8 +37,8 @@ from pytorch_forecasting.utils import apply_to_list, to_list
 class DeepAR(AutoRegressiveBaseModelWithCovariates):
     """DeepAR: Probabilistic forecasting with autoregressive recurrent networks."""
 
-    @property
-    def pkg(self):
+    @classmethod
+    def _pkg(cls):
         """Package containing the model."""
         from pytorch_forecasting.models.deepar._deepar_pkg import DeepAR_pkg
 

--- a/pytorch_forecasting/models/deepar/_deepar.py
+++ b/pytorch_forecasting/models/deepar/_deepar.py
@@ -37,13 +37,6 @@ from pytorch_forecasting.utils import apply_to_list, to_list
 class DeepAR(AutoRegressiveBaseModelWithCovariates):
     """DeepAR: Probabilistic forecasting with autoregressive recurrent networks."""
 
-    @classmethod
-    def _pkg(cls):
-        """Package containing the model."""
-        from pytorch_forecasting.models.deepar._deepar_pkg import DeepAR_pkg
-
-        return DeepAR_pkg
-
     def __init__(
         self,
         cell_type: str = "LSTM",

--- a/pytorch_forecasting/models/deepar/_deepar.py
+++ b/pytorch_forecasting/models/deepar/_deepar.py
@@ -35,6 +35,7 @@ from pytorch_forecasting.utils import apply_to_list, to_list
 
 
 class DeepAR(AutoRegressiveBaseModelWithCovariates):
+    """DeepAR: Probabilistic forecasting with autoregressive recurrent networks."""
 
     @property
     def pkg(self):

--- a/pytorch_forecasting/models/deepar/_deepar.py
+++ b/pytorch_forecasting/models/deepar/_deepar.py
@@ -35,6 +35,14 @@ from pytorch_forecasting.utils import apply_to_list, to_list
 
 
 class DeepAR(AutoRegressiveBaseModelWithCovariates):
+
+    @property
+    def pkg(self):
+        """Package containing the model."""
+        from pytorch_forecasting.models.deepar._deepar_pkg import DeepAR_pkg
+
+        return DeepAR_pkg
+
     def __init__(
         self,
         cell_type: str = "LSTM",

--- a/pytorch_forecasting/models/deepar/_deepar_pkg.py
+++ b/pytorch_forecasting/models/deepar/_deepar_pkg.py
@@ -1,10 +1,10 @@
-"""DeepAR metadata container."""
+"""DeepAR package container."""
 
 from pytorch_forecasting.models.base._base_object import _BasePtForecaster
 
 
-class DeepARMetadata(_BasePtForecaster):
-    """DeepAR metadata container."""
+class DeepAR_pkg(_BasePtForecaster):
+    """DeepAR package container."""
 
     _tags = {
         "info:name": "DeepAR",

--- a/pytorch_forecasting/models/mlp/__init__.py
+++ b/pytorch_forecasting/models/mlp/__init__.py
@@ -1,7 +1,7 @@
 """Simple models based on fully connected networks."""
 
 from pytorch_forecasting.models.mlp._decodermlp import DecoderMLP
-from pytorch_forecasting.models.mlp._decodermlp_metadata import DecoderMLPMetadata
+from pytorch_forecasting.models.mlp._decodermlp_pkg import DecoderMLP_pkg
 from pytorch_forecasting.models.mlp.submodules import FullyConnectedModule
 
-__all__ = ["DecoderMLP", "DecoderMLPMetadata", "FullyConnectedModule"]
+__all__ = ["DecoderMLP", "DecoderMLP_pkg", "FullyConnectedModule"]

--- a/pytorch_forecasting/models/mlp/_decodermlp.py
+++ b/pytorch_forecasting/models/mlp/_decodermlp.py
@@ -29,8 +29,8 @@ class DecoderMLP(BaseModelWithCovariates):
     MLP that predicts output only based on information available in the decoder.
     """
 
-    @property
-    def pkg(self):
+    @classmethod
+    def _pkg(cls):
         """Package for the model."""
         from pytorch_forecasting.models.mlp._decodermlp_pkg import DecoderMLP_pkg
 

--- a/pytorch_forecasting/models/mlp/_decodermlp.py
+++ b/pytorch_forecasting/models/mlp/_decodermlp.py
@@ -29,13 +29,6 @@ class DecoderMLP(BaseModelWithCovariates):
     MLP that predicts output only based on information available in the decoder.
     """
 
-    @classmethod
-    def _pkg(cls):
-        """Package for the model."""
-        from pytorch_forecasting.models.mlp._decodermlp_pkg import DecoderMLP_pkg
-
-        return DecoderMLP_pkg
-
     def __init__(
         self,
         activation_class: str = "ReLU",

--- a/pytorch_forecasting/models/mlp/_decodermlp.py
+++ b/pytorch_forecasting/models/mlp/_decodermlp.py
@@ -30,6 +30,13 @@ class DecoderMLP(BaseModelWithCovariates):
     MLP that predicts output only based on information available in the decoder.
     """
 
+    @property
+    def pkg(self):
+        """Package for the model."""
+        from pytorch_forecasting.models.mlp._decodermlp_pkg import DecoderMLP_pkg
+
+        return DecoderMLP_pkg
+
     def __init__(
         self,
         activation_class: str = "ReLU",

--- a/pytorch_forecasting/models/mlp/_decodermlp.py
+++ b/pytorch_forecasting/models/mlp/_decodermlp.py
@@ -24,8 +24,7 @@ from pytorch_forecasting.models.nn.embeddings import MultiEmbedding
 
 
 class DecoderMLP(BaseModelWithCovariates):
-    """
-    MLP on the decoder.
+    """MLP on the decoder.
 
     MLP that predicts output only based on information available in the decoder.
     """

--- a/pytorch_forecasting/models/mlp/_decodermlp_pkg.py
+++ b/pytorch_forecasting/models/mlp/_decodermlp_pkg.py
@@ -1,10 +1,10 @@
-"""DecoderMLP metadata container."""
+"""DecoderMLP package container."""
 
 from pytorch_forecasting.models.base._base_object import _BasePtForecaster
 
 
-class DecoderMLPMetadata(_BasePtForecaster):
-    """DecoderMLP metadata container."""
+class DecoderMLP_pkg(_BasePtForecaster):
+    """DecoderMLP package container."""
 
     _tags = {
         "info:name": "DecoderMLP",

--- a/pytorch_forecasting/models/nbeats/__init__.py
+++ b/pytorch_forecasting/models/nbeats/__init__.py
@@ -1,7 +1,7 @@
 """N-Beats model for timeseries forecasting without covariates."""
 
 from pytorch_forecasting.models.nbeats._nbeats import NBeats
-from pytorch_forecasting.models.nbeats._nbeats_metadata import NBeatsMetadata
+from pytorch_forecasting.models.nbeats._nbeats_pkg import NBeats_pkg
 from pytorch_forecasting.models.nbeats.sub_modules import (
     NBEATSGenericBlock,
     NBEATSSeasonalBlock,
@@ -11,7 +11,7 @@ from pytorch_forecasting.models.nbeats.sub_modules import (
 __all__ = [
     "NBeats",
     "NBEATSGenericBlock",
-    "NBeatsMetadata",
+    "NBeats_pkg",
     "NBEATSSeasonalBlock",
     "NBEATSTrendBlock",
 ]

--- a/pytorch_forecasting/models/nbeats/_nbeats.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats.py
@@ -20,6 +20,7 @@ from pytorch_forecasting.utils._dependencies import _check_matplotlib
 
 
 class NBeats(BaseModel):
+    """N-Beats model for timeseries forecasting without covariates."""
 
     @property
     def pkg(self):

--- a/pytorch_forecasting/models/nbeats/_nbeats.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats.py
@@ -22,8 +22,8 @@ from pytorch_forecasting.utils._dependencies import _check_matplotlib
 class NBeats(BaseModel):
     """N-Beats model for timeseries forecasting without covariates."""
 
-    @property
-    def pkg(self):
+    @classmethod
+    def _pkg(cls):
         """Package for the model."""
         from pytorch_forecasting.models.nbeats._nbeats_pkg import NBeats_pkg
 

--- a/pytorch_forecasting/models/nbeats/_nbeats.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats.py
@@ -20,6 +20,14 @@ from pytorch_forecasting.utils._dependencies import _check_matplotlib
 
 
 class NBeats(BaseModel):
+
+    @property
+    def pkg(self):
+        """Package for the model."""
+        from pytorch_forecasting.models.nbeats._nbeats_pkg import NBeats_pkg
+
+        return NBeats_pkg
+
     def __init__(
         self,
         stack_types: Optional[list[str]] = None,

--- a/pytorch_forecasting/models/nbeats/_nbeats.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats.py
@@ -22,13 +22,6 @@ from pytorch_forecasting.utils._dependencies import _check_matplotlib
 class NBeats(BaseModel):
     """N-Beats model for timeseries forecasting without covariates."""
 
-    @classmethod
-    def _pkg(cls):
-        """Package for the model."""
-        from pytorch_forecasting.models.nbeats._nbeats_pkg import NBeats_pkg
-
-        return NBeats_pkg
-
     def __init__(
         self,
         stack_types: Optional[list[str]] = None,

--- a/pytorch_forecasting/models/nbeats/_nbeats_pkg.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_pkg.py
@@ -1,10 +1,10 @@
-"""NBeats metadata container."""
+"""NBeats package container."""
 
 from pytorch_forecasting.models.base._base_object import _BasePtForecaster
 
 
-class NBeatsMetadata(_BasePtForecaster):
-    """NBeats metadata container."""
+class NBeats_pkg(_BasePtForecaster):
+    """NBeats package container."""
 
     _tags = {
         "info:name": "NBeats",

--- a/pytorch_forecasting/models/tide/__init__.py
+++ b/pytorch_forecasting/models/tide/__init__.py
@@ -1,11 +1,11 @@
 """Tide model."""
 
 from pytorch_forecasting.models.tide._tide import TiDEModel
-from pytorch_forecasting.models.tide._tide_metadata import TiDEModelMetadata
+from pytorch_forecasting.models.tide._tide_pkg import TiDEModel_pkg
 from pytorch_forecasting.models.tide.sub_modules import _TideModule
 
 __all__ = [
     "_TideModule",
     "TiDEModel",
-    "TiDEModelMetadata",
+    "TiDEModel_pkg",
 ]

--- a/pytorch_forecasting/models/tide/_tide.py
+++ b/pytorch_forecasting/models/tide/_tide.py
@@ -18,6 +18,14 @@ from pytorch_forecasting.models.tide.sub_modules import _TideModule
 
 
 class TiDEModel(BaseModelWithCovariates):
+
+    @property
+    def pkg(self):
+        """Package for the model."""
+        from pytorch_forecasting.models.tide._tide_pkg import TiDEModel_pkg
+
+        return TiDEModel_pkg
+
     def __init__(
         self,
         output_chunk_length: int,

--- a/pytorch_forecasting/models/tide/_tide.py
+++ b/pytorch_forecasting/models/tide/_tide.py
@@ -18,6 +18,7 @@ from pytorch_forecasting.models.tide.sub_modules import _TideModule
 
 
 class TiDEModel(BaseModelWithCovariates):
+    """TiDE model for long-term time-series forecasting."""
 
     @property
     def pkg(self):

--- a/pytorch_forecasting/models/tide/_tide.py
+++ b/pytorch_forecasting/models/tide/_tide.py
@@ -20,13 +20,6 @@ from pytorch_forecasting.models.tide.sub_modules import _TideModule
 class TiDEModel(BaseModelWithCovariates):
     """TiDE model for long-term time-series forecasting."""
 
-    @classmethod
-    def _pkg(cls):
-        """Package for the model."""
-        from pytorch_forecasting.models.tide._tide_pkg import TiDEModel_pkg
-
-        return TiDEModel_pkg
-
     def __init__(
         self,
         output_chunk_length: int,

--- a/pytorch_forecasting/models/tide/_tide.py
+++ b/pytorch_forecasting/models/tide/_tide.py
@@ -20,8 +20,8 @@ from pytorch_forecasting.models.tide.sub_modules import _TideModule
 class TiDEModel(BaseModelWithCovariates):
     """TiDE model for long-term time-series forecasting."""
 
-    @property
-    def pkg(self):
+    @classmethod
+    def _pkg(cls):
         """Package for the model."""
         from pytorch_forecasting.models.tide._tide_pkg import TiDEModel_pkg
 

--- a/pytorch_forecasting/models/tide/_tide_pkg.py
+++ b/pytorch_forecasting/models/tide/_tide_pkg.py
@@ -3,7 +3,7 @@
 from pytorch_forecasting.models.base._base_object import _BasePtForecaster
 
 
-class TiDEModelMetadata(_BasePtForecaster):
+class TiDEModel_pkg(_BasePtForecaster):
     """Package container for TiDE Model."""
 
     _tags = {

--- a/pytorch_forecasting/models/tide/_tide_pkg.py
+++ b/pytorch_forecasting/models/tide/_tide_pkg.py
@@ -1,10 +1,10 @@
-"""TiDE metadata container."""
+"""TiDE package container."""
 
 from pytorch_forecasting.models.base._base_object import _BasePtForecaster
 
 
 class TiDEModelMetadata(_BasePtForecaster):
-    """Metadata container for TiDE Model."""
+    """Package container for TiDE Model."""
 
     _tags = {
         "info:name": "TiDEModel",

--- a/pytorch_forecasting/models/timexer/__init__.py
+++ b/pytorch_forecasting/models/timexer/__init__.py
@@ -3,7 +3,7 @@ TimeXer model for forecasting time series.
 """
 
 from pytorch_forecasting.models.timexer._timexer import TimeXer
-from pytorch_forecasting.models.timexer._timexer_metadata import TimeXerMetadata
+from pytorch_forecasting.models.timexer._timexer_pkg import TimeXer_pkg
 from pytorch_forecasting.models.timexer.sub_modules import (
     AttentionLayer,
     DataEmbedding_inverted,
@@ -27,5 +27,5 @@ __all__ = [
     "EnEmbedding",
     "Encoder",
     "EncoderLayer",
-    "TimeXerMetadata",
+    "TimeXer_pkg",
 ]

--- a/pytorch_forecasting/models/timexer/_timexer.py
+++ b/pytorch_forecasting/models/timexer/_timexer.py
@@ -38,6 +38,15 @@ from pytorch_forecasting.models.timexer.sub_modules import (
 
 
 class TimeXer(BaseModelWithCovariates):
+    """TimeXer model for time series forecasting with exogenous variables."""
+
+    @property
+    def pkg(self):
+        """Package for the model."""
+        from pytorch_forecasting.models.timexer._timexer_pkg import TimeXer_pkg
+
+        return TimeXer_pkg
+
     def __init__(
         self,
         context_length: int,

--- a/pytorch_forecasting/models/timexer/_timexer.py
+++ b/pytorch_forecasting/models/timexer/_timexer.py
@@ -40,8 +40,8 @@ from pytorch_forecasting.models.timexer.sub_modules import (
 class TimeXer(BaseModelWithCovariates):
     """TimeXer model for time series forecasting with exogenous variables."""
 
-    @property
-    def pkg(self):
+    @classmethod
+    def _pkg(cls):
         """Package for the model."""
         from pytorch_forecasting.models.timexer._timexer_pkg import TimeXer_pkg
 
@@ -96,64 +96,64 @@ class TimeXer(BaseModelWithCovariates):
 
         TimeXer model for time series forecasting with exogenous variables.
 
-        Args:
-
-            context_length (int): Length of input sequence used for making predictions.
-            prediction_length (int): Number of future time steps to predict.
-            task_name (str, optional): Type of forecasting task, either
-                'long_term_forecast' or 'short_term_forecast', which corresponds to
-                forecasting scenarios implied by the task names.
-            features (str, optional): Type of features used in the model ('MS' for
-                multivariate forecating with single target, 'M' for multivariate
-                forecasting with multiple targets and 'S' for univariate forecasting).
-            enc_in (int, optional): Number of input variables for encoder.
-            hidden_size (int, optional): Dimension of model embeddings and hidden
-                representations.
-            n_heads (int, optional): Number of attention heads in multi-head attention
-                layers.
-            e_layers (int, optional): Number of encoder layers with dual attention
-                mechanism.
-            d_ff (int, optional): Dimension of feedforward network in transformer layers
-            dropout (float, optional): Dropout rate applied throughout the network for
-                regularization.
-            activation (str, optional): Activation function used in feedforward networks
-                ('relu' or 'gelu').
-            patch_length (int, optional): Length of each non-overlapping patch for
-                endogenous variable tokenization.
-            use_norm (bool, optional): Whether to apply normalization to input data.
-                Do not change, as it a setting controlled by the pytorch-forecasting API
-            factor: Scaling factor for attention scores.
-            embed_type: Type of time feature embedding ('timeF' for time-based features)
-            freq: Frequency of the time series data('h' for hourly,'d' for daily, etc.).
-            static_categoricals (list[str]): names of static categorical variables
-            static_reals (list[str]): names of static continuous variables
-            time_varying_categoricals_encoder (list[str]): names of categorical
-                variables for encoder
-            time_varying_categoricals_decoder (list[str]): names of categorical
-                variables for decoder
-            time_varying_reals_encoder (list[str]): names of continuous variables for
-                encoder
-            time_varying_reals_decoder (list[str]): names of continuous variables for
-                decoder
-            x_reals (list[str]): order of continuous variables in tensor passed to
-                forward function
-            x_categoricals (list[str]): order of categorical variables in tensor passed
-                to forward function
-            embedding_sizes (dict[str, tuple[int, int]]): dictionary mapping categorical
-                variables to tuple of integers where the first integer denotes the
-                number of categorical classes and the second the embedding size
-            embedding_labels (dict[str, list[str]]): dictionary mapping (string) indices
-                to list of categorical labels
-            embedding_paddings (list[str]): names of categorical variables for which
-                label 0 is always mapped to an embedding vector filled with zeros
-            categorical_groups (dict[str, list[str]]): dictionary of categorical
-                variables that are grouped together and can also take multiple values
-                simultaneously (e.g. holiday during octoberfest). They should be
-                implemented as bag of embeddings.
-            logging_metrics (nn.ModuleList[LightningMetric]): list of metrics that are
-                logged during training. Defaults to
-                nn.ModuleList([SMAPE(), MAE(), RMSE(), MAPE()]).
-            **kwargs: additional arguments to :py:class:`~BaseModel`.
+        Parameters
+        ----------
+        context_length (int): Length of input sequence used for making predictions.
+        prediction_length (int): Number of future time steps to predict.
+        task_name (str, optional): Type of forecasting task, either
+            'long_term_forecast' or 'short_term_forecast', which corresponds to
+            forecasting scenarios implied by the task names.
+        features (str, optional): Type of features used in the model ('MS' for
+            multivariate forecating with single target, 'M' for multivariate
+            forecasting with multiple targets and 'S' for univariate forecasting).
+        enc_in (int, optional): Number of input variables for encoder.
+        hidden_size (int, optional): Dimension of model embeddings and hidden
+            representations.
+        n_heads (int, optional): Number of attention heads in multi-head attention
+            layers.
+        e_layers (int, optional): Number of encoder layers with dual attention
+            mechanism.
+        d_ff (int, optional): Dimension of feedforward network in transformer layers
+        dropout (float, optional): Dropout rate applied throughout the network for
+            regularization.
+        activation (str, optional): Activation function used in feedforward networks
+            ('relu' or 'gelu').
+        patch_length (int, optional): Length of each non-overlapping patch for
+            endogenous variable tokenization.
+        use_norm (bool, optional): Whether to apply normalization to input data.
+            Do not change, as it a setting controlled by the pytorch-forecasting API
+        factor: Scaling factor for attention scores.
+        embed_type: Type of time feature embedding ('timeF' for time-based features)
+        freq: Frequency of the time series data('h' for hourly,'d' for daily, etc.).
+        static_categoricals (list[str]): names of static categorical variables
+        static_reals (list[str]): names of static continuous variables
+        time_varying_categoricals_encoder (list[str]): names of categorical
+            variables for encoder
+        time_varying_categoricals_decoder (list[str]): names of categorical
+            variables for decoder
+        time_varying_reals_encoder (list[str]): names of continuous variables for
+            encoder
+        time_varying_reals_decoder (list[str]): names of continuous variables for
+            decoder
+        x_reals (list[str]): order of continuous variables in tensor passed to
+            forward function
+        x_categoricals (list[str]): order of categorical variables in tensor passed
+            to forward function
+        embedding_sizes (dict[str, tuple[int, int]]): dictionary mapping categorical
+            variables to tuple of integers where the first integer denotes the
+            number of categorical classes and the second the embedding size
+        embedding_labels (dict[str, list[str]]): dictionary mapping (string) indices
+            to list of categorical labels
+        embedding_paddings (list[str]): names of categorical variables for which
+            label 0 is always mapped to an embedding vector filled with zeros
+        categorical_groups (dict[str, list[str]]): dictionary of categorical
+            variables that are grouped together and can also take multiple values
+            simultaneously (e.g. holiday during octoberfest). They should be
+            implemented as bag of embeddings.
+        logging_metrics (nn.ModuleList[LightningMetric]): list of metrics that are
+            logged during training. Defaults to
+            nn.ModuleList([SMAPE(), MAE(), RMSE(), MAPE()]).
+        **kwargs: additional arguments to :py:class:`~BaseModel`.
         """
 
         if static_categoricals is None:

--- a/pytorch_forecasting/models/timexer/_timexer.py
+++ b/pytorch_forecasting/models/timexer/_timexer.py
@@ -40,13 +40,6 @@ from pytorch_forecasting.models.timexer.sub_modules import (
 class TimeXer(BaseModelWithCovariates):
     """TimeXer model for time series forecasting with exogenous variables."""
 
-    @classmethod
-    def _pkg(cls):
-        """Package for the model."""
-        from pytorch_forecasting.models.timexer._timexer_pkg import TimeXer_pkg
-
-        return TimeXer_pkg
-
     def __init__(
         self,
         context_length: int,

--- a/pytorch_forecasting/models/timexer/_timexer_pkg.py
+++ b/pytorch_forecasting/models/timexer/_timexer_pkg.py
@@ -1,10 +1,10 @@
-"""TimeXer metadata container."""
+"""TimeXer package container."""
 
 from pytorch_forecasting.models.base._base_object import _BasePtForecaster
 
 
-class TimeXerMetadata(_BasePtForecaster):
-    """TimeXer metdata container."""
+class TimeXer_pkg(_BasePtForecaster):
+    """TimeXer package container."""
 
     _tags = {
         "info:name": "TimeXer",

--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -137,8 +137,11 @@ class BaseFixtureGenerator(_BaseFixtureGenerator):
         object_class: object inheriting from BaseObject
             ranges over all object classes not excluded by self.excluded_tests
         """
-        # call _generate_estimator_class to get all the classes
-        all_model_pkgs, _ = self._generate_object_pkg(test_name=test_name)
+        if "object_pkg" in kwargs.keys():
+            all_model_pkgs = [kwargs["object_pkg"]]
+        else:
+            # call _generate_estimator_class to get all the classes
+            all_model_pkgs, _ = self._generate_object_pkg(test_name=test_name)
 
         all_cls = [est.get_model_cls() for est in all_model_pkgs]
         object_classes_to_test = [

--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -276,11 +276,20 @@ class TestAllPtForecasters(PackageConfig, BaseFixtureGenerator):
         assert object_pkg is object_class.pkg
         # assert object_pkg is object_instance.pkg
 
-        # check naming convention
+        # check name method
         msg = (
-            f"Package {object_pkg.name()} does not match class "
+            f"Package {object_pkg}.name() does not match class "
             f"name {object_class.__name__}. "
             "The expected package name is "
             f"{object_class.__name__}_pkg."
         )
-        assert object_pkg.name() == object_class.__name__ + "_pkg", msg
+        assert object_pkg.name() == object_class.__name__, msg
+
+        # check naming convention
+        msg = (
+            f"Package {object_pkg.__name__} does not match class "
+            f"name {object_class.__name__}. "
+            "The expected package name is "
+            f"{object_class.__name__}_pkg."
+        )
+        assert object_pkg.__name__ == object_class.__name__ + "_pkg", msg

--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -264,11 +264,12 @@ class TestAllPtForecasters(PackageConfig, BaseFixtureGenerator):
 
         _integration(object_class, dataloaders, tmp_path, **trainer_kwargs)
 
-    def test_pkg_linkage(self, object_pkg, object_class):
+    def test_pkg_linkage(self, object_pkg, object_class, object_instance):
         """Test that the package is linked correctly."""
         msg = f"{object_class.__name__} does not have a pkg attribute."
         assert hasattr(object_class, "pkg"), msg
         assert object_pkg is object_class.pkg
+        assert object_pkg is object_instance.pkg
         # check naming convention
         msg = (
             f"Package {object_pkg.name()} does not match class "

--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -108,19 +108,19 @@ class BaseFixtureGenerator(_BaseFixtureGenerator):
 
     # which sequence the conditional fixtures are generated in
     fixture_sequence = [
-        "object_metadata",
+        "object_pkg",
         "object_class",
         "object_instance",
         "trainer_kwargs",
     ]
 
-    def _generate_object_metadata(self, test_name, **kwargs):
-        """Return object class fixtures.
+    def _generate_object_pkg(self, test_name, **kwargs):
+        """Return object package fixtures.
 
         Fixtures parametrized
         ---------------------
-        object_class: object inheriting from BaseObject
-            ranges over all object classes not excluded by self.excluded_tests
+        object_pkg: object package inheriting from BaseObject
+            ranges over all object packages not excluded by self.excluded_tests
         """
         object_classes_to_test = [
             est for est in self._all_objects() if not self.is_excluded(test_name, est)
@@ -137,8 +137,8 @@ class BaseFixtureGenerator(_BaseFixtureGenerator):
         object_class: object inheriting from BaseObject
             ranges over all object classes not excluded by self.excluded_tests
         """
-        all_metadata = self._all_objects()
-        all_cls = [est.get_model_cls() for est in all_metadata]
+        all_model_pkgs = self._all_objects()
+        all_cls = [est.get_model_cls() for est in all_model_pkgs]
         object_classes_to_test = [
             est for est in all_cls if not self.is_excluded(test_name, est)
         ]
@@ -154,8 +154,8 @@ class BaseFixtureGenerator(_BaseFixtureGenerator):
         trainer_kwargs: dict
             ranges over all kwargs for the trainer
         """
-        if "object_metadata" in kwargs.keys():
-            obj_meta = kwargs["object_metadata"]
+        if "object_pkg" in kwargs.keys():
+            obj_meta = kwargs["object_pkg"]
         else:
             return []
 
@@ -253,13 +253,17 @@ class TestAllPtForecasters(PackageConfig, BaseFixtureGenerator):
 
     def test_integration(
         self,
-        object_metadata,
+        object_pkg,
         trainer_kwargs,
         tmp_path,
     ):
         """Fails for certain, for testing."""
 
-        object_class = object_metadata.get_model_cls()
-        dataloaders = object_metadata._get_test_dataloaders_from(trainer_kwargs)
+        object_class = object_pkg.get_model_cls()
+        dataloaders = object_pkg._get_test_dataloaders_from(trainer_kwargs)
 
         _integration(object_class, dataloaders, tmp_path, **trainer_kwargs)
+
+    def test_pkg_linkage(self, object_pkg, object_class):
+        """Test that the package is linked correctly."""
+        assert object_pkg is object_class.pkg

--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -266,9 +266,8 @@ class TestAllPtForecasters(PackageConfig, BaseFixtureGenerator):
 
     def test_pkg_linkage(self, object_pkg, object_class):
         """Test that the package is linked correctly."""
-        assert hasattr(object_class, "pkg"), (
-            f"{object_class.__name__} does not have a pkg attribute."
-        )
+        msg = f"{object_class.__name__} does not have a pkg attribute."
+        assert hasattr(object_class, "pkg"), msg
         assert object_pkg is object_class.pkg
         # check naming convention
         msg = (

--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -264,12 +264,13 @@ class TestAllPtForecasters(PackageConfig, BaseFixtureGenerator):
 
         _integration(object_class, dataloaders, tmp_path, **trainer_kwargs)
 
-    def test_pkg_linkage(self, object_pkg, object_class, object_instance):
+    def test_pkg_linkage(self, object_pkg, object_class):
         """Test that the package is linked correctly."""
         msg = f"{object_class.__name__} does not have a pkg attribute."
         assert hasattr(object_class, "pkg"), msg
         assert object_pkg is object_class.pkg
-        assert object_pkg is object_instance.pkg
+        # assert object_pkg is object_instance.pkg
+
         # check naming convention
         msg = (
             f"Package {object_pkg.name()} does not match class "

--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -266,4 +266,15 @@ class TestAllPtForecasters(PackageConfig, BaseFixtureGenerator):
 
     def test_pkg_linkage(self, object_pkg, object_class):
         """Test that the package is linked correctly."""
+        assert hasattr(object_class, "pkg"), (
+            f"{object_class.__name__} does not have a pkg attribute."
+        )
         assert object_pkg is object_class.pkg
+        # check naming convention
+        msg = (
+            f"Package {object_pkg.name()} does not match class "
+            f"name {object_class.__name__}. "
+            "The expected package name is "
+            f"{object_class.__name__}_pkg."
+        )
+        assert object_pkg.name() == object_class.__name__ + "_pkg", msg

--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -137,7 +137,9 @@ class BaseFixtureGenerator(_BaseFixtureGenerator):
         object_class: object inheriting from BaseObject
             ranges over all object classes not excluded by self.excluded_tests
         """
-        all_model_pkgs = self._all_objects()
+        # call _generate_estimator_class to get all the classes
+        all_model_pkgs, _ = self._generate_object_pkg(test_name=test_name)
+
         all_cls = [est.get_model_cls() for est in all_model_pkgs]
         object_classes_to_test = [
             est for est in all_cls if not self.is_excluded(test_name, est)

--- a/pytorch_forecasting/utils/_classproperty.py
+++ b/pytorch_forecasting/utils/_classproperty.py
@@ -1,0 +1,6 @@
+"""A class property decorator."""
+
+
+class classproperty(property):
+    def __get__(self, obj, cls):
+        return self.fget(cls)


### PR DESCRIPTION
Proposed solution for, and fixes https://github.com/sktime/pytorch-forecasting/issues/1886

This PR contains changes naming convention of "model metadata" class to "model package container" nomenclature

Not breaking as the v2 package/metadata layer has not been released yet.