### PR TITLE
Standardize output format of NBeats and NBeatsKAN estimators

### DIFF
--- a/pytorch_forecasting/models/nbeats/_nbeats_adapter.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_adapter.py
@@ -93,20 +93,20 @@ class NBeatsAdapter(BaseModel):
             forecast = forecast + forecast_block
 
         return self.to_network_output(
-            prediction=self.transform_output(forecast, target_scale=x["target_scale"]),
+            prediction=self.transform_output(forecast.unsqueeze(-1), target_scale=x["target_scale"]),
             backcast=self.transform_output(
-                prediction=target - backcast, target_scale=x["target_scale"]
+                prediction=(target - backcast).unsqueeze(-1), target_scale=x["target_scale"]
             ),
             trend=self.transform_output(
-                torch.stack(trend_forecast, dim=0).sum(0),
+                torch.stack(trend_forecast, dim=0).sum(0).unsqueeze(-1),
                 target_scale=x["target_scale"],
             ),
             seasonality=self.transform_output(
-                torch.stack(seasonal_forecast, dim=0).sum(0),
+                torch.stack(seasonal_forecast, dim=0).sum(0).unsqueeze(-1),
                 target_scale=x["target_scale"],
             ),
             generic=self.transform_output(
-                torch.stack(generic_forecast, dim=0).sum(0),
+                torch.stack(generic_forecast, dim=0).sum(0).unsqueeze(-1),
                 target_scale=x["target_scale"],
             ),
         )

--- a/pytorch_forecasting/models/nbeats/_nbeats_adapter.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_adapter.py
@@ -93,9 +93,12 @@ class NBeatsAdapter(BaseModel):
             forecast = forecast + forecast_block
 
         return self.to_network_output(
-            prediction=self.transform_output(forecast.unsqueeze(-1), target_scale=x["target_scale"]),
+            prediction=self.transform_output(
+                forecast.unsqueeze(-1), target_scale=x["target_scale"]
+            ),
             backcast=self.transform_output(
-                prediction=(target - backcast).unsqueeze(-1), target_scale=x["target_scale"]
+                prediction=(target - backcast).unsqueeze(-1),
+                target_scale=x["target_scale"],
             ),
             trend=self.transform_output(
                 torch.stack(trend_forecast, dim=0).sum(0).unsqueeze(-1),

--- a/pytorch_forecasting/models/nbeats/_nbeats_pkg.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_pkg.py
@@ -17,7 +17,6 @@ class NBeats_pkg(_BasePtForecaster):
         "capability:pred_int": False,
         "capability:flexible_history_length": False,
         "capability:cold_start": False,
-        "tests:skip_by_name": "test_integration",
     }
 
     @classmethod

--- a/pytorch_forecasting/models/nbeats/_nbeatskan_pkg.py
+++ b/pytorch_forecasting/models/nbeats/_nbeatskan_pkg.py
@@ -17,7 +17,6 @@ class NBeatsKAN_pkg(_BasePtForecaster):
         "capability:pred_int": False,
         "capability:flexible_history_length": False,
         "capability:cold_start": False,
-        "tests:skip_by_name": "test_integration",
     }
 
     @classmethod


### PR DESCRIPTION
This PR updates the NBeatsAdapter to ensure that both NBeats and NBeatsKAN models return 3D tensors (batch_size, prediction_length, 1) for point predictions, aligning with the expected output format #1975.