### PR TITLE
[BUG] Ensure writable NumPy array before tensor indexing in `decoded_index`

### DIFF
--- a/pytorch_forecasting/data/timeseries/_timeseries.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries.py
@@ -1934,8 +1934,8 @@ class TimeSeriesDataSet(Dataset):
             pd.DataFrame: index that can be understood in terms of original data
         """
         # get dataframe to filter
-        index_start = self.index["index_start"].to_numpy()
-        index_last = self.index["index_end"].to_numpy()
+        index_start = self.index["index_start"].to_numpy(copy=True)
+        index_last = self.index["index_end"].to_numpy(copy=True)
         index = (
             # get group ids in order of index
             pd.DataFrame(


### PR DESCRIPTION
  ## Summary
This PR fixes #2299.

A warning raised by PyTorch when `.decoded_index` uses a non‑writable NumPy array (derived from `pandas.DataFrame.to_numpy()`) to index a `torch.Tensor`.

PyTorch emits the following warning on first occurrence:

> UserWarning: The given NumPy array is not writable, and PyTorch does not support non-writable tensors. This means writing to this tensor will result in undefined behavior. You may want to copy the array to protect its data or make it writable before converting it to a tensor. This type of warning will be suppressed for the rest of this program.

Although the warning is suppressed after the first emission, it indicates a real underlying issue.

---

 ## Root cause
`pandas.DataFrame.to_numpy()` returns a **read‑only** NumPy array in this context.  
This array is then used for tensor slicing inside `.decoded_index`, which triggers PyTorch’s safety check.

---

 ## Fix
The fix is minimal and safe:

- explicitly copy the NumPy array before using it for tensor indexing  
- ensures the array is writable  
- avoids the PyTorch warning entirely

Example change:

```python
index = df.index.to_numpy(copy=True)   # ensure writable
```

---

 ## Why no test is included
 
PyTorch suppresses this warning after the first emission in a process, making it impractical to reliably detect in automated tests.  
The fix is straightforward and low‑risk.

---

 ## Impact
 
- eliminates the PyTorch warning

- avoids undefined behavior

- improves robustness when filtering datasets

- no API changes

- no performance impact


---