### PR TITLE
[BUG] Fix issue with `plot_prediction_actual_by_variable`  unsupported operand type(s) for *: 'numpy.ndarray' and 'Tensor'

### DIFF
--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -727,13 +727,13 @@ class TorchNormalizer(
         else:
             return y
 
-    def inverse_transform(self, y: torch.Tensor) -> torch.Tensor:
+    def inverse_transform(self, y: Union[torch.Tensor, np.ndarray]) -> torch.Tensor:
         """
         Inverse scale.
 
         Parameters
         ----------
-        y: torch.Tensor
+        y: Union[torch.Tensor, np.ndarray]
             scaled data
 
         Returns
@@ -741,6 +741,8 @@ class TorchNormalizer(
         torch.Tensor
             de-scaled data
         """
+        if isinstance(y, np.ndarray):
+            y = torch.from_numpy(y)
         return self(dict(prediction=y, target_scale=self.get_parameters().unsqueeze(0)))
 
     def __call__(self, data: dict[str, torch.Tensor]) -> torch.Tensor:
@@ -760,9 +762,6 @@ class TorchNormalizer(
         torch.Tensor
             de-scaled data
         """
-        # ensure prediction is a tensor
-        if isinstance(data["prediction"], np.ndarray):
-            data["prediction"] = torch.from_numpy(data["prediction"])
         # ensure output dtype matches input dtype
         dtype = data["prediction"].dtype
 

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -762,6 +762,10 @@ class TorchNormalizer(
         """
         # ensure output dtype matches input dtype
         dtype = data["prediction"].dtype
+        if isinstance(dtype, np.dtype):
+            # convert the array into tensor if it is a numpy array
+            data["prediction"] = torch.as_tensor(data["prediction"])
+            dtype = data["prediction"].dtype
 
         # inverse transformation with tensors
         norm = data["target_scale"]

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -763,7 +763,7 @@ class TorchNormalizer(
 
         Parameters
         ----------
-        y: Union[torch.Tensor]
+        y: torch.Tensor
             scaled data
 
         Returns

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -757,13 +757,13 @@ class TorchNormalizer(
         else:
             return y
 
-    def inverse_transform(self, y: torch.Tensor) -> torch.Tensor:
+    def inverse_transform(self, y: Union[torch.Tensor, np.ndarray]) -> torch.Tensor:
         """
         Inverse scale.
 
         Parameters
         ----------
-        y: torch.Tensor
+        y: Union[torch.Tensor, np.ndarray])
             scaled data
 
         Returns

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -760,12 +760,11 @@ class TorchNormalizer(
         torch.Tensor
             de-scaled data
         """
+        # ensure prediction is a tensor
+        if isinstance(data["prediction"], np.ndarray):
+            data["prediction"] = torch.from_numpy(data["prediction"])
         # ensure output dtype matches input dtype
         dtype = data["prediction"].dtype
-        if isinstance(dtype, np.dtype):
-            # convert the array into tensor if it is a numpy array
-            data["prediction"] = torch.as_tensor(data["prediction"])
-            dtype = data["prediction"].dtype
 
         # inverse transformation with tensors
         norm = data["target_scale"]


### PR DESCRIPTION
fixes https://github.com/sktime/pytorch-forecasting/issues/1822

This PR fixes the issue with `plot_prediction_actual_by_variable` where the input `np.ndarray` was being multiplied to `torch.Tensor` in `TorchNormalizer` `__call__`