### PR TITLE
[BUG]: Fixed the incorrect time propagation

### DIFF
--- a/pytorch_forecasting/data/_tslib_data_module.py
+++ b/pytorch_forecasting/data/_tslib_data_module.py
@@ -219,8 +219,37 @@ class _TslibDataset(Dataset):
             x["future_relative_time_idx"] = torch.arange(0, prediction_length)
 
         if processed_data["static"] is not None:
-            x["static_categorical_features"] = processed_data["static"].unsqueeze(0)
-            x["static_continuous_features"] = processed_data["static"].unsqueeze(0)
+            static_features = processed_data["static"]
+            if not isinstance(static_features, torch.Tensor):
+                static_features = torch.tensor(static_features, dtype=torch.float32)
+            static_features = static_features.flatten()
+
+            static_feature_names = metadata["feature_names"]["static"]
+            static_categorical_names = set(
+                metadata["feature_names"]["static_categorical"]
+            )
+
+            static_categorical_indices = [
+                idx
+                for idx, name in enumerate(static_feature_names)
+                if name in static_categorical_names
+            ]
+            static_continuous_indices = [
+                idx
+                for idx, name in enumerate(static_feature_names)
+                if name not in static_categorical_names
+            ]
+
+            x["static_categorical_features"] = (
+                static_features[static_categorical_indices].unsqueeze(0)
+                if len(static_categorical_indices) > 0
+                else torch.zeros((1, 0), dtype=static_features.dtype)
+            )
+            x["static_continuous_features"] = (
+                static_features[static_continuous_indices].unsqueeze(0)
+                if len(static_continuous_indices) > 0
+                else torch.zeros((1, 0), dtype=static_features.dtype)
+            )
 
         if "target_scale" in processed_data:
             x["target_scale"] = processed_data["target_scale"]

--- a/pytorch_forecasting/data/_tslib_data_module.py
+++ b/pytorch_forecasting/data/_tslib_data_module.py
@@ -192,8 +192,8 @@ class _TslibDataset(Dataset):
         history_target = processed_data["target"][history_indices]
         future_target = processed_data["target"][future_indices]
 
-        # history_time_idx = processed_data["timestep"][history_indices]
-        # future_time_idx = processed_data["timestep"][future_indices]
+        history_time_idx = torch.as_tensor(processed_data["timestep"][history_indices])
+        future_time_idx = torch.as_tensor(processed_data["timestep"][future_indices])
 
         x = {
             "history_cont": history_cont,
@@ -205,10 +205,8 @@ class _TslibDataset(Dataset):
             "history_mask": history_mask,
             "future_mask": future_mask,
             "groups": processed_data["group"],
-            "history_time_idx": torch.arange(context_length),
-            "future_time_idx": torch.arange(
-                context_length, context_length + prediction_length
-            ),
+            "history_time_idx": history_time_idx,
+            "future_time_idx": future_time_idx,
             "history_target": history_target,
             "future_target": future_target,
             "future_target_len": torch.tensor(prediction_length),

--- a/pytorch_forecasting/data/tests/test_tslib_data_module.py
+++ b/pytorch_forecasting/data/tests/test_tslib_data_module.py
@@ -269,6 +269,42 @@ def test_tslib_dataset(tslib_data_module):
     assert sample_y.dtype == torch.float32
 
 
+def test_tslib_dataset_preserves_original_time_idx():
+    """Test that dataset windows preserve source timesteps for time indices."""
+    df = pd.DataFrame(
+        {
+            "series_id": [0] * 6,
+            "time_idx": [10, 12, 15, 19, 20, 25],
+            "target": [1.0, 1.2, 1.5, 1.9, 2.0, 2.5],
+            "feature_1": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
+        }
+    )
+
+    ts = TimeSeries(
+        data=df,
+        time="time_idx",
+        target="target",
+        group=["series_id"],
+        num=["feature_1"],
+        known=["feature_1"],
+        unknown=["target"],
+    )
+
+    dm = TslibDataModule(
+        time_series_dataset=ts,
+        context_length=3,
+        prediction_length=2,
+        batch_size=1,
+        train_val_test_split=(1.0, 0.0, 0.0),
+    )
+    dm.setup(stage="fit")
+
+    x, _ = dm.train_dataset[0]
+
+    assert torch.equal(x["history_time_idx"], torch.tensor([10, 12, 15]))
+    assert torch.equal(x["future_time_idx"], torch.tensor([19, 20]))
+
+
 def test_collate_fn(tslib_data_module):
     """Test the collate function in the TslibDataModule to ensure it correctly
     collates the data into batches and properly handles stacking of batches."""

--- a/tests/test_models/test_timexer_v2.py
+++ b/tests/test_models/test_timexer_v2.py
@@ -440,3 +440,4 @@ def test_static_features_are_split_by_type_in_tslib_output():
     x, _ = next(iter(dm.train_dataloader()))
     assert x["static_categorical_features"].shape[-1] == 1
     assert x["static_continuous_features"].shape[-1] == 1
+    

--- a/tests/test_models/test_timexer_v2.py
+++ b/tests/test_models/test_timexer_v2.py
@@ -440,4 +440,3 @@ def test_static_features_are_split_by_type_in_tslib_output():
     x, _ = next(iter(dm.train_dataloader()))
     assert x["static_categorical_features"].shape[-1] == 1
     assert x["static_continuous_features"].shape[-1] == 1
-    

--- a/tests/test_models/test_timexer_v2.py
+++ b/tests/test_models/test_timexer_v2.py
@@ -394,3 +394,49 @@ def test_integration_with_datamodule(model, basic_tslib_data_module):
             assert test_output["prediction"].shape[1] == model.prediction_length
         except StopIteration:
             print("Test set is empty, skipping test testing")
+
+
+def test_static_features_are_split_by_type_in_tslib_output():
+    """Ensure static categorical and continuous tensors are separated in v2 output."""
+    np.random.seed(42)
+
+    df = pd.DataFrame(
+        {
+            "time_idx": np.tile(np.arange(30), 2),
+            "group_id": np.repeat(["group_0", "group_1"], 30),
+            "value": np.random.randn(60).astype(np.float32),
+            "temperature": np.random.randn(60).astype(np.float32),
+            "humidity": np.random.randn(60).astype(np.float32),
+            "pressure": np.random.randn(60).astype(np.float32),
+            "static_cont_feat": np.repeat([10.0, 20.0], 30).astype(np.float32),
+            "static_cat_feat": np.repeat([0, 1], 30),
+        }
+    )
+    df["group_id"] = df["group_id"].astype("category")
+
+    ts = TimeSeries(
+        df,
+        time="time_idx",
+        target="value",
+        group=["group_id"],
+        num=["value", "temperature", "humidity", "pressure", "static_cont_feat"],
+        cat=["static_cat_feat"],
+        known=["temperature", "humidity", "pressure", "time_idx"],
+        static=["static_cont_feat", "static_cat_feat"],
+    )
+
+    dm = TslibDataModule(
+        time_series_dataset=ts,
+        batch_size=2,
+        context_length=12,
+        prediction_length=8,
+    )
+    dm.setup(stage="fit")
+
+    metadata = dm.metadata
+    assert metadata["n_features"]["static_categorical"] == 1
+    assert metadata["n_features"]["static_continuous"] == 1
+
+    x, _ = next(iter(dm.train_dataloader()))
+    assert x["static_categorical_features"].shape[-1] == 1
+    assert x["static_continuous_features"].shape[-1] == 1


### PR DESCRIPTION
<!--
Welcome to pytorch-forecasting, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

# Reference Issues/PRs
Fixes #2263 

# What does this fix? Explain your changes.
This fixes an issue where history_time_idx and future_time_idx in pytorch_forecasting/data/_tslib_data_module.py could be generated from synthetic sequential indices (torch.arange(...)) instead of real timesteps.
The implementation now propagates true timesteps from processed_data["timestep"], preserving non-zero and irregular time indices.

 # What should a reviewer concentrate their feedback on?
- Correctness of history_time_idx / future_time_idx construction from processed_data["timestep"]
- Any side effects on window slicing/batching behavior in TSLib v2
- Regression test coverage for irregular/non-zero time index scenarios

# Did you add any tests for the change?
Yes. Added:
pytorch_forecasting/data/tests/test_tslib_data_module.py::test_tslib_dataset_preserves_original_time_idx

# Also validated with:

- ruff check on changed files 

# Any other comments?
There is a pre-existing unrelated baseline failure in full test_tslib_data_module.py (test_multivariate_target, list-vs-shape assertion), observed prior to this fix.

# PR checklist
 - The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
 - Added/modified tests
 - Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with pre-commit install. To run hooks independent of commit, execute pre-commit run --all-files