### PR TITLE
[ENH] Suppress PyTorch deprecation warning: UserWarning: `nn.init.constant` is now deprecated in favor of `nn.init.constant_`

### DIFF
--- a/pytorch_forecasting/models/dlinear/_dlinear_v2.py
+++ b/pytorch_forecasting/models/dlinear/_dlinear_v2.py
@@ -102,9 +102,9 @@ class DLinear(TslibBaseModel):
 
     def _weight_init(self, m: nn.Module):
         if isinstance(m, nn.Linear):
-            nn.init.constant(m.weight.data, 1.0 / self.context_length)
+            nn.init.constant_(m.weight.data, 1.0 / self.context_length)
             if m.bias is not None:
-                nn.init.constant(m.bias.data, 0.0)
+                nn.init.constant_(m.bias.data, 0.0)
 
     def _init_network(self):
         """


### PR DESCRIPTION
Behavior remains the same (in-place initialization)