### PR TITLE
[ENH] Suppress `__array_wrap__` warning in `numpy 2` for `torch` and `pandas`

### DIFF
--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -719,7 +719,10 @@ class TorchNormalizer(
             elif isinstance(y, np.ndarray):
                 y_was = "numpy"
                 np_dtype = y.dtype
-                y = torch.from_numpy(y.astype(np.float32))
+                try:
+                    y = torch.from_numpy(y)
+                except TypeError:
+                    y = torch.as_tensor(y.astype(np.float32))
         else:
             y_was = "torch"
         if isinstance(center, np.ndarray):

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -762,6 +762,10 @@ class TorchNormalizer(
         """
         # ensure output dtype matches input dtype
         dtype = data["prediction"].dtype
+        if isinstance(dtype, np.dtype):
+            # convert the array into tensor if it is a numpy array
+            data["prediction"] = torch.as_tensor(data["prediction"])
+            dtype = data["prediction"].dtype
 
         # inverse transformation with tensors
         norm = data["target_scale"]

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -725,6 +725,7 @@ class TorchNormalizer(
                     y = torch.as_tensor(y.astype(np.float32))
         else:
             y_was = "torch"
+            torch_dtype = y.dtype
         if isinstance(center, np.ndarray):
             center = torch.from_numpy(center)
         if isinstance(scale, np.ndarray):
@@ -732,9 +733,6 @@ class TorchNormalizer(
         if y.ndim > center.ndim:  # multiple batches -> expand size
             center = center.view(*center.size(), *(1,) * (y.ndim - center.ndim))
             scale = scale.view(*scale.size(), *(1,) * (y.ndim - scale.ndim))
-
-        # transform
-        dtype = y.dtype
 
         y = (y - center) / scale
 
@@ -751,7 +749,7 @@ class TorchNormalizer(
                 pandas_dtype = np.float64
             y = pd.Series(numpy_data, index=index, dtype=pandas_dtype)
         else:
-            y = y.type(dtype)
+            y = y.type(torch_dtype)
 
         # return with center and scale or without
         if return_norm:

--- a/pytorch_forecasting/data/encoders.py
+++ b/pytorch_forecasting/data/encoders.py
@@ -739,9 +739,17 @@ class TorchNormalizer(
         y = (y - center) / scale
 
         if y_was == "numpy":
-            y = y.numpy().astype(np_dtype)
+            numpy_data = y.numpy()
+            if np_dtype.kind in "iu" and numpy_data.dtype.kind == "f":
+                # Original was integer, but normalized data is float
+                y = numpy_data.astype(np.float64)
+            else:
+                y = numpy_data.astype(np_dtype)
         elif y_was == "pandas":
-            y = pd.Series(y.numpy(), index=index, dtype=pandas_dtype)
+            numpy_data = y.numpy()
+            if pandas_dtype.kind in "iu" and numpy_data.dtype.kind == "f":
+                pandas_dtype = np.float64
+            y = pd.Series(numpy_data, index=index, dtype=pandas_dtype)
         else:
             y = y.type(dtype)
 


### PR DESCRIPTION
fixes https://github.com/sktime/pytorch-forecasting/issues/1764

Adding the comments from the Initial PR https://github.com/sktime/pytorch-forecasting/pull/1855 by @fkiraly 


The reason is that `numpy 2` added additional arguments to `__array_wrap__` which was interacting with `torch.Tensor.__array_wrap__` or `pandas.Series.__array_wrap__` that did not have said arguments on earlier versions, in `TorchNormalizer`.

The warning can be avoided by explicit coercion to `torch` prior to mixed usage - avoiding mixed types across packages entirely.

This also makes the coercions more explicit, enabling future refactors where we may want to move to more "clean" type assumptions instead of polymorphic union types.