### PR TITLE
[ENH] Remove references to model from the `BaseFixtureGenerator`

### DIFF
--- a/pytorch_forecasting/tests/_base/_fixture_generator.py
+++ b/pytorch_forecasting/tests/_base/_fixture_generator.py
@@ -115,7 +115,7 @@ class BaseFixtureGenerator(_BaseFixtureGenerator):
         if "object_pkg" in kwargs.keys():
             all_pkgs = [kwargs["object_pkg"]]
         else:
-            # call _generate_estimator_class to get all the classes
+            # call _generate_object_pkg to get all the packages
             all_pkgs, _ = self._generate_object_pkg(test_name=test_name)
 
         all_cls = [obj.get_cls() for obj in all_pkgs]

--- a/pytorch_forecasting/tests/_base/_fixture_generator.py
+++ b/pytorch_forecasting/tests/_base/_fixture_generator.py
@@ -113,12 +113,12 @@ class BaseFixtureGenerator(_BaseFixtureGenerator):
         """
 
         if "object_pkg" in kwargs.keys():
-            all_model_pkgs = [kwargs["object_pkg"]]
+            all_pkgs = [kwargs["object_pkg"]]
         else:
             # call _generate_estimator_class to get all the classes
-            all_model_pkgs, _ = self._generate_object_pkg(test_name=test_name)
+            all_pkgs, _ = self._generate_object_pkg(test_name=test_name)
 
-        all_cls = [obj.get_cls() for obj in all_model_pkgs]
+        all_cls = [obj.get_cls() for obj in all_pkgs]
         object_classes_to_test = [
             obj for obj in all_cls if not self.is_excluded(test_name, obj)
         ]


### PR DESCRIPTION
The current `BaseFixtureGenerator` is intended to serve as a common base class for generating fixtures in both model and metric test frameworks. However, it still contains model-specific references (e.g., `all_model_pkgs`), which is against its general-purpose design.

This PR refactors the class to remove model-specific terminology and behavior. It introduces more generic naming conventions (e.g., renaming `all_model_pkgs` to `all_pkgs`)

FYI @PranavBhatP 