### PR TITLE
[DOC] Add FAQ's section for v2 (#2305)

### DIFF
--- a/docs/source/faq_v2.rst
+++ b/docs/source/faq_v2.rst
@@ -12,7 +12,7 @@ and may change without prior notice.
 For general questions about v1, see :doc:`FAQ <faq>`.
 Other places to seek help:
 
-* `PyTorch Lightning documentation <https://pytorch-lightning.readthedocs.io>`_ and issues
+* `PyTorch Lightning documentation <https://lightning.ai/docs/pytorch/stable/>`_ and issues
 * `PyTorch documentation <https://pytorch.org/>`_ and issues
 * `Stack Overflow <https://stackoverflow.com/>`_
 

--- a/docs/source/faq_v2.rst
+++ b/docs/source/faq_v2.rst
@@ -1,0 +1,245 @@
+.. _faq_v2:
+
+FAQ for v2
+==========
+
+.. currentmodule:: pytorch_forecasting
+
+Common questions and answers about the experimental v2 architecture
+of pytorch-forecasting. Note that this API is still under developement
+and may change without prior notice.
+
+For general questions about v1, see :doc:`FAQ <faq>`.
+Other places to seek help:
+
+* `PyTorch Lightning documentation <https://pytorch-lightning.readthedocs.io>`_ and issues
+* `PyTorch documentation <https://pytorch.org/>`_ and issues
+* `Stack Overflow <https://stackoverflow.com/>`_
+
+
+Architecture Overview
+---------------------
+
+* **What is the architecture of v2?**
+
+  pytorch-forecasting v2 is organized into four layers to seperate data ingestion,
+  preprocessing, modelling, and workflow managment:
+
+  * **D1 Layer (TimeSeries):** The raw data ingestion layer. Takes a pandas
+    DataFrame and converts it into PyTorch tensors. It also extracts metadata
+    about the columns.
+  * **D2 Layer (DataModule):** The processing layer. Handles preprocessing,
+    scaling, windowing into encoder/decoder sequences, and creating DataLoaders.
+  * **M Layer (BaseModel):** The neural network layer. Performs the forward pass,
+    training step, and generates predictions.
+  * **P Layer (Package):** A high-level wrapper that coordinates the other layers
+    and provides a simplified ``fit()`` and ``predict()`` API.
+
+  .. code-block:: text
+
+      ┌──────────────────────────────────────────────────┐
+      │             P Layer (Base_pkg)                   │
+      │      High-level API: fit() and predict()         │
+      │                                                  │
+      │   ┌──────────────┐    ┌────────────────────┐     │
+      │   │  D1 Layer    │───▶│  D2 Layer          │     │
+      │   │  TimeSeries  │    │  DataModule        │     │
+      │   │  (Raw Data)  │    │  (Preprocessing)   │     │
+      │   └──────────────┘    └────────────────────┘     │
+      │                              │                   │
+      │                              ▼                   │
+      │                     ┌────────────────────┐       │
+      │                     │  M Layer           │       │
+      │                     │  BaseModel         │       │
+      │                     │  (Neural Network)  │       │
+      │                     └────────────────────┘       │
+      └──────────────────────────────────────────────────┘
+
+
+Creating datasets
+-----------------
+
+* **How do I create a TimeSeries object?**
+
+  The :py:class:`~data.timeseries.TimeSeries` class is the D1 layer.
+  It takes your pandas DataFrame and converts it to raw tensors.
+
+  .. code-block:: python
+
+      import pandas as pd
+      from pytorch_forecasting.data import TimeSeries
+
+      # prepare your pandas DataFrame
+      data = pd.DataFrame({
+          "time_idx": [0, 1, 2, 3, 4, 5] * 2,
+          "group": ["A"] * 6 + ["B"] * 6,
+          "target": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+                     1.5, 2.5, 3.5, 4.5, 5.5, 6.5],
+          "feature_1": [10, 20, 30, 40, 50, 60] * 2,
+          "holiday": [0, 0, 1, 0, 0, 1] * 2,
+      })
+
+      # create the TimeSeries dataset
+      dataset = TimeSeries(
+          data=data,
+          time="time_idx",           # column with time index
+          target="target",           # what to predict
+          group=["group"],           # each group is a seperate time series
+          known=["holiday"],         # known in the future
+          unknown=["feature_1"],     # not known in the future
+          num=["feature_1"],         # numerical columns
+          cat=["holiday"],           # categorical columns
+      )
+
+      # access a single time series by index
+      sample = dataset[0]
+      print(sample["y"])   # target values as tensor
+      print(sample["x"])   # feature values as tensor
+      print(sample["t"])   # time index values
+
+
+* **What is the difference between TimeSeries, TimeSeriesDataSet and DataModule?**
+
+  In v1, ``TimeSeriesDataSet`` handled everthing from data loading to preprocessing
+  and batching in a single monolithic class. In v2, these responsibilites are split
+  into ``TimeSeries`` (D1 layer, raw data only) and ``DataModule``
+  (D2 layer, preprocessing and batching).
+
+  .. list-table:: v1 vs v2 Comparison
+     :header-rows: 1
+     :widths: 25 35 40
+
+     * - Feature
+       - v1: ``TimeSeriesDataSet``
+       - v2: ``TimeSeries`` + ``DataModule``
+     * - Data Loading
+       - Built-in
+       - ``TimeSeries`` (D1)
+     * - Preprocessing and Scaling
+       - Built-in
+       - ``DataModule`` (D2)
+     * - Windowing and Split
+       - Built-in
+       - ``DataModule`` (D2)
+     * - DataLoaders
+       - ``to_dataloader()``
+       - ``DataModule.train_dataloader()``
+     * - Separation of Concerns
+       - Everything in one large class
+       - Clear responsibilty per layer
+
+  The key advantage of v2 is that each layer has exactly one job, which makes
+  the codebase easier to maintain and extend.
+
+
+Using DataModules
+-----------------
+
+* **How do I create and use DataModules?**
+
+  The DataModule is the D2 layer - it takes the raw tensors from the
+  ``TimeSeries`` object and prepares them for the model. Currently two
+  DataModules are available:
+
+  - ``EncoderDecoderTimeSeriesDataModule`` - for encoder-decoder style models
+  - ``TslibDataModule`` - for TSLib-style models (e.g. DLinear)
+
+  .. code-block:: python
+
+      from pytorch_forecasting.data import TimeSeries
+      from pytorch_forecasting.data.data_module import (
+          EncoderDecoderTimeSeriesDataModule,
+      )
+
+      # first, create the D1 layer (TimeSeries)
+      dataset = TimeSeries(
+          data=data,
+          time="time_idx",
+          target="target",
+          group=["group"],
+      )
+
+      # then create the D2 layer (DataModule)
+      datamodule = EncoderDecoderTimeSeriesDataModule(
+          time_series_dataset=dataset,
+          max_encoder_length=30,        # how much past history to use
+          max_prediction_length=6,      # how far into future to predict
+          batch_size=32,
+          train_val_test_split=(0.7, 0.15, 0.15),
+      )
+
+      # setup creates the internal windows and data splits
+      datamodule.setup(stage="fit")
+
+      # now you can use the DataLoaders for training
+      train_loader = datamodule.train_dataloader()
+      val_loader = datamodule.val_dataloader()
+
+      # metadata is available for model initalization
+      print(datamodule.metadata)
+
+
+Training and Prediction
+-----------------------
+
+* **How do I use pkg classes to perform fit and predict?**
+
+  The ``pkg`` (package) is the P layer - it wraps model, datamodule, and
+  trainer configuration into a single convenient interface.
+
+  Each model class has a ``pkg`` class property that returns the corresponding
+  package class. You can instanciate it with your configs and call ``fit()``
+  and ``predict()``.
+
+  .. code-block:: python
+
+      from pytorch_forecasting.models.dlinear import DLinear
+
+      # DLinear.pkg returns the package class (DLinear_pkg_v2)
+      # instantiate it with your configuration
+      pkg = DLinear.pkg(
+          model_cfg={"moving_avg": 25},
+          datamodule_cfg={
+              "context_length": 30,
+              "prediction_length": 6,
+          },
+          trainer_cfg={"max_epochs": 10},
+      )
+
+      # fit the model - pass your TimeSeries object directly
+      best_ckpt_path = pkg.fit(dataset, save_ckpt=True)
+
+      # generate predictions
+      predictions = pkg.predict(dataset)
+
+      # later, you can load from a checkpoint
+      pkg_loaded = DLinear.pkg(ckpt_path="checkpoints/best-model.ckpt")
+      predictions = pkg_loaded.predict(new_dataset)
+
+
+Extending the package
+---------------------
+
+* **How do I add a new model to the package?**
+
+  To add a new model, use the extension templates provided in
+  ``extension_templates/v2/model_simple/``:
+
+  1. Copy ``model.py`` and ``model_pkg.py`` templates to your target directory.
+  2. **Implement the Model class:** Inherit from ``BaseModel`` and implement
+     ``__init__()``, ``forward()``, and ``_pkg()`` methods.
+  3. **Implement the Package class:** Inherit from ``Base_pkg``, set the
+     ``_tags`` dictionary describing your model's capabilites, and implement
+     ``get_cls()``, ``get_datamodule_cls()``, and ``get_test_train_params()``.
+  4. **Register** your model in ``pytorch_forecasting/models/__init__.py``.
+  5. **Verify** your implementation by running the built-in interface checks:
+
+  .. code-block:: python
+
+      from pytorch_forecasting.utils._estimator_checks import check_estimator
+      from pytorch_forecasting.models.my_model import MyModel
+
+      check_estimator(MyModel)
+
+  For detailed instructions, see the
+  `extension templates README <https://github.com/sktime/pytorch-forecasting/blob/main/extension_templates/v2/README.md>`_.

--- a/docs/source/faq_v2.rst
+++ b/docs/source/faq_v2.rst
@@ -6,7 +6,7 @@ FAQ for v2
 .. currentmodule:: pytorch_forecasting
 
 Common questions and answers about the experimental v2 architecture
-of pytorch-forecasting. Note that this API is still under developement
+of pytorch-forecasting. Note that this API is still under development
 and may change without prior notice.
 
 For general questions about v1, see :doc:`FAQ <faq>`.
@@ -22,8 +22,8 @@ Architecture Overview
 
 * **What is the architecture of v2?**
 
-  pytorch-forecasting v2 is organized into four layers to seperate data ingestion,
-  preprocessing, modelling, and workflow managment:
+  pytorch-forecasting v2 is organized into four layers to separate data ingestion,
+  preprocessing, modeling, and workflow management:
 
   * **D1 Layer (TimeSeries):** The raw data ingestion layer. Takes a pandas
     DataFrame and converts it into PyTorch tensors. It also extracts metadata
@@ -84,7 +84,7 @@ Creating datasets
           data=data,
           time="time_idx",           # column with time index
           target="target",           # what to predict
-          group=["group"],           # each group is a seperate time series
+          group=["group"],           # each group is a separate time series
           known=["holiday"],         # known in the future
           unknown=["feature_1"],     # not known in the future
           num=["feature_1"],         # numerical columns
@@ -100,8 +100,8 @@ Creating datasets
 
 * **What is the difference between TimeSeries, TimeSeriesDataSet and DataModule?**
 
-  In v1, ``TimeSeriesDataSet`` handled everthing from data loading to preprocessing
-  and batching in a single monolithic class. In v2, these responsibilites are split
+  In v1, ``TimeSeriesDataSet`` handled everything from data loading to preprocessing
+  and batching in a single monolithic class. In v2, these responsibilities are split
   into ``TimeSeries`` (D1 layer, raw data only) and ``DataModule``
   (D2 layer, preprocessing and batching).
 
@@ -126,7 +126,7 @@ Creating datasets
        - ``DataModule.train_dataloader()``
      * - Separation of Concerns
        - Everything in one large class
-       - Clear responsibilty per layer
+       - Clear responsibility per layer
 
   The key advantage of v2 is that each layer has exactly one job, which makes
   the codebase easier to maintain and extend.
@@ -175,7 +175,7 @@ Using DataModules
       train_loader = datamodule.train_dataloader()
       val_loader = datamodule.val_dataloader()
 
-      # metadata is available for model initalization
+      # metadata is available for model initialization
       print(datamodule.metadata)
 
 
@@ -188,7 +188,7 @@ Training and Prediction
   trainer configuration into a single convenient interface.
 
   Each model class has a ``pkg`` class property that returns the corresponding
-  package class. You can instanciate it with your configs and call ``fit()``
+  package class. You can instantiate it with your configs and call ``fit()``
   and ``predict()``.
 
   .. code-block:: python
@@ -229,7 +229,7 @@ Extending the package
   2. **Implement the Model class:** Inherit from ``BaseModel`` and implement
      ``__init__()``, ``forward()``, and ``_pkg()`` methods.
   3. **Implement the Package class:** Inherit from ``Base_pkg``, set the
-     ``_tags`` dictionary describing your model's capabilites, and implement
+     ``_tags`` dictionary describing your model's capabilities, and implement
      ``get_cls()``, ``get_datamodule_cls()``, and ``get_test_train_params()``.
   4. **Register** your model in ``pytorch_forecasting/models/__init__.py``.
   5. **Verify** your implementation by running the built-in interface checks:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -66,6 +66,7 @@ The :ref:`Tutorials <tutorials>` section provides guidance on how to use models 
    models
    metrics
    faq
+   faq_v2
    installation
    api
    CHANGELOG

--- a/docs/source/tutorials/ar.ipynb
+++ b/docs/source/tutorials/ar.ipynb
@@ -342,8 +342,7 @@
     "    min_lr=1e-5,\n",
     ")\n",
     "print(f\"suggested learning rate: {res.suggestion()}\")\n",
-    "fig = res.plot(show=True, suggest=True)\n",
-    "fig.show()\n",
+    "res.plot(show=True, suggest=True)\n",
     "net.hparams.learning_rate = res.suggestion()"
    ]
   },

--- a/docs/source/tutorials/deepar.ipynb
+++ b/docs/source/tutorials/deepar.ipynb
@@ -359,8 +359,7 @@
     "    early_stop_threshold=100,\n",
     ")\n",
     "print(f\"suggested learning rate: {res.suggestion()}\")\n",
-    "fig = res.plot(show=True, suggest=True)\n",
-    "fig.show()\n",
+    "res.plot(show=True, suggest=True)\n",
     "net.hparams.learning_rate = res.suggestion()"
    ]
   },

--- a/docs/source/tutorials/nhits.ipynb
+++ b/docs/source/tutorials/nhits.ipynb
@@ -363,8 +363,7 @@
     "    max_lr=1e-1,\n",
     ")\n",
     "print(f\"suggested learning rate: {res.suggestion()}\")\n",
-    "fig = res.plot(show=True, suggest=True)\n",
-    "fig.show()\n",
+    "res.plot(show=True, suggest=True)\n",
     "net.hparams.learning_rate = res.suggestion()"
    ]
   },

--- a/docs/source/tutorials/stallion.ipynb
+++ b/docs/source/tutorials/stallion.ipynb
@@ -41,7 +41,6 @@
    "source": [
     "import warnings\n",
     "\n",
-    "\n",
     "warnings.filterwarnings(\"ignore\")  # avoid printing out absolute paths"
    ]
   },
@@ -1078,8 +1077,7 @@
     ")\n",
     "\n",
     "print(f\"suggested learning rate: {res.suggestion()}\")\n",
-    "fig = res.plot(show=True, suggest=True)\n",
-    "fig.show()"
+    "res.plot(show=True, suggest=True)"
    ]
   },
   {


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #2305

#### What does this implement/fix? Explain your changes.
Added a new `docs/source/faq_v2.rst` file to document the experimental v2 architecture with a dedicated FAQ section. The following topics are covered:

- Overview of the v2 layered architecture (D1, D2, M, P) with a text diagram
- How to create a `TimeSeries` object (D1 layer) with code example
- Comparison table between v1 `TimeSeriesDataSet` and v2 `TimeSeries` + `DataModule`
- How to create and use `DataModules` (D2 layer) with code example
- How to use `pkg` classes for `fit()` and `predict()` with code example
- How to add a new model using extension templates

Also added `faq_v2` to the toctree in `docs/source/index.rst`.

#### What should a reviewer concentrate their feedback on?
- Whether a separate `faq_v2.rst` file is preferred, or should this content be appended to the existing `faq.rst` instead?
- Accuracy of the architecture description and code examples
- Whether `TslibDataModule` should also get its own detailed example alongside `EncoderDecoderTimeSeriesDataModule`

#### Did you add any tests for the change?
No, this is a documentation-only change. No tests are required.

#### Any other comments?
All code examples were verified against the current source code to ensure correctness. AI tools were used to assist with drafting.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] Added/modified tests (N/A - documentation only)
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.


