### PR TITLE
[ENH] Add `Metrics` support to `ptf-v2`

### DIFF
--- a/pytorch_forecasting/models/tide/_tide_dsipts/_tide_v2_pkg.py
+++ b/pytorch_forecasting/models/tide/_tide_dsipts/_tide_v2_pkg.py
@@ -109,7 +109,7 @@ class TIDE_pkg_v2(_BasePtForecasterV2):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
-        import torch.nn as nn
+        from pytorch_forecasting.metrics import MAE, MAPE
 
         return [
             dict(
@@ -126,7 +126,7 @@ class TIDE_pkg_v2(_BasePtForecasterV2):
                 n_add_dec=2,
                 dropout_rate=0.2,
                 data_loader_kwargs=dict(max_encoder_length=5, max_prediction_length=3),
-                loss=nn.MSELoss(),
+                loss=MAE(),
             ),
             dict(
                 hidden_size=64,
@@ -135,6 +135,6 @@ class TIDE_pkg_v2(_BasePtForecasterV2):
                 n_add_dec=2,
                 dropout_rate=0.1,
                 data_loader_kwargs=dict(max_encoder_length=4, max_prediction_length=2),
-                loss=nn.PoissonNLLLoss(),
+                loss=MAPE(),
             ),
         ]

--- a/pytorch_forecasting/tests/test_all_estimators_v2.py
+++ b/pytorch_forecasting/tests/test_all_estimators_v2.py
@@ -1,13 +1,12 @@
 """Automated tests based on the skbase test suite template."""
 
-from inspect import isclass
 import shutil
 
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks import EarlyStopping
 from lightning.pytorch.loggers import TensorBoardLogger
-import torch.nn as nn
 
+from pytorch_forecasting.metrics import SMAPE
 from pytorch_forecasting.tests.test_all_estimators import (
     EstimatorFixtureGenerator,
     EstimatorPackageConfig,
@@ -61,7 +60,7 @@ def _integration(
         loss = kwargs["loss"]
         kwargs.pop("loss")
     else:
-        loss = nn.MSELoss()
+        loss = SMAPE()
 
     net = estimator_cls(
         metadata=metadata,


### PR DESCRIPTION
Fixes #1956, Fixes #1844
 This PR tries to make `v2` compatible with `Metrics`. It also changes the contract of tensors to match v1: `list` for multi-target and a `tensor` for single-target