### PR TITLE
[ENH] Add v2 interface support for N-BEATS model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/d3j8x8q7/olympus-base-python:latest
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir .[dev,all_extras]
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM public.ecr.aws/d3j8x8q7/olympus-base-python:latest
-
-WORKDIR /app
-
-COPY . .
-
-RUN pip install --no-cache-dir .[dev,all_extras]
-
-CMD ["/bin/bash"]

--- a/docs/source/m_layer_v2.rst
+++ b/docs/source/m_layer_v2.rst
@@ -48,3 +48,4 @@ See the detailed API documentation for the V2 base classes and specific model im
    models.tide._tide_dsipts._tide_v2.TIDE
    models.timexer._timexer_v2.TimeXer
    models.mlp._decodermlp_v2.DecoderMLP_v2
+   models.nbeats._nbeats_v2.NBeats_v2

--- a/docs/source/pkg_v2.rst
+++ b/docs/source/pkg_v2.rst
@@ -100,3 +100,4 @@ See the detailed API documentation for the available V2 Package classes below:
    models.tide._tide_dsipts._tide_v2_pkg.TIDE_pkg_v2
    models.timexer._timexer_pkg_v2.TimeXer_pkg_v2
    models.mlp._decodermlp_pkg_v2.DecoderMLP_pkg_v2
+   models.nbeats._nbeats_pkg_v2.NBeats_pkg_v2

--- a/pytorch_forecasting/models/__init__.py
+++ b/pytorch_forecasting/models/__init__.py
@@ -11,7 +11,12 @@ from pytorch_forecasting.models.base import (
 from pytorch_forecasting.models.baseline import Baseline
 from pytorch_forecasting.models.deepar import DeepAR
 from pytorch_forecasting.models.mlp import DecoderMLP
-from pytorch_forecasting.models.nbeats import NBeats, NBeatsKAN
+from pytorch_forecasting.models.nbeats import (
+    NBeats,
+    NBeats_pkg_v2,
+    NBeats_v2,
+    NBeatsKAN,
+)
 from pytorch_forecasting.models.nhits import NHiTS
 from pytorch_forecasting.models.nn import GRU, LSTM, MultiEmbedding, get_rnn
 from pytorch_forecasting.models.rnn import RecurrentNetwork
@@ -25,6 +30,8 @@ from pytorch_forecasting.models.xlstm import xLSTMTime
 
 __all__ = [
     "NBeats",
+    "NBeats_v2",
+    "NBeats_pkg_v2",
     "NBeatsKAN",
     "NHiTS",
     "TemporalFusionTransformer",

--- a/pytorch_forecasting/models/nbeats/__init__.py
+++ b/pytorch_forecasting/models/nbeats/__init__.py
@@ -14,6 +14,7 @@ from pytorch_forecasting.models.nbeats._grid_callback import GridUpdateCallback
 from pytorch_forecasting.models.nbeats._nbeats import NBeats
 from pytorch_forecasting.models.nbeats._nbeats_adapter import NBeatsAdapter
 from pytorch_forecasting.models.nbeats._nbeats_pkg import NBeats_pkg
+from pytorch_forecasting.models.nbeats._nbeats_pkg_v2 import NBeats_pkg_v2
 from pytorch_forecasting.models.nbeats._nbeatskan import NBeatsKAN
 from pytorch_forecasting.models.nbeats._nbeatskan_pkg import NBeatsKAN_pkg
 
@@ -21,6 +22,7 @@ __all__ = [
     "NBeats",
     "NBeatsKAN",
     "NBeats_pkg",
+    "NBeats_pkg_v2",
     "NBeatsKAN_pkg",
     "NBEATSGenericBlock",
     "NBEATSSeasonalBlock",

--- a/pytorch_forecasting/models/nbeats/__init__.py
+++ b/pytorch_forecasting/models/nbeats/__init__.py
@@ -15,11 +15,13 @@ from pytorch_forecasting.models.nbeats._nbeats import NBeats
 from pytorch_forecasting.models.nbeats._nbeats_adapter import NBeatsAdapter
 from pytorch_forecasting.models.nbeats._nbeats_pkg import NBeats_pkg
 from pytorch_forecasting.models.nbeats._nbeats_pkg_v2 import NBeats_pkg_v2
+from pytorch_forecasting.models.nbeats._nbeats_v2 import NBeats_v2
 from pytorch_forecasting.models.nbeats._nbeatskan import NBeatsKAN
 from pytorch_forecasting.models.nbeats._nbeatskan_pkg import NBeatsKAN_pkg
 
 __all__ = [
     "NBeats",
+    "NBeats_v2",
     "NBeatsKAN",
     "NBeats_pkg",
     "NBeats_pkg_v2",

--- a/pytorch_forecasting/models/nbeats/_nbeats_pkg_v2.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_pkg_v2.py
@@ -1,0 +1,79 @@
+"""NBeats package container."""
+
+from pytorch_forecasting.base._base_pkg import Base_pkg
+
+
+class NBeats_pkg_v2(Base_pkg):
+    """NBeats package container."""
+
+    _tags = {
+        "info:name": "NBeats",
+        "authors": ["jdb78"],
+        "capability:exogenous": False,
+        "capability:multivariate": False,
+        "capability:pred_int": True,
+        "capability:flexible_history_length": False,
+    }
+
+    @classmethod
+    def get_cls(cls):
+        """Get model class."""
+        from pytorch_forecasting.models.nbeats._nbeats_v2 import NBeats
+
+        return NBeats
+
+    @classmethod
+    def get_datamodule_cls(cls):
+        """Get the underlying DataModule class."""
+        from pytorch_forecasting.data.data_module import (
+            EncoderDecoderTimeSeriesDataModule,
+        )
+
+        return EncoderDecoderTimeSeriesDataModule
+
+    @classmethod
+    def get_test_train_params(cls):
+        """Return testing parameter settings for the trainer.
+
+        Returns
+        -------
+        params : dict or list of dict, default = {}
+            Parameters to create testing instances of the class
+            Each dict are parameters to construct an "interesting" test instance, i.e.,
+            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
+            `create_test_instance` uses the first (or only) dictionary in `params`
+        """
+        from pytorch_forecasting.metrics import QuantileLoss
+
+        params = [
+            {},
+            dict(
+                stack_types=["generic"],
+                num_blocks=[1],
+                num_block_layers=[4],
+                widths=[16],
+                backcast_loss_ratio=1.0,
+            ),
+            dict(
+                stack_types=["trend", "seasonality"],
+                num_blocks=[2, 2],
+                widths=[16, 32],
+                backcast_loss_ratio=0.5,
+            ),
+            dict(
+                loss=QuantileLoss(quantiles=[0.1, 0.5, 0.9]),
+                stack_types=["generic"],
+                num_blocks=[1],
+                widths=[16],
+            ),
+        ]
+
+        default_dm_cfg = {"max_encoder_length": 8, "max_prediction_length": 2}
+
+        for param in params:
+            current_dm_cfg = param.get("datamodule_cfg", {})
+            default_dm_cfg.update(current_dm_cfg)
+
+            param["datamodule_cfg"] = default_dm_cfg
+
+        return params

--- a/pytorch_forecasting/models/nbeats/_nbeats_pkg_v2.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_pkg_v2.py
@@ -1,30 +1,53 @@
-"""NBeats package container."""
+"""NBeats v2 package container."""
 
 from pytorch_forecasting.base._base_pkg import Base_pkg
 
 
 class NBeats_pkg_v2(Base_pkg):
-    """NBeats package container."""
+    """
+    NBeats v2 package container.
+
+    Acts as an orchestrator for the N-BEATS v2 model, providing a streamlined
+    configuration-driven interface for dataset handling, model instantiation,
+    training, and inference.
+    """
 
     _tags = {
-        "info:name": "NBeats",
-        "authors": ["jdb78"],
+        "info:name": "NBeats_v2",
+        "info:compute": 1,
+        "authors": ["jdb78", "harshsomankar123-tech"],
+        "info:y_type": ["numeric"],
         "capability:exogenous": False,
         "capability:multivariate": False,
         "capability:pred_int": True,
         "capability:flexible_history_length": False,
+        "capability:cold_start": False,
     }
 
     @classmethod
     def get_cls(cls):
-        """Get model class."""
-        from pytorch_forecasting.models.nbeats._nbeats_v2 import NBeats
+        """
+        Get the underlying model class.
 
-        return NBeats
+        Returns
+        -------
+        type
+            The ``NBeats_v2`` class.
+        """
+        from pytorch_forecasting.models.nbeats._nbeats_v2 import NBeats_v2
+
+        return NBeats_v2
 
     @classmethod
     def get_datamodule_cls(cls):
-        """Get the underlying DataModule class."""
+        """
+        Get the underlying DataModule class.
+
+        Returns
+        -------
+        type
+            The ``EncoderDecoderTimeSeriesDataModule`` class.
+        """
         from pytorch_forecasting.data.data_module import (
             EncoderDecoderTimeSeriesDataModule,
         )
@@ -33,15 +56,15 @@ class NBeats_pkg_v2(Base_pkg):
 
     @classmethod
     def get_test_train_params(cls):
-        """Return testing parameter settings for the trainer.
+        """
+        Return testing parameter settings for the trainer.
 
         Returns
         -------
-        params : dict or list of dict, default = {}
-            Parameters to create testing instances of the class
-            Each dict are parameters to construct an "interesting" test instance, i.e.,
-            `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
-            `create_test_instance` uses the first (or only) dictionary in `params`
+        params : list[dict]
+            Parameters to create testing instances of the package.
+            Each dictionary contains parameters passed to instantiate
+            the package and the underlying model.
         """
         from pytorch_forecasting.metrics import QuantileLoss
 

--- a/pytorch_forecasting/models/nbeats/_nbeats_v2.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_v2.py
@@ -1,6 +1,11 @@
 """
-N-Beats model for timeseries forecasting without covariates.
+N-BEATS model for time series forecasting for pytorch-forecasting v2.
 """
+
+########################################################################################
+# Disclaimer: This implementation is based on the new v2 data pipeline and is
+# experimental, please use with care.
+########################################################################################
 
 from typing import Any, Optional, Union
 import warnings
@@ -19,18 +24,85 @@ from pytorch_forecasting.metrics import MASE, Metric
 from pytorch_forecasting.models.base._base_model_v2 import BaseModel
 
 
-class NBeats(BaseModel):
+class NBeats_v2(BaseModel):
     """
-    Initialize NBeats Model v2.
+    N-BEATS: Neural basis expansion analysis for interpretable time series forecasting.
 
-    Based on the article
-    `N-BEATS: Neural basis expansion analysis for interpretable time series
-        forecasting <http://arxiv.org/abs/1905.10437>`_.
+    An architecture based on backward and forward residual links and a deep stack of
+    fully-connected layers with basis expansion. It decomposes forecasts into trend,
+    seasonality, and generic components without relying on manual feature engineering.
+
+    Parameters
+    ----------
+    loss : Metric
+        Loss function used for model training and evaluation (e.g. MAE, SMAPE,
+        QuantileLoss, MASE).
+    stack_types : Optional[list[str]], default=None
+        Types of stacks in the network architecture. Each element must be one of
+        ``"generic"``, ``"trend"``, or ``"seasonality"``.
+        Defaults to ``["trend", "seasonality"]`` if None.
+    num_blocks : Optional[list[int]], default=None
+        Number of blocks per stack. Must have the same length as ``stack_types``.
+        Defaults to ``[3, 3]`` if None.
+    num_block_layers : Optional[list[int]], default=None
+        Number of fully connected layers per block for each stack.
+        Must have the same length as ``stack_types``. Defaults to ``[3, 3]`` if None.
+    widths : Optional[list[int]], default=None
+        Hidden layer width of the fully connected layers for each stack.
+        Must have the same length as ``stack_types``. Defaults to ``[32, 512]`` if None.
+    sharing : Optional[list[bool]], default=None
+        Whether weights are shared across blocks in a stack.
+        Must have the same length as ``stack_types``.
+        Defaults to ``[True, True]`` if None.
+    expansion_coefficient_lengths : Optional[list[int]], default=None
+        Expansion coefficient length per stack: degree of polynomial for trend stacks,
+        minimum period for seasonality stacks, and theta dimension for generic stacks.
+        Defaults to ``[3, 7]`` if None.
+    dropout : float, default=0.1
+        Dropout probability applied across fully connected layers in the blocks.
+        Must be non-negative and <= 0.3.
+    backcast_loss_ratio : float, default=0.0
+        Weight ratio for the backcast loss component relative to the forecast loss.
+        0.0 disables backcast loss calculation.
+    logging_metrics : Optional[list[nn.Module]], default=None
+        Metrics to log during training, validation, and testing.
+    optimizer : Optional[Union[Optimizer, str]], default="adam"
+        Optimizer to use for training (name string or optimizer class).
+    optimizer_params : Optional[dict], default=None
+        Parameters forwarded to the optimizer constructor.
+    lr_scheduler : Optional[str], default=None
+        Learning rate scheduler name string.
+    lr_scheduler_params : Optional[dict], default=None
+        Parameters forwarded to the learning rate scheduler constructor.
+    metadata : Optional[dict], default=None
+        Metadata dictionary extracted from ``EncoderDecoderTimeSeriesDataModule``
+        containing ``max_encoder_length`` (lookback window) and
+        ``max_prediction_length`` (forecast horizon).
+    **kwargs : Any
+        Additional keyword arguments forwarded to ``BaseModel``.
+
+    References
+    ----------
+    .. [1] Boris N. Oreshkin, Dmitry Carpov, Nicolas Chapados, Yoshua Bengio.
+       "N-BEATS: Neural basis expansion analysis for interpretable time series
+       forecasting." ICLR 2020. https://arxiv.org/abs/1905.10437
+
+    Notes
+    -----
+    This model implements the v2 interface for ``pytorch-forecasting``, decoupling
+    data preparation from the neural network logic.
     """
 
     @classmethod
     def _pkg(cls):
-        """Package for the model."""
+        """
+        Package class containing the model.
+
+        Returns
+        -------
+        type
+            The corresponding ``NBeats_pkg_v2`` package container class.
+        """
         from pytorch_forecasting.models.nbeats._nbeats_pkg_v2 import NBeats_pkg_v2
 
         return NBeats_pkg_v2
@@ -86,7 +158,7 @@ class NBeats(BaseModel):
         )
 
         warnings.warn(
-            "NBeats is an experimental model implemented on BaseModelV2. "
+            "NBeats_v2 is an experimental model implemented on BaseModelV2. "
             "It is an unstable version and may be subject to unannounced changes. "
             "Please use with caution.",
             UserWarning,
@@ -147,7 +219,22 @@ class NBeats(BaseModel):
         y_hat: torch.Tensor,
         target_scale: torch.Tensor | dict[str, torch.Tensor] | None,
     ) -> torch.Tensor:
-        """Transform output scale."""
+        """
+        Rescale network outputs back to the original scale of the target variable.
+
+        Parameters
+        ----------
+        y_hat : torch.Tensor
+            Normalized predictions of shape ``(batch_size, timesteps)`` or
+            ``(batch_size, timesteps, ...)``.
+        target_scale : Union[torch.Tensor, dict[str, torch.Tensor], None]
+            Scaling parameters containing either center/scale tensors or direct scale.
+
+        Returns
+        -------
+        torch.Tensor
+            Rescaled predictions matching the original data scale.
+        """
         if target_scale is None:
             return y_hat
 
@@ -166,7 +253,28 @@ class NBeats(BaseModel):
         return y_hat * scale
 
     def forward(self, x: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
-        """Pass forward of network."""
+        """
+        Network forward pass decomposing the input sequence into backcast and forecast.
+
+        Parameters
+        ----------
+        x : dict[str, torch.Tensor]
+            Dictionary containing batch tensors. Must include ``"target_past"`` or
+            ``"encoder_cont"`` representing the historical target sequence. Optionally
+            includes ``"target_scale"`` for denormalization.
+
+        Returns
+        -------
+        dict[str, torch.Tensor]
+            Dictionary containing:
+            - ``"prediction"``: Output forecasts of shape
+              ``(batch_size, prediction_length, n_quantiles)``
+            - ``"backcast"``: Reconstructed backcast of shape
+              ``(batch_size, context_length, n_quantiles)``
+            - ``"trend"``: Trend decomposition across all timesteps
+            - ``"seasonality"``: Seasonality decomposition across all timesteps
+            - ``"generic"``: Generic decomposition across all timesteps
+        """
         # target_past is the target history (backcast input)
         target = x.get("target_past", None)
         if target is None:
@@ -261,7 +369,26 @@ class NBeats(BaseModel):
         y: torch.Tensor,
         prefix: str,
     ) -> torch.Tensor:
-        """Compute the combined loss (forecast loss + optional backcast loss)."""
+        """
+        Compute combined loss with forecast loss and optional backcast loss.
+
+        Parameters
+        ----------
+        y_hat_dict : dict[str, torch.Tensor]
+            Output dictionary from forward pass containing ``"prediction"`` and
+            ``"backcast"``.
+        x : dict[str, torch.Tensor]
+            Input batch dictionary containing ``"target_past"``.
+        y : torch.Tensor
+            Ground truth forecast target tensor.
+        prefix : str
+            Stage prefix for logging (e.g. ``"train"``, ``"val"``, ``"test"``).
+
+        Returns
+        -------
+        torch.Tensor
+            Scalar combined loss tensor.
+        """
         y_hat = y_hat_dict["prediction"]
         y_target = y.squeeze(-1) if y.ndim == 3 and y.size(-1) == 1 else y
         loss = self.loss(y_hat, y_target)
@@ -306,7 +433,21 @@ class NBeats(BaseModel):
     def training_step(
         self, batch: tuple[dict[str, torch.Tensor], torch.Tensor], batch_idx: int
     ) -> STEP_OUTPUT:
-        """Training step for the model."""
+        """
+        Execute training step on a batch.
+
+        Parameters
+        ----------
+        batch : tuple[dict[str, torch.Tensor], torch.Tensor]
+            Tuple containing input features dictionary ``x`` and target tensor ``y``.
+        batch_idx : int
+            Index of the current training batch.
+
+        Returns
+        -------
+        STEP_OUTPUT
+            Dictionary containing the training loss.
+        """
         x, y = batch
         y_hat_dict = self(x)
         loss = self._compute_combined_loss(y_hat_dict, x, y, prefix="train")
@@ -319,7 +460,21 @@ class NBeats(BaseModel):
     def validation_step(
         self, batch: tuple[dict[str, torch.Tensor], torch.Tensor], batch_idx: int
     ) -> STEP_OUTPUT:
-        """Validation step for the model."""
+        """
+        Execute validation step on a batch.
+
+        Parameters
+        ----------
+        batch : tuple[dict[str, torch.Tensor], torch.Tensor]
+            Tuple containing input features dictionary ``x`` and target tensor ``y``.
+        batch_idx : int
+            Index of the current validation batch.
+
+        Returns
+        -------
+        STEP_OUTPUT
+            Dictionary containing the validation loss.
+        """
         x, y = batch
         y_hat_dict = self(x)
         loss = self._compute_combined_loss(y_hat_dict, x, y, prefix="val")
@@ -332,7 +487,21 @@ class NBeats(BaseModel):
     def test_step(
         self, batch: tuple[dict[str, torch.Tensor], torch.Tensor], batch_idx: int
     ) -> STEP_OUTPUT:
-        """Test step for the model."""
+        """
+        Execute test step on a batch.
+
+        Parameters
+        ----------
+        batch : tuple[dict[str, torch.Tensor], torch.Tensor]
+            Tuple containing input features dictionary ``x`` and target tensor ``y``.
+        batch_idx : int
+            Index of the current test batch.
+
+        Returns
+        -------
+        STEP_OUTPUT
+            Dictionary containing the test loss.
+        """
         x, y = batch
         y_hat_dict = self(x)
         loss = self._compute_combined_loss(y_hat_dict, x, y, prefix="test")
@@ -350,7 +519,29 @@ class NBeats(BaseModel):
         ax=None,
         plot_seasonality_and_generic_on_secondary_axis: bool = False,
     ):
-        """Plot decomposition into trend, seasonality and generic forecast."""
+        """
+        Plot decomposition into trend, seasonality and generic components.
+
+        Parameters
+        ----------
+        x : dict[str, torch.Tensor]
+            Input dictionary containing ``"target_past"`` and optional
+            ``"decoder_target"``.
+        output : dict[str, torch.Tensor]
+            Model forward output dictionary containing ``"prediction"``,
+            ``"backcast"``, ``"trend"``, ``"seasonality"``, and ``"generic"``.
+        idx : int
+            Index of the specific sample in the batch to plot.
+        ax : Optional[matplotlib.axes.Axes], default=None
+            Array of two matplotlib axes. If None, a new figure is created.
+        plot_seasonality_and_generic_on_secondary_axis : bool, default=False
+            Whether to plot seasonality and generic components on a secondary y-axis.
+
+        Returns
+        -------
+        matplotlib.figure.Figure
+            Figure with the interpretation plots.
+        """
         import matplotlib.pyplot as plt
 
         if ax is None:
@@ -366,8 +557,6 @@ class NBeats(BaseModel):
         decoder_target = x.get("decoder_target", None)
         if decoder_target is None:
             # Fallback if decoder_target is not in batch (e.g. at prediction time)
-            # Try self.predict or use dummy/zeros if available.
-            # During plotting we can pass actual decoder_target.
             decoder_target = torch.zeros(
                 (target_past.size(0), self.prediction_length), device=target_past.device
             )

--- a/pytorch_forecasting/models/nbeats/_nbeats_v2.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_v2.py
@@ -1,0 +1,438 @@
+"""
+N-Beats model for timeseries forecasting without covariates.
+"""
+
+from typing import Any, Optional, Union
+import warnings
+
+from lightning.pytorch.utilities.types import STEP_OUTPUT
+import torch
+import torch.nn as nn
+from torch.optim import Optimizer
+
+from pytorch_forecasting.layers._nbeats._blocks import (
+    NBEATSGenericBlock,
+    NBEATSSeasonalBlock,
+    NBEATSTrendBlock,
+)
+from pytorch_forecasting.metrics import MASE, Metric
+from pytorch_forecasting.models.base._base_model_v2 import BaseModel
+
+
+class NBeats(BaseModel):
+    """
+    Initialize NBeats Model v2.
+
+    Based on the article
+    `N-BEATS: Neural basis expansion analysis for interpretable time series
+        forecasting <http://arxiv.org/abs/1905.10437>`_.
+    """
+
+    @classmethod
+    def _pkg(cls):
+        """Package for the model."""
+        from pytorch_forecasting.models.nbeats._nbeats_pkg_v2 import NBeats_pkg_v2
+
+        return NBeats_pkg_v2
+
+    def __init__(
+        self,
+        loss: Metric,
+        stack_types: list[str] | None = None,
+        num_blocks: list[int] | None = None,
+        num_block_layers: list[int] | None = None,
+        widths: list[int] | None = None,
+        sharing: list[bool] | None = None,
+        expansion_coefficient_lengths: list[int] | None = None,
+        dropout: float = 0.1,
+        backcast_loss_ratio: float = 0.0,
+        logging_metrics: list[nn.Module] | None = None,
+        optimizer: Optimizer | str | None = "adam",
+        optimizer_params: dict | None = None,
+        lr_scheduler: str | None = None,
+        lr_scheduler_params: dict | None = None,
+        metadata: dict | None = None,
+        **kwargs: Any,
+    ):
+        if dropout < 0.0:
+            raise ValueError("dropout must be non-negative")
+        elif dropout > 0.3:
+            warnings.warn("dropout is greater than 0.3, clipping to 0.3", UserWarning)
+            dropout = 0.3
+
+        if backcast_loss_ratio < 0.0:
+            raise ValueError("backcast_loss_ratio must be non-negative")
+
+        if expansion_coefficient_lengths is None:
+            expansion_coefficient_lengths = [3, 7]
+        if sharing is None:
+            sharing = [True, True]
+        if widths is None:
+            widths = [32, 512]
+        if num_block_layers is None:
+            num_block_layers = [3, 3]
+        if num_blocks is None:
+            num_blocks = [3, 3]
+        if stack_types is None:
+            stack_types = ["trend", "seasonality"]
+
+        super().__init__(
+            loss=loss,
+            logging_metrics=logging_metrics,
+            optimizer=optimizer,
+            optimizer_params=optimizer_params,
+            lr_scheduler=lr_scheduler,
+            lr_scheduler_params=lr_scheduler_params,
+        )
+
+        warnings.warn(
+            "NBeats is an experimental model implemented on BaseModelV2. "
+            "It is an unstable version and may be subject to unannounced changes. "
+            "Please use with caution.",
+            UserWarning,
+        )
+
+        self.save_hyperparameters(ignore=["loss", "logging_metrics", "metadata"])
+        self.metadata = metadata or {}
+
+        self.context_length = self.metadata.get(
+            "max_encoder_length", self.metadata.get("context_length", 1)
+        )
+        self.prediction_length = self.metadata.get(
+            "max_prediction_length", self.metadata.get("prediction_length", 1)
+        )
+
+        self.n_quantiles = 1
+        if hasattr(loss, "quantiles") and loss.quantiles is not None:
+            self.n_quantiles = len(loss.quantiles)
+
+        # setup stacks
+        self.net_blocks = nn.ModuleList()
+        for stack_id, stack_type in enumerate(stack_types):
+            for _ in range(num_blocks[stack_id]):
+                if stack_type == "generic":
+                    net_block = NBEATSGenericBlock(
+                        units=self.hparams.widths[stack_id],
+                        thetas_dim=self.hparams.expansion_coefficient_lengths[stack_id],
+                        num_block_layers=self.hparams.num_block_layers[stack_id],
+                        backcast_length=self.context_length,
+                        forecast_length=self.prediction_length,
+                        dropout=dropout,
+                    )
+                elif stack_type == "seasonality":
+                    net_block = NBEATSSeasonalBlock(
+                        units=self.hparams.widths[stack_id],
+                        num_block_layers=self.hparams.num_block_layers[stack_id],
+                        backcast_length=self.context_length,
+                        forecast_length=self.prediction_length,
+                        min_period=expansion_coefficient_lengths[stack_id],
+                        dropout=dropout,
+                    )
+                elif stack_type == "trend":
+                    net_block = NBEATSTrendBlock(
+                        units=self.hparams.widths[stack_id],
+                        thetas_dim=self.hparams.expansion_coefficient_lengths[stack_id],
+                        num_block_layers=self.hparams.num_block_layers[stack_id],
+                        backcast_length=self.context_length,
+                        forecast_length=self.prediction_length,
+                        dropout=dropout,
+                    )
+                else:
+                    raise ValueError(f"Unknown stack type {stack_type}")
+
+                self.net_blocks.append(net_block)
+
+    def transform_output(
+        self,
+        y_hat: torch.Tensor,
+        target_scale: torch.Tensor | dict[str, torch.Tensor] | None,
+    ) -> torch.Tensor:
+        """Transform output scale."""
+        if target_scale is None:
+            return y_hat
+
+        if isinstance(target_scale, dict):
+            scale = target_scale.get("scale", None)
+            center = target_scale.get("center", None)
+            if scale is not None and center is not None:
+                while scale.dim() < y_hat.dim():
+                    scale = scale.unsqueeze(0)
+                    center = center.unsqueeze(0)
+                return y_hat * scale + center
+
+        scale = target_scale
+        while scale.dim() < y_hat.dim():
+            scale = scale.unsqueeze(-1)
+        return y_hat * scale
+
+    def forward(self, x: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+        """Pass forward of network."""
+        # target_past is the target history (backcast input)
+        target = x.get("target_past", None)
+        if target is None:
+            # fallback if target_past is not set (e.g. from tests)
+            target = x["encoder_cont"][..., 0]
+
+        if target.ndim == 3:
+            # if shape is (batch, time, 1), squeeze the last dimension
+            target = target.squeeze(-1)
+
+        timesteps = self.context_length + self.prediction_length
+        generic_forecast = [
+            torch.zeros(
+                (target.size(0), timesteps), dtype=torch.float32, device=self.device
+            )
+        ]
+        trend_forecast = [
+            torch.zeros(
+                (target.size(0), timesteps), dtype=torch.float32, device=self.device
+            )
+        ]
+        seasonal_forecast = [
+            torch.zeros(
+                (target.size(0), timesteps), dtype=torch.float32, device=self.device
+            )
+        ]
+        forecast = torch.zeros(
+            (target.size(0), self.prediction_length),
+            dtype=torch.float32,
+            device=self.device,
+        )
+
+        backcast = target  # initialize backcast
+        for i, block in enumerate(self.net_blocks):
+            # evaluate block
+            backcast_block, forecast_block = block(backcast)
+
+            # add for interpretation
+            full = torch.cat([backcast_block.detach(), forecast_block.detach()], dim=1)
+            if isinstance(block, NBEATSTrendBlock):
+                trend_forecast.append(full)
+            elif isinstance(block, NBEATSSeasonalBlock):
+                seasonal_forecast.append(full)
+            else:
+                generic_forecast.append(full)
+
+            # update backcast and forecast (do not use -= inline)
+            backcast = backcast - backcast_block
+            forecast = forecast + forecast_block
+
+        prediction = forecast
+        backcast_val = target - backcast
+        trend_val = torch.stack(trend_forecast, dim=0).sum(0)
+        seasonal_val = torch.stack(seasonal_forecast, dim=0).sum(0)
+        generic_val = torch.stack(generic_forecast, dim=0).sum(0)
+
+        # Scale output back if target_scale is present
+        if "target_scale" in x:
+            target_scale = x["target_scale"]
+            prediction = self.transform_output(prediction, target_scale)
+            backcast_val = self.transform_output(backcast_val, target_scale)
+            trend_val = self.transform_output(trend_val, target_scale)
+            seasonal_val = self.transform_output(seasonal_val, target_scale)
+            generic_val = self.transform_output(generic_val, target_scale)
+
+        # Format shapes based on quantiles
+        if self.n_quantiles > 1:
+            prediction = prediction.unsqueeze(-1).expand(-1, -1, self.n_quantiles)
+            backcast_val = backcast_val.unsqueeze(-1).expand(-1, -1, self.n_quantiles)
+            trend_val = trend_val.unsqueeze(-1).expand(-1, -1, self.n_quantiles)
+            seasonal_val = seasonal_val.unsqueeze(-1).expand(-1, -1, self.n_quantiles)
+            generic_val = generic_val.unsqueeze(-1).expand(-1, -1, self.n_quantiles)
+        else:
+            prediction = prediction.unsqueeze(-1)
+            backcast_val = backcast_val.unsqueeze(-1)
+            trend_val = trend_val.unsqueeze(-1)
+            seasonal_val = seasonal_val.unsqueeze(-1)
+            generic_val = generic_val.unsqueeze(-1)
+
+        return {
+            "prediction": prediction,
+            "backcast": backcast_val,
+            "trend": trend_val,
+            "seasonality": seasonal_val,
+            "generic": generic_val,
+        }
+
+    def _compute_combined_loss(
+        self,
+        y_hat_dict: dict[str, torch.Tensor],
+        x: dict[str, torch.Tensor],
+        y: torch.Tensor,
+        prefix: str,
+    ) -> torch.Tensor:
+        """Compute the combined loss (forecast loss + optional backcast loss)."""
+        y_hat = y_hat_dict["prediction"]
+        y_target = y.squeeze(-1) if y.ndim == 3 and y.size(-1) == 1 else y
+        loss = self.loss(y_hat, y_target)
+
+        if self.hparams.backcast_loss_ratio > 0:
+            backcast = y_hat_dict["backcast"]
+            backcast_weight = (
+                self.hparams.backcast_loss_ratio
+                * self.prediction_length
+                / self.context_length
+            )
+            backcast_weight = backcast_weight / (backcast_weight + 1)
+            forecast_weight = 1 - backcast_weight
+
+            target_past = x["target_past"]
+            if target_past.ndim == 3 and target_past.size(-1) == 1:
+                target_past = target_past.squeeze(-1)
+
+            if isinstance(self.loss, MASE):
+                backcast_loss = self.loss(backcast, target_past, y_target)
+            else:
+                backcast_loss = self.loss(backcast, target_past)
+
+            self.log(
+                f"{prefix}_backcast_loss",
+                backcast_loss,
+                on_step=(prefix == "train"),
+                on_epoch=True,
+                batch_size=len(y),
+            )
+            self.log(
+                f"{prefix}_forecast_loss",
+                loss,
+                on_step=(prefix == "train"),
+                on_epoch=True,
+                batch_size=len(y),
+            )
+            loss = loss * forecast_weight + backcast_loss * backcast_weight
+
+        return loss
+
+    def training_step(
+        self, batch: tuple[dict[str, torch.Tensor], torch.Tensor], batch_idx: int
+    ) -> STEP_OUTPUT:
+        """Training step for the model."""
+        x, y = batch
+        y_hat_dict = self(x)
+        loss = self._compute_combined_loss(y_hat_dict, x, y, prefix="train")
+        self.log(
+            "train_loss", loss, on_step=True, on_epoch=True, prog_bar=True, logger=True
+        )
+        self.log_metrics(y_hat_dict["prediction"], y, prefix="train")
+        return {"loss": loss}
+
+    def validation_step(
+        self, batch: tuple[dict[str, torch.Tensor], torch.Tensor], batch_idx: int
+    ) -> STEP_OUTPUT:
+        """Validation step for the model."""
+        x, y = batch
+        y_hat_dict = self(x)
+        loss = self._compute_combined_loss(y_hat_dict, x, y, prefix="val")
+        self.log(
+            "val_loss", loss, on_step=False, on_epoch=True, prog_bar=True, logger=True
+        )
+        self.log_metrics(y_hat_dict["prediction"], y, prefix="val")
+        return {"val_loss": loss}
+
+    def test_step(
+        self, batch: tuple[dict[str, torch.Tensor], torch.Tensor], batch_idx: int
+    ) -> STEP_OUTPUT:
+        """Test step for the model."""
+        x, y = batch
+        y_hat_dict = self(x)
+        loss = self._compute_combined_loss(y_hat_dict, x, y, prefix="test")
+        self.log(
+            "test_loss", loss, on_step=False, on_epoch=True, prog_bar=True, logger=True
+        )
+        self.log_metrics(y_hat_dict["prediction"], y, prefix="test")
+        return {"test_loss": loss}
+
+    def plot_interpretation(
+        self,
+        x: dict[str, torch.Tensor],
+        output: dict[str, torch.Tensor],
+        idx: int,
+        ax=None,
+        plot_seasonality_and_generic_on_secondary_axis: bool = False,
+    ):
+        """Plot decomposition into trend, seasonality and generic forecast."""
+        import matplotlib.pyplot as plt
+
+        if ax is None:
+            fig, ax = plt.subplots(2, 1, figsize=(6, 8))
+        else:
+            fig = ax[0].get_figure()
+
+        time = torch.arange(-self.context_length, self.prediction_length)
+
+        target_past = x["target_past"]
+        if target_past.ndim == 3:
+            target_past = target_past[..., 0]
+        decoder_target = x.get("decoder_target", None)
+        if decoder_target is None:
+            # Fallback if decoder_target is not in batch (e.g. at prediction time)
+            # Try self.predict or use dummy/zeros if available.
+            # During plotting we can pass actual decoder_target.
+            decoder_target = torch.zeros(
+                (target_past.size(0), self.prediction_length), device=target_past.device
+            )
+
+        if decoder_target.ndim == 3:
+            decoder_target = decoder_target[..., 0]
+
+        # plot target vs prediction
+        ax[0].plot(
+            time.cpu(),
+            torch.cat([target_past[idx], decoder_target[idx]]).detach().cpu(),
+            label="target",
+        )
+
+        backcast_pred = output["backcast"][idx]
+        if backcast_pred.ndim == 2:
+            backcast_pred = backcast_pred[..., 0]
+        forecast_pred = output["prediction"][idx]
+        if forecast_pred.ndim == 2:
+            forecast_pred = forecast_pred[..., 0]
+
+        ax[0].plot(
+            time.cpu(),
+            torch.cat(
+                [
+                    backcast_pred.detach(),
+                    forecast_pred.detach(),
+                ],
+                dim=0,
+            ).cpu(),
+            label="prediction",
+        )
+        ax[0].set_xlabel("Time")
+
+        # plot blocks
+        prop_cycle = iter(plt.rcParams["axes.prop_cycle"])
+        next(prop_cycle)  # prediction
+        next(prop_cycle)  # observations
+        if plot_seasonality_and_generic_on_secondary_axis:
+            ax2 = ax[1].twinx()
+            ax2.set_ylabel("Seasonality / Generic")
+        else:
+            ax2 = ax[1]
+        for title in ["trend", "seasonality", "generic"]:
+            if title not in self.hparams.stack_types:
+                continue
+            component = output[title][idx]
+            if component.ndim == 2:
+                component = component[..., 0]
+            if title == "trend":
+                ax[1].plot(
+                    time.cpu(),
+                    component.detach().cpu(),
+                    label=title.capitalize(),
+                    c=next(prop_cycle)["color"],
+                )
+            else:
+                ax2.plot(
+                    time.cpu(),
+                    component.detach().cpu(),
+                    label=title.capitalize(),
+                    c=next(prop_cycle)["color"],
+                )
+        ax[1].set_xlabel("Time")
+        ax[1].set_ylabel("Decomposition")
+
+        fig.legend()
+        return fig

--- a/pytorch_forecasting/models/nbeats/_nbeats_v2.py
+++ b/pytorch_forecasting/models/nbeats/_nbeats_v2.py
@@ -542,6 +542,9 @@ class NBeats_v2(BaseModel):
         matplotlib.figure.Figure
             Figure with the interpretation plots.
         """
+        from pytorch_forecasting.utils._dependencies import _check_matplotlib
+
+        _check_matplotlib("plot_interpretation")
         import matplotlib.pyplot as plt
 
         if ax is None:

--- a/tests/test_models/test_nbeats_v2.py
+++ b/tests/test_models/test_nbeats_v2.py
@@ -1,0 +1,222 @@
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+from torch import nn
+
+from pytorch_forecasting.data import TimeSeries
+from pytorch_forecasting.data.data_module import (
+    EncoderDecoderTimeSeriesDataModule,
+    TslibDataModule,
+)
+from pytorch_forecasting.metrics import MAE, SMAPE, QuantileLoss
+from pytorch_forecasting.models.nbeats._nbeats_pkg_v2 import NBeats_pkg_v2
+from pytorch_forecasting.models.nbeats._nbeats_v2 import NBeats_v2
+
+
+@pytest.fixture
+def sample_dataset():
+    """Create sample univariate dataset and datamodule for testing NBeats v2."""
+    n_samples = 100
+    time_idx = np.arange(n_samples)
+    trend = 0.05 * time_idx
+    seasonality = 5 * np.sin(2 * np.pi * time_idx / 12)
+    noise = np.random.normal(0, 0.5, n_samples)
+    values = trend + seasonality + noise
+
+    series = pd.DataFrame(
+        {
+            "time_idx": time_idx,
+            "series_id": 0,
+            "value": values,
+        }
+    )
+
+    ts = TimeSeries(
+        series,
+        time="time_idx",
+        group=["series_id"],
+        target=["value"],
+        num=[],
+        cat=[],
+        known=["time_idx"],
+        unknown=["value"],
+    )
+
+    dm = EncoderDecoderTimeSeriesDataModule(
+        ts, max_encoder_length=16, max_prediction_length=4, batch_size=4
+    )
+    dm.setup()
+    return {"data_module": dm, "time_series": ts}
+
+
+def test_nbeats_v2_init(sample_dataset):
+    """Test initialization of NBeats_v2 model."""
+    dm = sample_dataset["data_module"]
+    loss = MAE()
+    model = NBeats_v2(
+        loss=loss,
+        stack_types=["generic"],
+        num_blocks=[2],
+        num_block_layers=[3],
+        widths=[32],
+        backcast_loss_ratio=1.0,
+        metadata=dm.metadata,
+    )
+
+    assert model.context_length == 16
+    assert model.prediction_length == 4
+    assert model.n_quantiles == 1
+    assert len(model.net_blocks) == 2
+
+
+def test_nbeats_v2_invalid_params():
+    """Test validation errors for invalid parameters."""
+    with pytest.raises(ValueError, match="dropout must be non-negative"):
+        NBeats_v2(loss=MAE(), dropout=-0.1)
+
+    with pytest.raises(ValueError, match="backcast_loss_ratio must be non-negative"):
+        NBeats_v2(loss=MAE(), backcast_loss_ratio=-0.5)
+
+    with pytest.warns(UserWarning, match="dropout is greater than 0.3"):
+        model = NBeats_v2(loss=MAE(), dropout=0.5)
+        assert model.hparams.dropout == 0.3
+
+
+def test_nbeats_v2_forward(sample_dataset):
+    """Test forward pass of NBeats_v2."""
+    dm = sample_dataset["data_module"]
+    train_dataloader = dm.train_dataloader()
+    batch = next(iter(train_dataloader))[0]
+
+    model = NBeats_v2(
+        loss=MAE(),
+        stack_types=["trend", "seasonality"],
+        num_blocks=[2, 2],
+        widths=[16, 32],
+        metadata=dm.metadata,
+    )
+
+    with torch.no_grad():
+        output = model(batch)
+
+    assert "prediction" in output
+    assert "backcast" in output
+    assert "trend" in output
+    assert "seasonality" in output
+    assert "generic" in output
+
+    pred = output["prediction"]
+    assert pred.shape[0] == dm.batch_size
+    assert pred.shape[1] == dm.metadata["max_prediction_length"]
+    assert pred.shape[2] == 1
+
+
+def test_nbeats_v2_quantile_loss_forward(sample_dataset):
+    """Test forward pass with QuantileLoss."""
+    dm = sample_dataset["data_module"]
+    train_dataloader = dm.train_dataloader()
+    batch = next(iter(train_dataloader))[0]
+
+    quantiles = [0.1, 0.5, 0.9]
+    loss = QuantileLoss(quantiles=quantiles)
+    model = NBeats_v2(
+        loss=loss,
+        stack_types=["generic"],
+        num_blocks=[1],
+        widths=[16],
+        metadata=dm.metadata,
+    )
+
+    with torch.no_grad():
+        output = model(batch)
+
+    assert output["prediction"].shape[-1] == len(quantiles)
+    assert output["backcast"].shape[-1] == len(quantiles)
+
+
+def test_nbeats_v2_training_step(sample_dataset):
+    """Test training and validation step with combined backcast loss."""
+    dm = sample_dataset["data_module"]
+    train_dataloader = dm.train_dataloader()
+    batch = next(iter(train_dataloader))
+
+    model = NBeats_v2(
+        loss=MAE(),
+        stack_types=["trend", "seasonality"],
+        num_blocks=[1, 1],
+        widths=[16, 16],
+        backcast_loss_ratio=1.0,
+        logging_metrics=[SMAPE()],
+        metadata=dm.metadata,
+    )
+
+    train_out = model.training_step(batch, 0)
+    assert "loss" in train_out
+    assert isinstance(train_out["loss"], torch.Tensor)
+
+    val_out = model.validation_step(batch, 0)
+    assert "val_loss" in val_out
+
+    test_out = model.test_step(batch, 0)
+    assert "test_loss" in test_out
+
+
+def test_nbeats_v2_interpretation_plot(sample_dataset):
+    """Test interpretation plotting."""
+    import matplotlib.pyplot as plt
+
+    dm = sample_dataset["data_module"]
+    train_dataloader = dm.train_dataloader()
+    batch = next(iter(train_dataloader))[0]
+
+    model = NBeats_v2(
+        loss=MAE(),
+        stack_types=["trend", "seasonality"],
+        num_blocks=[1, 1],
+        widths=[16, 16],
+        metadata=dm.metadata,
+    )
+
+    with torch.no_grad():
+        output = model(batch)
+
+    fig = model.plot_interpretation(batch, output, idx=0)
+    assert fig is not None
+    plt.close(fig)
+
+    fig2 = model.plot_interpretation(
+        batch, output, idx=0, plot_seasonality_and_generic_on_secondary_axis=True
+    )
+    assert fig2 is not None
+    plt.close(fig2)
+
+
+def test_nbeats_v2_transform_output():
+    """Test scale transformation."""
+    model = NBeats_v2(loss=MAE())
+    y_hat = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+
+    # No scale
+    assert torch.equal(model.transform_output(y_hat, None), y_hat)
+
+    # Tensor scale
+    scale = torch.tensor([2.0, 2.0])
+    res = model.transform_output(y_hat, scale)
+    assert res.shape == y_hat.shape
+
+    # Dict scale
+    scale_dict = {"scale": torch.tensor(2.0), "center": torch.tensor(1.0)}
+    res_dict = model.transform_output(y_hat, scale_dict)
+    assert torch.equal(res_dict, y_hat * 2.0 + 1.0)
+
+
+def test_nbeats_pkg_v2_interface(sample_dataset):
+    """Test NBeats_pkg_v2 wrapper interface."""
+    pkg = NBeats_pkg_v2()
+    assert pkg.get_cls() == NBeats_v2
+    assert pkg.get_datamodule_cls() == EncoderDecoderTimeSeriesDataModule
+
+    test_params = pkg.get_test_train_params()
+    assert len(test_params) > 0
+    assert "datamodule_cfg" in test_params[0]

--- a/tests/test_models/test_nbeats_v2.py
+++ b/tests/test_models/test_nbeats_v2.py
@@ -16,23 +16,31 @@ from pytorch_forecasting.models.nbeats._nbeats_v2 import NBeats_v2
 @pytest.fixture
 def sample_dataset():
     """Create sample univariate dataset and datamodule for testing NBeats v2."""
-    n_samples = 100
-    time_idx = np.arange(n_samples)
-    trend = 0.05 * time_idx
-    seasonality = 5 * np.sin(2 * np.pi * time_idx / 12)
-    noise = np.random.normal(0, 0.5, n_samples)
-    values = trend + seasonality + noise
+    n_samples = 60
+    n_series = 4
+    data_list = []
 
-    series = pd.DataFrame(
-        {
-            "time_idx": time_idx,
-            "series_id": 0,
-            "value": values,
-        }
-    )
+    for i in range(n_series):
+        time_idx = np.arange(n_samples)
+        trend = 0.05 * time_idx + i
+        seasonality = 5 * np.sin(2 * np.pi * time_idx / 12)
+        noise = np.random.normal(0, 0.5, n_samples)
+        values = trend + seasonality + noise
+
+        data_list.append(
+            pd.DataFrame(
+                {
+                    "time_idx": time_idx,
+                    "series_id": f"s_{i}",
+                    "value": values.astype(np.float32),
+                }
+            )
+        )
+
+    df = pd.concat(data_list, ignore_index=True)
 
     ts = TimeSeries(
-        series,
+        df,
         time="time_idx",
         group=["series_id"],
         target=["value"],
@@ -43,9 +51,14 @@ def sample_dataset():
     )
 
     dm = EncoderDecoderTimeSeriesDataModule(
-        ts, max_encoder_length=16, max_prediction_length=4, batch_size=4
+        ts,
+        max_encoder_length=16,
+        max_prediction_length=4,
+        batch_size=4,
+        train_val_test_split=(0.5, 0.25, 0.25),
     )
-    dm.setup()
+    dm.setup("fit")
+    dm.setup("test")
     return {"data_module": dm, "time_series": ts}
 
 

--- a/tests/test_models/test_nbeats_v2.py
+++ b/tests/test_models/test_nbeats_v2.py
@@ -1,13 +1,12 @@
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 import torch
-from torch import nn
 
 from pytorch_forecasting.data import TimeSeries
 from pytorch_forecasting.data.data_module import (
     EncoderDecoderTimeSeriesDataModule,
-    TslibDataModule,
 )
 from pytorch_forecasting.metrics import MAE, SMAPE, QuantileLoss
 from pytorch_forecasting.models.nbeats._nbeats_pkg_v2 import NBeats_pkg_v2
@@ -162,6 +161,10 @@ def test_nbeats_v2_training_step(sample_dataset):
     assert "test_loss" in test_out
 
 
+@pytest.mark.skipif(
+    not _check_soft_dependencies("matplotlib", severity="none"),
+    reason="skip test if required package matplotlib not installed",
+)
 def test_nbeats_v2_interpretation_plot(sample_dataset):
     """Test interpretation plotting."""
     import matplotlib.pyplot as plt


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #2034.

#### What does this implement/fix? Explain your changes.
This PR adds v2 interface support for the N-BEATS model, following the v2 patterns recently established by DLinear, SAMformer, and TFT in the codebase. 

Specifically, this implements:
* **Model Core (`pytorch_forecasting/models/nbeats/_nbeats_v2.py`):** * Implemented `NBeats` inheriting from the experimental `BaseModel` v2.
  * Added dynamic parameter metadata extraction for lookback (`context_length`) and horizon (`prediction_length`).
  * Implemented the forward pass to return prediction, backcast, trend, seasonality, and generic forecasts.
  * Squeezed target/prediction shapes where necessary to maintain strict compatibility with 2D loss metrics (e.g., MAE, QuantileLoss, MASE) and v2 training loops.
  * Integrated an optional backcast loss scaling hook when `backcast_loss_ratio > 0`.
  * Preserved model interpretation functionality (`plot_interpretation`) and scaling transformation (`transform_output`).
* **Package Wrapper & Registration (`pytorch_forecasting/models/nbeats/_nbeats_pkg_v2.py` & `__init__.py`):** * Created package container `NBeats_pkg_v2` inheriting from `Base_pkg` to represent the high-level workflow wrapper.
  * Registered model parameters, metadata, and testing configurations (`get_test_train_params`).
  * Updated imports and exports for the new v2 components.

#### What should a reviewer concentrate their feedback on?
* [x] The implementation of the target/prediction shape squeezing to ensure robust compatibility with 2D loss metrics.
* [x] The integration strategy with the new `BaseModel` (v2) and `Base_pkg` classes.
* [x] The optional backcast loss scaling hook logic.
* [x] Verification that the new `get_test_train_params` adequately covers required testing configurations for the package wrapper.

#### Did you add any tests for the change?
Yes. Robust test coverage was added in `tests/test_models/test_nbeats_v2.py`. 

The new tests cover initialization, forward pass configurations, quantile loss output shapes, step functions (training, validation, test), packaging/fitting pipelines, and interpretation plotting (including matplotlib soft-dependency checking). 

**Verification:** All new v2 tests (7 passes, 1 skipped due to matplotlib missing) and legacy v1 tests (2 passes, 1 skipped) execute successfully without regressions.

#### Any other comments?
N/A

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. 
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`