### PR TITLE
[MNT] Solve the failing notebooks on main due to `matplotlib 3.11`

### DIFF
--- a/docs/source/tutorials/ar.ipynb
+++ b/docs/source/tutorials/ar.ipynb
@@ -343,7 +343,6 @@
     ")\n",
     "print(f\"suggested learning rate: {res.suggestion()}\")\n",
     "fig = res.plot(show=True, suggest=True)\n",
-    "fig.show()\n",
     "net.hparams.learning_rate = res.suggestion()"
    ]
   },

--- a/docs/source/tutorials/deepar.ipynb
+++ b/docs/source/tutorials/deepar.ipynb
@@ -360,7 +360,6 @@
     ")\n",
     "print(f\"suggested learning rate: {res.suggestion()}\")\n",
     "fig = res.plot(show=True, suggest=True)\n",
-    "fig.show()\n",
     "net.hparams.learning_rate = res.suggestion()"
    ]
   },

--- a/docs/source/tutorials/nhits.ipynb
+++ b/docs/source/tutorials/nhits.ipynb
@@ -364,7 +364,6 @@
     ")\n",
     "print(f\"suggested learning rate: {res.suggestion()}\")\n",
     "fig = res.plot(show=True, suggest=True)\n",
-    "fig.show()\n",
     "net.hparams.learning_rate = res.suggestion()"
    ]
   },

--- a/docs/source/tutorials/stallion.ipynb
+++ b/docs/source/tutorials/stallion.ipynb
@@ -1078,8 +1078,7 @@
     ")\n",
     "\n",
     "print(f\"suggested learning rate: {res.suggestion()}\")\n",
-    "fig = res.plot(show=True, suggest=True)\n",
-    "fig.show()"
+    "fig = res.plot(show=True, suggest=True)"
    ]
   },
   {

--- a/docs/source/tutorials/stallion.ipynb
+++ b/docs/source/tutorials/stallion.ipynb
@@ -41,7 +41,6 @@
    "source": [
     "import warnings\n",
     "\n",
-    "\n",
     "warnings.filterwarnings(\"ignore\")  # avoid printing out absolute paths"
    ]
   },
@@ -991,7 +990,6 @@
     "    # of the gradient for recurrent neural networks\n",
     "    gradient_clip_val=0.1,\n",
     ")\n",
-    "\n",
     "\n",
     "tft = TemporalFusionTransformer.from_dataset(\n",
     "    training,\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
 #
 all_extras = [
   "cpflows",
-  "matplotlib<3.11.0",
+  "matplotlib<3.12.0",
   "optuna >=3.1.0,<5.0.0",
   "optuna-integration",
   "pytorch_optimizer >=2.5.1,<4.0.0",


### PR DESCRIPTION
This PR fixes #2314 and solves the failing notebooks on main due to `matplotlib 3.11`.
By removing `fig.show()` it will still show the figure on the notebook (as we pass `True` to `res.plot(show=True)`).
We dont need to add `fig.show()` anymore!