### PR TITLE
[MNT] Fix windows CI failing on main by adding upper bound on `pytest-github-actions-annotate-failures`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,6 @@ jobs:
         shell: bash
         run: |
           pip install ".[dev,github-actions]"
-          pip install pytest-github-actions-annotate-failures==0.4.0
 
       - name: Show dependencies
         run: python -m pip list
@@ -191,7 +190,6 @@ jobs:
         shell: bash
         run: |
           pip install ".[dev,all_extras,github-actions]"
-          pip install pytest-github-actions-annotate-failures==0.4.0
 
       - name: Show dependencies
         run: python -m pip list

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,7 @@ jobs:
         shell: bash
         run: |
           pip install ".[dev,github-actions]"
+          pip install pytest-github-actions-annotate-failures==0.4.0
 
       - name: Show dependencies
         run: python -m pip list
@@ -190,6 +191,7 @@ jobs:
         shell: bash
         run: |
           pip install ".[dev,all_extras,github-actions]"
+          pip install pytest-github-actions-annotate-failures==0.4.0
 
       - name: Show dependencies
         run: python -m pip list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ docs = [
   "docutils",
 ]
 
-github-actions = ["pytest-github-actions-annotate-failures"]
+github-actions = ["pytest-github-actions-annotate-failures<0.4.1"]
 
 [tool.setuptools.packages.find]
 exclude = ["build_tools"]


### PR DESCRIPTION
This PR tries to fix the failing windows CI on main

- Attempt 1: `pytest-github-actions-annotate-failures` released a patch 15 hours ago, maybe that is an issue? 
