### PR TITLE
[MNT] remove import conditionals for `python 3.6`

### DIFF
--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -9,6 +9,7 @@ from lightning.pytorch.loggers import TensorBoardLogger
 import numpy as np
 import pandas as pd
 import pytest
+from test_models.conftest import make_dataloaders
 import torch
 
 from pytorch_forecasting import Baseline, TimeSeriesDataSet
@@ -29,7 +30,6 @@ from pytorch_forecasting.models.temporal_fusion_transformer.tuning import (
     optimize_hyperparameters,
 )
 from pytorch_forecasting.utils._dependencies import _get_installed_packages
-from test_models.conftest import make_dataloaders
 
 
 def test_integration(multiple_dataloaders_with_covariates, tmp_path):

--- a/tests/test_models/test_temporal_fusion_transformer.py
+++ b/tests/test_models/test_temporal_fusion_transformer.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 import pickle
 import shutil
 import sys
@@ -28,17 +29,6 @@ from pytorch_forecasting.models.temporal_fusion_transformer.tuning import (
     optimize_hyperparameters,
 )
 from pytorch_forecasting.utils._dependencies import _get_installed_packages
-
-if sys.version.startswith("3.6"):  # python 3.6 does not have nullcontext
-    from contextlib import contextmanager
-
-    @contextmanager
-    def nullcontext(enter_result=None):
-        yield enter_result
-
-else:
-    from contextlib import nullcontext
-
 from test_models.conftest import make_dataloaders
 
 


### PR DESCRIPTION
removes import conditionals for `python 3.6` - 3.6 has been deprecated for years now.