### PR TITLE
standardize output format of xLSTMTime estimator for point predictions

### DIFF
--- a/pytorch_forecasting/models/xlstm/_xlstm.py
+++ b/pytorch_forecasting/models/xlstm/_xlstm.py
@@ -151,6 +151,7 @@ class xLSTMTime(AutoRegressiveBaseModel):
         output = output.transpose(1, 2)
 
         output = output[0, ..., : self.hparams.output_size]
+        output = output.unsqueeze(-1)
         return self.to_network_output(prediction=output)
 
     @classmethod


### PR DESCRIPTION
This PR standardizes the output format of the xLSTMTime estimator for point predictions.