### PR TITLE
Fix TslibDataModule setup re-entrancy guards

### DIFF
--- a/pytorch_forecasting/data/_tslib_data_module.py
+++ b/pytorch_forecasting/data/_tslib_data_module.py
@@ -697,30 +697,31 @@ class TslibDataModule(LightningDataModule):
 
         # this is a very rudimentary way to handle the splits when
         # the dataset is of size equal to 1 or 2.
-        self._indices = torch.randperm(total_series)
-        if total_series == 1:
-            self._train_indices = self._indices
-            self._val_indices = self._indices
-            self._test_indices = self._indices
-        elif total_series == 2:
-            self._train_indices = self._indices[0:1]
-            self._val_indices = self._indices[1:2]
-            self._test_indices = self._indices[1:2]
-        else:
-            self._train_size = int(self.train_val_test_split[0] * total_series)
-            self._val_size = int(self.train_val_test_split[1] * total_series)
+        if not hasattr(self, "_indices"):
+            self._indices = torch.randperm(total_series)
+            if total_series == 1:
+                self._train_indices = self._indices
+                self._val_indices = self._indices
+                self._test_indices = self._indices
+            elif total_series == 2:
+                self._train_indices = self._indices[0:1]
+                self._val_indices = self._indices[1:2]
+                self._test_indices = self._indices[1:2]
+            else:
+                self._train_size = int(self.train_val_test_split[0] * total_series)
+                self._val_size = int(self.train_val_test_split[1] * total_series)
 
-            self._train_indices = self._indices[: self._train_size]
-            self._val_indices = self._indices[
-                self._train_size : self._train_size + self._val_size
-            ]
+                self._train_indices = self._indices[: self._train_size]
+                self._val_indices = self._indices[
+                    self._train_size : self._train_size + self._val_size
+                ]
 
-            self._test_indices = self._indices[
-                self._train_size + self._val_size : total_series
-            ]
+                self._test_indices = self._indices[
+                    self._train_size + self._val_size : total_series
+                ]
 
         if stage == "fit" or stage is None:
-            if not hasattr(self, "_train_dataset") or not hasattr(self, "_val_dataset"):
+            if self.train_dataset is None or self.val_dataset is None:
                 self._train_windows = self._create_windows(self._train_indices)
                 self._val_windows = self._create_windows(self._val_indices)
 
@@ -738,7 +739,7 @@ class TslibDataModule(LightningDataModule):
                     add_relative_time_idx=self.add_relative_time_idx,
                 )
         elif stage == "test":
-            if not hasattr(self, "_test_dataset"):
+            if self.test_dataset is None:
                 self._test_windows = self._create_windows(self._test_indices)
 
                 self.test_dataset = _TslibDataset(

--- a/pytorch_forecasting/data/_tslib_data_module.py
+++ b/pytorch_forecasting/data/_tslib_data_module.py
@@ -350,6 +350,7 @@ class TslibDataModule(LightningDataModule):
         self.train_dataset = None
         self.val_dataset = None
         self.test_dataset = None
+        self.predict_dataset = None
 
         self.window_stride = window_stride
 
@@ -750,15 +751,16 @@ class TslibDataModule(LightningDataModule):
                 )
 
         elif stage == "predict":
-            predict_indices = torch.arange(len(self.time_series_dataset))
-            self._predict_windows = self._create_windows(predict_indices)
+            if self.predict_dataset is None:
+                predict_indices = torch.arange(len(self.time_series_dataset))
+                self._predict_windows = self._create_windows(predict_indices)
 
-            self.predict_dataset = _TslibDataset(
-                dataset=self.time_series_dataset,
-                data_module=self,
-                windows=self._predict_windows,
-                add_relative_time_idx=self.add_relative_time_idx,
-            )
+                self.predict_dataset = _TslibDataset(
+                    dataset=self.time_series_dataset,
+                    data_module=self,
+                    windows=self._predict_windows,
+                    add_relative_time_idx=self.add_relative_time_idx,
+                )
 
     def train_dataloader(self) -> DataLoader:
         """

--- a/pytorch_forecasting/data/tests/test_tslib_data_module.py
+++ b/pytorch_forecasting/data/tests/test_tslib_data_module.py
@@ -175,6 +175,19 @@ def test_setup_fit_is_reentrant(tslib_data_module):
     assert tslib_data_module._val_windows is first_val_windows
 
 
+def test_setup_predict_is_reentrant(tslib_data_module):
+    """Repeated predict setup should not recreate the predict dataset."""
+    tslib_data_module.setup(stage="predict")
+
+    first_predict_dataset = tslib_data_module.predict_dataset
+    first_predict_windows = tslib_data_module._predict_windows
+
+    tslib_data_module.setup(stage="predict")
+
+    assert tslib_data_module.predict_dataset is first_predict_dataset
+    assert tslib_data_module._predict_windows is first_predict_windows
+
+
 def test_train_dataloader(tslib_data_module):
     """Test the train dataloader to ensure it returns the batches of the data,
     and all hyperparameters are correctly set."""

--- a/pytorch_forecasting/data/tests/test_tslib_data_module.py
+++ b/pytorch_forecasting/data/tests/test_tslib_data_module.py
@@ -156,6 +156,25 @@ def test_setup(tslib_data_module):
     assert len(tslib_data_module._predict_windows) > 0
 
 
+def test_setup_fit_is_reentrant(tslib_data_module):
+    """Repeated fit setup should not recreate splits or datasets."""
+    tslib_data_module.setup(stage="fit")
+
+    first_indices = tslib_data_module._indices.clone()
+    first_train_dataset = tslib_data_module.train_dataset
+    first_val_dataset = tslib_data_module.val_dataset
+    first_train_windows = tslib_data_module._train_windows
+    first_val_windows = tslib_data_module._val_windows
+
+    tslib_data_module.setup(stage="fit")
+
+    assert torch.equal(tslib_data_module._indices, first_indices)
+    assert tslib_data_module.train_dataset is first_train_dataset
+    assert tslib_data_module.val_dataset is first_val_dataset
+    assert tslib_data_module._train_windows is first_train_windows
+    assert tslib_data_module._val_windows is first_val_windows
+
+
 def test_train_dataloader(tslib_data_module):
     """Test the train dataloader to ensure it returns the batches of the data,
     and all hyperparameters are correctly set."""


### PR DESCRIPTION
## Summary
- reuse the original randomized split indices when setup() is called repeatedly
- check the actual dataset attributes instead of nonexistent private names before rebuilding datasets
- add a regression test covering repeated setup(stage="fit") calls

## Testing
- python3.11 -m py_compile pytorch_forecasting/data/_tslib_data_module.py pytorch_forecasting/data/tests/test_tslib_data_module.py

Closes #2218