### PR TITLE
[MNT] add an upper bound on `matplotlib` to prevent failing notebooks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
 #
 all_extras = [
   "cpflows",
-  "matplotlib",
+  "matplotlib<3.11.0",
   "optuna >=3.1.0,<5.0.0",
   "optuna-integration",
   "pytorch_optimizer >=2.5.1,<4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dev = [
   "black[jupyter]",
   # documentatation
   "sphinx",
-  "pydata-sphinx-theme<0.19.0",
+  "pydata-sphinx-theme",
   "nbsphinx",
   "recommonmark",
   "ipywidgets>=8.0.1,<9.0.0",
@@ -108,7 +108,7 @@ dev = [
 # docs - dependencies for building the documentation
 docs = [
   "sphinx>3.2,<9.1.1",
-  "pydata-sphinx-theme<0.19.0",
+  "pydata-sphinx-theme",
   "nbsphinx",
   "pandoc",
   "nbconvert",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dev = [
   "black[jupyter]",
   # documentatation
   "sphinx",
-  "pydata-sphinx-theme",
+  "pydata-sphinx-theme<0.19.0",
   "nbsphinx",
   "recommonmark",
   "ipywidgets>=8.0.1,<9.0.0",
@@ -108,7 +108,7 @@ dev = [
 # docs - dependencies for building the documentation
 docs = [
   "sphinx>3.2,<9.1.1",
-  "pydata-sphinx-theme",
+  "pydata-sphinx-theme<0.19.0",
   "nbsphinx",
   "pandoc",
   "nbconvert",


### PR DESCRIPTION
This PR adds an upper bound to  `matplotlib` to prevent failing notebooks on main.
See #2314
