### PR TITLE
&Nidhicodes [ENH] Add support for nn losses to ptf-v2 

### DIFF
--- a/docs/source/tutorials/stallion.ipynb
+++ b/docs/source/tutorials/stallion.ipynb
@@ -41,7 +41,6 @@
    "source": [
     "import warnings\n",
     "\n",
-    "\n",
     "warnings.filterwarnings(\"ignore\")  # avoid printing out absolute paths"
    ]
   },

--- a/pytorch_forecasting/metrics/__init__.py
+++ b/pytorch_forecasting/metrics/__init__.py
@@ -37,6 +37,7 @@ from pytorch_forecasting.metrics.distributions import (
     NegativeBinomialDistributionLoss,
     NormalDistributionLoss,
 )
+from pytorch_forecasting.metrics.nn_loss_adapter import NNLossAdapter
 from pytorch_forecasting.metrics.point import (
     MAE,
     MAPE,
@@ -50,6 +51,7 @@ from pytorch_forecasting.metrics.point import (
 from pytorch_forecasting.metrics.quantile import QuantileLoss
 
 __all__ = [
+    "NNLossAdapter",
     "MultiHorizonMetric",
     "DistributionLoss",
     "MultivariateDistributionLoss",

--- a/pytorch_forecasting/metrics/__init__.py
+++ b/pytorch_forecasting/metrics/__init__.py
@@ -26,7 +26,7 @@ from pytorch_forecasting.metrics.base_metrics import (
     MultiHorizonMetric,
     MultiLoss,
     MultivariateDistributionLoss,
-    convert_torchmetric_to_pytorch_forecasting_metric,
+    coerce_to_pytorch_forecasting_metric,
 )
 from pytorch_forecasting.metrics.distributions import (
     BetaDistributionLoss,
@@ -57,7 +57,7 @@ __all__ = [
     "MultivariateDistributionLoss",
     "MultiLoss",
     "Metric",
-    "convert_torchmetric_to_pytorch_forecasting_metric",
+    "coerce_to_pytorch_forecasting_metric",
     "MAE",
     "MAPE",
     "MASE",

--- a/pytorch_forecasting/metrics/base_metrics/__init__.py
+++ b/pytorch_forecasting/metrics/base_metrics/__init__.py
@@ -10,7 +10,7 @@ from pytorch_forecasting.metrics.base_metrics._base_metrics import (
     MultiHorizonMetric,
     MultiLoss,
     MultivariateDistributionLoss,
-    convert_torchmetric_to_pytorch_forecasting_metric,
+    coerce_to_pytorch_forecasting_metric,
 )
 
 __all__ = [
@@ -19,7 +19,7 @@ __all__ = [
     "DistributionLoss",
     "MultivariateDistributionLoss",
     "MultiLoss",
-    "convert_torchmetric_to_pytorch_forecasting_metric",
+    "coerce_to_pytorch_forecasting_metric",
     "AggregationMetric",
     "CompositeMetric",
 ]

--- a/pytorch_forecasting/metrics/base_metrics/_base_metrics.py
+++ b/pytorch_forecasting/metrics/base_metrics/_base_metrics.py
@@ -267,13 +267,11 @@ def coerce_to_pytorch_forecasting_metric(
     Metric or torch.nn.Module
         Loss/metric usable in ptf training (``forward(y_pred, y_actual)``).
     """
-    if isinstance(metric, Metric | MultiLoss | CompositeMetric):
-        return metric
-
     from pytorch_forecasting.metrics.nn_loss_adapter import NNLossAdapter
 
-    if isinstance(metric, NNLossAdapter):
+    if isinstance(metric, (Metric, MultiLoss, CompositeMetric, NNLossAdapter)):
         return metric
+
     # bare torch.nn loss (nn.Module, but not a torchmetrics Metric)
     if isinstance(metric, torch.nn.Module) and not isinstance(metric, LightningMetric):
         return NNLossAdapter(metric)

--- a/pytorch_forecasting/metrics/base_metrics/_base_metrics.py
+++ b/pytorch_forecasting/metrics/base_metrics/_base_metrics.py
@@ -245,23 +245,39 @@ class TorchMetricWrapper(Metric):
         return f"WrappedTorchmetric({repr(self.torchmetric)})"
 
 
-def convert_torchmetric_to_pytorch_forecasting_metric(
-    metric: LightningMetric,
-) -> Metric:
+def coerce_to_pytorch_forecasting_metric(
+    metric: LightningMetric | torch.nn.Module,
+) -> Metric | torch.nn.Module:
     """
-    If necessary, convert a torchmetric to a PyTorch Forecasting metric that
-    works with PyTorch Forecasting models.
+    Coerce a loss or metric into something usable by PyTorch Forecasting models.
 
-    Args:
-        metric (LightningMetric): metric to (potentially) convert
+    Accepts ptf metrics, plain ``torch.nn`` losses, and torchmetrics metrics.
 
-    Returns:
-        Metric: PyTorch Forecasting metric
+    * Already a ptf ``Metric`` / ``MultiLoss`` / ``CompositeMetric`` → unchanged
+    * Plain ``torch.nn`` loss module (e.g. ``nn.MSELoss()``) → ``NNLossAdapter``
+    * Other torchmetrics ``Metric`` → ``TorchMetricWrapper``
+
+    Parameters
+    ----------
+    metric :
+        Metric or loss to (potentially) adapt.
+
+    Returns
+    -------
+    Metric or torch.nn.Module
+        Loss/metric usable in ptf training (``forward(y_pred, y_actual)``).
     """
-    if not isinstance(metric, Metric | MultiLoss | CompositeMetric):
-        return TorchMetricWrapper(metric)
-    else:
+    if isinstance(metric, Metric | MultiLoss | CompositeMetric):
         return metric
+
+    from pytorch_forecasting.metrics.nn_loss_adapter import NNLossAdapter
+
+    if isinstance(metric, NNLossAdapter):
+        return metric
+    # bare torch.nn loss (nn.Module, but not a torchmetrics Metric)
+    if isinstance(metric, torch.nn.Module) and not isinstance(metric, LightningMetric):
+        return NNLossAdapter(metric)
+    return TorchMetricWrapper(metric)
 
 
 class MultiLoss(LightningMetric):
@@ -286,9 +302,7 @@ class MultiLoss(LightningMetric):
             metrics
         ), "Number of weights has to match number of metrics"
 
-        self.metrics = [
-            convert_torchmetric_to_pytorch_forecasting_metric(m) for m in metrics
-        ]
+        self.metrics = [coerce_to_pytorch_forecasting_metric(m) for m in metrics]
         self.weights = weights
 
         super().__init__()

--- a/pytorch_forecasting/metrics/nn_loss_adapter.py
+++ b/pytorch_forecasting/metrics/nn_loss_adapter.py
@@ -1,0 +1,140 @@
+from typing import List, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+
+
+class NNLossAdapter(nn.Module):
+    """Adapter to use PyTorch nn losses in ptf-v2.
+
+    This class wraps a standard PyTorch loss (nn.Module) to handle the specific
+    input formats used in pytorch-forecasting v2, such as (target, weight) tuples
+    and multi-target list of tensors.
+
+    Args:
+        loss (nn.Module): The PyTorch loss to wrap.
+    """
+
+    def __init__(self, loss: nn.Module):
+        super().__init__()
+        self.loss = loss
+
+    def forward(
+        self,
+        y_pred: Union[torch.Tensor, List[torch.Tensor]],
+        y_actual: Union[torch.Tensor, Tuple[Union[torch.Tensor, List[torch.Tensor]], torch.Tensor]],
+    ) -> torch.Tensor:
+        """
+        Forward pass of the adapter.
+
+        Args:
+            y_pred (Union[torch.Tensor, List[torch.Tensor]]): Model predictions.
+                Expected to be [B, T, N] for multi-target or [B, T, 1] / [B, T] for single target.
+            y_actual (Union[torch.Tensor, Tuple]): Actual values and optionally weights.
+                Can be a tensor, or a tuple (target, weight), where target can be a list of tensors.
+
+        Returns:
+            torch.Tensor: The computed and reduced loss.
+        """
+        # Handle y_actual as (target, weight) or just target
+        if isinstance(y_actual, (list, tuple)) and not isinstance(y_actual, torch.Tensor):
+            if len(y_actual) == 2:
+                target, weight = y_actual
+            else:
+                target = y_actual[0]
+                weight = None
+        else:
+            target, weight = y_actual, None
+
+        if isinstance(target, list):
+            # Multi-target scenario
+            if not isinstance(y_pred, torch.Tensor):
+                raise ValueError(
+                    f"NNLossAdapter expected y_pred to be a torch.Tensor for multi-target, "
+                    f"but got {type(y_pred)}. Standard multi-target in ptf-v2 expects "
+                    f"y_pred of shape [B, T, N]."
+                )
+
+            # y_pred is [B, T, N], split along last dimension
+            y_preds = y_pred.split(1, dim=-1)
+            y_preds = [yp.squeeze(-1) for yp in y_preds]
+
+            if len(y_preds) != len(target):
+                raise ValueError(
+                    f"Number of predictions ({len(y_preds)}) does not match "
+                    f"number of targets ({len(target)})."
+                )
+
+            total_loss = torch.tensor(0.0, device=y_pred.device)
+            for yp, t in zip(y_preds, target):
+                total_loss = total_loss + self._compute_loss(yp, t, weight)
+            return total_loss
+        else:
+            # Single target scenario
+            if isinstance(y_pred, list):
+                # Error if list of predictions but single tensor target
+                raise ValueError(
+                    "NNLossAdapter does not support list of predictions with single target tensor."
+                )
+
+            if y_pred.ndim == 3:
+                if y_pred.size(-1) != 1:
+                    raise ValueError(
+                        f"NNLossAdapter only supports point predictions (H=1). "
+                        f"Got y_pred shape {list(y_pred.shape)} with H={y_pred.size(-1)}. "
+                        "For multi-horizon losses, use a ptf metrics loss instead."
+                    )
+                y_pred = y_pred.squeeze(-1)
+
+            return self._compute_loss(y_pred, target, weight)
+
+    def _compute_loss(
+        self, y_pred: torch.Tensor, target: torch.Tensor, weight: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        """
+        Compute the loss for a single target, applying weights if provided.
+        """
+        if weight is None:
+            return self.loss(y_pred, target)
+
+        # Handle weighting
+        old_reduction = getattr(self.loss, "reduction", "mean")
+        self.loss.reduction = "none"
+        try:
+            loss = self.loss(y_pred, target)
+        finally:
+            self.loss.reduction = old_reduction
+
+        # Ensure weight has same dimensions as loss for multiplication
+        if weight.ndim < loss.ndim:
+            weight = weight.unsqueeze(-1).expand_as(loss)
+        elif weight.ndim > loss.ndim:
+            # Squeeze weight if it has more dimensions (e.g. [B, T, 1] vs [B, T])
+            weight = weight.squeeze(-1)
+
+        weighted_loss = loss * weight
+
+        if old_reduction == "mean":
+            return weighted_loss.sum() / weight.sum()
+        elif old_reduction == "sum":
+            return weighted_loss.sum()
+        else:
+            # 'none' or others
+            return weighted_loss
+
+    def to_prediction(self, y_pred: torch.Tensor, **kwargs) -> torch.Tensor:
+        """
+        Convert network prediction into a point prediction.
+        """
+        if y_pred.ndim == 3:
+            if y_pred.size(-1) == 1:
+                return y_pred.squeeze(-1)
+        return y_pred
+
+    def to_quantiles(self, y_pred: torch.Tensor, **kwargs) -> torch.Tensor:
+        """
+        Convert network prediction into a quantile prediction.
+        """
+        if y_pred.ndim == 2:
+            return y_pred.unsqueeze(-1)
+        return y_pred

--- a/pytorch_forecasting/metrics/nn_loss_adapter.py
+++ b/pytorch_forecasting/metrics/nn_loss_adapter.py
@@ -1,4 +1,4 @@
-"""Adapter for native ``torch.nn`` loss modules in ptf-v2."""
+"""Adapter for native ``torch.nn`` loss modules as ptf metrics."""
 
 from __future__ import annotations
 
@@ -9,36 +9,52 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from pytorch_forecasting.metrics.base_metrics import MultiHorizonMetric
+
 _Mode = Literal["point", "class", "gaussian_nll"]
 _CLASS_LOSSES = (nn.CrossEntropyLoss, nn.NLLLoss)
 _GAUSSIAN_NLL_LOSSES = (nn.GaussianNLLLoss,)
 
 
-class NNLossAdapter(nn.Module):
-    """Adapt a ``torch.nn`` loss module to the ptf-v2 loss API.
+class NNLossAdapter(MultiHorizonMetric):
+    """Adapt a ``torch.nn`` loss module to the pytorch-forecasting metric API.
 
-    Wraps a standard PyTorch loss (nn.Module) to handle the specific
-    input formats used in pytorch-forecasting v2, such as (target, weight) tuples
-    and multi-target list of tensors.
+    Subclasses :class:`~pytorch_forecasting.metrics.MultiHorizonMetric` so the
+    wrapped loss participates in the same ecosystem as ``MAE`` / ``SMAPE``.
 
-    The reshape mode is inferred automatically from the wrapped loss type:
+
+    Reshape mode is inferred from the wrapped loss type:
 
     * **point** — same-shape ``[B, T]`` after squeeze (default)
     * **class** — logits ``[B, T, C]`` vs labels ``[B, T]``
       (``CrossEntropyLoss``, ``NLLLoss``)
     * **gaussian_nll** — mean/var head ``[B, T, 2]`` (``GaussianNLLLoss``)
 
+    Multi-target forecasting should use ``MultiLoss([NNLossAdapter(...), ...])``,
+    not a single adapter over stacked targets.
+
     Parameters
     ----------
     loss :
         Native PyTorch loss, e.g. ``nn.MSELoss()``.
+    **kwargs :
+        Forwarded to :class:`~pytorch_forecasting.metrics.MultiHorizonMetric`
+        (e.g. ``reduction``, ``name``).
     """
 
-    def __init__(self, loss: nn.Module):
-        super().__init__()
-        # deepcopy so we never mutate the caller's loss instance
+    def __init__(self, loss: nn.Module, **kwargs):
+        nn_reduction = getattr(loss, "reduction", "mean")
+        # MultiHorizonMetric reductions: mean | none | sqrt-mean
+        if "reduction" not in kwargs:
+            kwargs["reduction"] = "none" if nn_reduction == "none" else "mean"
+        if "name" not in kwargs or kwargs["name"] is None:
+            kwargs["name"] = f"NNLossAdapter({type(loss).__name__})"
+
+        super().__init__(**kwargs)
+
         self._loss = copy.deepcopy(loss)
-        self._reduction = getattr(loss, "reduction", "mean")
+        if hasattr(self._loss, "reduction"):
+            self._loss.reduction = "none"
         self._mode = self._infer_mode(self._loss)
 
     @staticmethod
@@ -62,110 +78,62 @@ class NNLossAdapter(nn.Module):
             return "gaussian_nll"
         return "point"
 
-    def forward(
-        self,
-        y_pred: torch.Tensor | list[torch.Tensor],
-        y_actual: torch.Tensor
-        | list[torch.Tensor]
-        | tuple[torch.Tensor | list[torch.Tensor], torch.Tensor],
-    ) -> torch.Tensor:
-        """
-        Forward pass of the adapter.
+    def loss(self, y_pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+        """Per-element losses ``[B, T]`` for :meth:`MultiHorizonMetric.update`.
 
         Parameters
         ----------
         y_pred :
-            Model predictions.
-
-            * point: ``[B, T, 1]`` / ``[B, T]``, or ``[B, T, N]`` for multi-target
-            * class: ``[B, T, C]`` logits
-            * gaussian_nll: ``[B, T, 2]`` as ``(mean, raw_variance)``
-        y_actual :
-            Targets, optionally as ``(target, weight)``. Multi-target uses a
-            list of ``[B, T]`` tensors (point mode only).
+            Network prediction (see class docstring for shapes by mode).
+        target :
+            Target tensor ``[B, T]`` (weight already stripped by ``update``).
 
         Returns
         -------
         torch.Tensor
-            Scalar (or unreduced) loss.
+            Unreduced loss of shape ``[B, T]``.
         """
-        target, weight = self._unpack_y_actual(y_actual)
-        mode = self._mode
-
-        # multi-target scenario
-        if isinstance(target, list):
-            if mode != "point":
-                raise ValueError(
-                    f"Error in NNLossAdapter: Multi-target lists are only supported"
-                    f"for point losses, got {self._loss.__class__.__name__!r}."
-                )
-            if not isinstance(y_pred, torch.Tensor):
-                raise ValueError(
-                    f"NNLossAdapter expected y_pred to be a torch.Tensor for "
-                    f"multi-target, but got {type(y_pred)}. Standard multi-target "
-                    f"in ptf-v2 expects y_pred of shape [B, T, N]."
-                )
-            # y_pred is [B, T, N], split along last dimension
-            y_preds = [yp.squeeze(-1) for yp in y_pred.split(1, dim=-1)]
-            if len(y_preds) != len(target):
-                raise ValueError(
-                    f"Number of predictions ({len(y_preds)}) does not match "
-                    f"number of targets ({len(target)})."
-                )
-
-            total_loss = torch.tensor(0.0, device=y_pred.device, dtype=y_pred.dtype)
-            for yp, t in zip(y_preds, target):
-                total_loss = total_loss + self._compute_loss(yp, t, weight, mode)
-            return total_loss
-
-        # single-target scenario
         if isinstance(y_pred, list):
             raise ValueError(
                 "NNLossAdapter does not support list of predictions "
-                "with single target tensor."
+                "with a single target tensor. For multi-target use "
+                "MultiLoss([NNLossAdapter(...), ...])."
+            )
+        if isinstance(target, list):
+            raise ValueError(
+                "NNLossAdapter does not accept a list of targets. "
+                "For multi-target use MultiLoss([NNLossAdapter(...), ...])."
             )
 
-        y_pred, target = self._prepare_inputs(y_pred, target, mode)
-        return self._compute_loss(y_pred, target, weight, mode)
+        mode = self._mode
+        batch_size, time_idx = target.shape[0], target.shape[1]
+        y_pred_p, target_p = self._prepare_inputs(y_pred, target, mode)
+        per_elem = self._call_loss(y_pred_p, target_p, mode)
 
-    @staticmethod
-    def _unpack_y_actual(
-        y_actual: torch.Tensor | list[torch.Tensor] | tuple,
-    ) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | None]:
-        """Split ``y_actual`` into ``(target, weight)``.
+        if mode == "class":
+            return per_elem.view(batch_size, time_idx)
+        if per_elem.ndim == 0:
+            # defensive: some losses ignore reduction="none"
+            return per_elem.expand(batch_size, time_idx)
+        return per_elem
 
-        Accepts a bare target tensor/list, ``(target, weight)``,
-        ``(target, None)``, or a length-1 sequence wrapping the target only.
-
-        Parameters
-        ----------
-        y_actual :
-            Target payload from the ptf-v2 training loop.
-
-        Returns
-        -------
-        target :
-            Tensor or list of target tensors.
-        weight :
-            Optional sample/time weight tensor, or ``None``.
-        """
+    def update(self, y_pred, target):
+        """Update metric state; reject multi-target lists with a clear error."""
+        # MultiHorizonMetric unpacks (target, weight) before calling loss();
+        # catch list targets here so the message is useful.
+        raw_target = target
         if (
-            isinstance(y_actual, tuple)
-            and len(y_actual) == 2
-            and torch.is_tensor(y_actual[1])
+            isinstance(target, (list, tuple))
+            and len(target) == 2
+            and (target[1] is None or torch.is_tensor(target[1]))
         ):
-            return y_actual[0], y_actual[1]
-        # also allow (target, None) or len-2 list/tuple without weight tensor
-        if isinstance(y_actual, (list, tuple)) and not isinstance(
-            y_actual, torch.Tensor
-        ):
-            if len(y_actual) == 2 and (
-                y_actual[1] is None or torch.is_tensor(y_actual[1])
-            ):
-                return y_actual[0], y_actual[1]
-            if len(y_actual) == 1:
-                return y_actual[0], None
-        return y_actual, None
+            raw_target = target[0]
+        if isinstance(raw_target, list):
+            raise ValueError(
+                "NNLossAdapter does not accept a list of targets. "
+                "For multi-target use MultiLoss([NNLossAdapter(...), ...])."
+            )
+        return super().update(y_pred, target)
 
     def _prepare_inputs(
         self,
@@ -198,10 +166,11 @@ class NNLossAdapter(nn.Module):
                 return y_pred, target
             if y_pred.size(-1) != 1:
                 raise ValueError(
-                    f"NNLossAdapter only supports point predictions (H=1). "
+                    "Error inNNLossAdapter for point prediction (H=1): "
                     f"Got y_pred shape {list(y_pred.shape)} with "
                     f"H={y_pred.size(-1)}. "
-                    "For multi-horizon losses, use a ptf metrics loss instead."
+                    "For multi-output / multi-target heads use MultiLoss "
+                    "or a ptf metric such as QuantileLoss."
                 )
             y_pred = y_pred.squeeze(-1)
             return y_pred, target
@@ -268,69 +237,6 @@ class NNLossAdapter(nn.Module):
             # NLLLoss expects log-probabilities
             return self._loss(F.log_softmax(y_pred, dim=-1), target)
         return self._loss(y_pred, target)
-
-    def _compute_loss(
-        self,
-        y_pred: torch.Tensor,
-        target: torch.Tensor,
-        weight: torch.Tensor | None,
-        mode: _Mode,
-    ) -> torch.Tensor:
-        """Compute (optionally sample-weighted) loss for one target.
-
-        When ``weight`` is set, temporarily forces ``reduction="none"``,
-        multiplies elementwise, then reduces with the original reduction
-        (weighted mean via ``sum(loss*w)/sum(w)``, ``sum``, or unreduced).
-
-        Parameters
-        ----------
-        y_pred :
-            Prepared prediction tensor.
-        target :
-            Prepared target tensor.
-        weight :
-            Optional weights broadcastable to the unreduced loss.
-        mode :
-            Used to flatten class-mode weights to ``(B*T,)``.
-
-        Returns
-        -------
-        torch.Tensor
-            Scalar or unreduced weighted loss.
-        """
-        if weight is None:
-            return self._call_loss(y_pred, target, mode)
-
-        old_reduction = getattr(self._loss, "reduction", None)
-        if old_reduction is not None:
-            self._loss.reduction = "none"
-        try:
-            loss = self._call_loss(y_pred, target, mode)
-        finally:
-            if old_reduction is not None:
-                self._loss.reduction = old_reduction
-
-        # class mode flattens to (B*T,); flatten matching weights
-        if mode == "class" and weight is not None:
-            weight = weight.reshape(-1)
-        elif mode == "gaussian_nll" and weight is not None and weight.ndim == 2:
-            pass  # already [B, T], matches per-element loss
-
-        # Ensure weight has same dimensions as loss for multiplication
-        if weight.ndim < loss.ndim:
-            weight = weight.unsqueeze(-1).expand_as(loss)
-        elif weight.ndim > loss.ndim:
-            # Squeeze weight if it has more dimensions (e.g. [B, T, 1] vs [B, T])
-            weight = weight.squeeze(-1)
-
-        weighted_loss = loss * weight
-
-        if old_reduction == "mean":
-            return weighted_loss.sum() / weight.sum()
-        elif old_reduction == "sum":
-            return weighted_loss.sum()
-        # 'none' or others
-        return weighted_loss
 
     def to_prediction(self, y_pred: torch.Tensor, **kwargs) -> torch.Tensor:
         """Convert network output to a point forecast.

--- a/pytorch_forecasting/metrics/nn_loss_adapter.py
+++ b/pytorch_forecasting/metrics/nn_loss_adapter.py
@@ -68,13 +68,13 @@ class NNLossAdapter(MultiHorizonMetric):
 
         Returns
         -------
-        {"point", "class", "gaussian_nll"}
+        Literal["point", "class", "gaussian_nll"]
             ``"class"`` for ``CrossEntropyLoss`` / ``NLLLoss``,
             ``"gaussian_nll"`` for ``GaussianNLLLoss``, else ``"point"``.
         """
         if isinstance(loss, _CLASS_LOSSES):
             return "class"
-        if isinstance(loss, _GAUSSIAN_NLL_LOSSES):
+        elif isinstance(loss, _GAUSSIAN_NLL_LOSSES):
             return "gaussian_nll"
         return "point"
 
@@ -112,13 +112,46 @@ class NNLossAdapter(MultiHorizonMetric):
 
         if mode == "class":
             return per_elem.view(batch_size, time_idx)
-        if per_elem.ndim == 0:
+        elif per_elem.ndim == 0:
             # defensive: some losses ignore reduction="none"
             return per_elem.expand(batch_size, time_idx)
         return per_elem
 
-    def update(self, y_pred, target):
-        """Update metric state; reject multi-target lists with a clear error."""
+    def update(
+        self,
+        y_pred: torch.Tensor | list[torch.Tensor],
+        target: torch.Tensor
+        | tuple[torch.Tensor, torch.Tensor | None]
+        | tuple[list[torch.Tensor], torch.Tensor | None],
+    ) -> None:
+        """Accumulate batch loss into metric state.
+
+        Parameters
+        ----------
+        y_pred : torch.Tensor or list of torch.Tensor
+            Network prediction for a single target.
+
+            * point: ``[B, T, 1]`` or ``[B, T]``
+            * class: ``[B, T, C]`` logits
+            * gaussian_nll: ``[B, T, 2]`` as ``(mean, raw_variance)``
+
+            A list of prediction tensors is not supported; use
+            :class:`~pytorch_forecasting.metrics.MultiLoss` for multi-target.
+        target : torch.Tensor or tuple
+            Ground truth. Either a tensor ``[B, T]``, or
+            ``(target, weight)`` where ``weight`` is ``[B, T]`` or ``None``.
+            A list of target tensors is not supported.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            If ``target`` (or the first element of ``(target, weight)``) is a
+            list of tensors.
+        """
         # MultiHorizonMetric unpacks (target, weight) before calling loss();
         # catch list targets here so the message is useful.
         raw_target = target
@@ -164,7 +197,7 @@ class NNLossAdapter(MultiHorizonMetric):
         if mode == "point":
             if y_pred.ndim != 3:
                 return y_pred, target
-            if y_pred.size(-1) != 1:
+            elif y_pred.size(-1) != 1:
                 raise ValueError(
                     "Error inNNLossAdapter for point prediction (H=1): "
                     f"Got y_pred shape {list(y_pred.shape)} with "
@@ -181,7 +214,7 @@ class NNLossAdapter(MultiHorizonMetric):
                     "Classification losses expect logits of shape "
                     f"(batch, time, classes), got {tuple(y_pred.shape)}."
                 )
-            if target.ndim != 2:
+            elif target.ndim != 2:
                 raise ValueError(
                     "Classification targets must have shape (batch, time), "
                     f"got {tuple(target.shape)}."
@@ -189,17 +222,19 @@ class NNLossAdapter(MultiHorizonMetric):
             return y_pred.reshape(-1, y_pred.size(-1)), target.reshape(-1).long()
 
         # gaussian_nll
-        if y_pred.ndim != 3 or y_pred.size(-1) != 2:
-            raise ValueError(
-                "GaussianNLLLoss expects predictions of shape "
-                f"(batch, time, 2) as (mean, raw_variance); got {tuple(y_pred.shape)}."
-            )
-        if target.ndim != 2:
-            raise ValueError(
-                "GaussianNLL targets must have shape (batch, time), "
-                f"got {tuple(target.shape)}."
-            )
-        return y_pred, target
+        else:
+            if y_pred.ndim != 3 or y_pred.size(-1) != 2:
+                raise ValueError(
+                    "GaussianNLLLoss expects predictions of shape "
+                    "(batch, time, 2) as (mean, raw_variance), "
+                    f"got {tuple(y_pred.shape)}."
+                )
+            elif target.ndim != 2:
+                raise ValueError(
+                    "GaussianNLL targets must have shape (batch, time), "
+                    f"got {tuple(target.shape)}."
+                )
+            return y_pred, target
 
     def _call_loss(
         self,
@@ -233,7 +268,7 @@ class NNLossAdapter(MultiHorizonMetric):
             mean = y_pred[..., 0]
             var = F.softplus(y_pred[..., 1]) + 1e-6
             return self._loss(mean, target, var)
-        if mode == "class" and isinstance(self._loss, nn.NLLLoss):
+        elif mode == "class" and isinstance(self._loss, nn.NLLLoss):
             # NLLLoss expects log-probabilities
             return self._loss(F.log_softmax(y_pred, dim=-1), target)
         return self._loss(y_pred, target)
@@ -261,9 +296,9 @@ class NNLossAdapter(MultiHorizonMetric):
         mode = self._mode
         if mode == "class" and y_pred.ndim == 3:
             return y_pred.argmax(dim=-1)
-        if mode == "gaussian_nll" and y_pred.ndim == 3 and y_pred.size(-1) == 2:
+        elif mode == "gaussian_nll" and y_pred.ndim == 3 and y_pred.size(-1) == 2:
             return y_pred[..., 0]
-        if y_pred.ndim == 3 and y_pred.size(-1) == 1:
+        elif y_pred.ndim == 3 and y_pred.size(-1) == 1:
             return y_pred.squeeze(-1)
         return y_pred
 

--- a/pytorch_forecasting/metrics/nn_loss_adapter.py
+++ b/pytorch_forecasting/metrics/nn_loss_adapter.py
@@ -43,6 +43,19 @@ class NNLossAdapter(nn.Module):
 
     @staticmethod
     def _infer_mode(loss: nn.Module) -> _Mode:
+        """Map a native loss class to the adapter reshape/call mode.
+
+        Parameters
+        ----------
+        loss :
+            Wrapped ``torch.nn`` loss module.
+
+        Returns
+        -------
+        {"point", "class", "gaussian_nll"}
+            ``"class"`` for ``CrossEntropyLoss`` / ``NLLLoss``,
+            ``"gaussian_nll"`` for ``GaussianNLLLoss``, else ``"point"``.
+        """
         if isinstance(loss, _CLASS_LOSSES):
             return "class"
         if isinstance(loss, _GAUSSIAN_NLL_LOSSES):
@@ -119,6 +132,23 @@ class NNLossAdapter(nn.Module):
     def _unpack_y_actual(
         y_actual: torch.Tensor | list[torch.Tensor] | tuple,
     ) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | None]:
+        """Split ``y_actual`` into ``(target, weight)``.
+
+        Accepts a bare target tensor/list, ``(target, weight)``,
+        ``(target, None)``, or a length-1 sequence wrapping the target only.
+
+        Parameters
+        ----------
+        y_actual :
+            Target payload from the ptf-v2 training loop.
+
+        Returns
+        -------
+        target :
+            Tensor or list of target tensors.
+        weight :
+            Optional sample/time weight tensor, or ``None``.
+        """
         if (
             isinstance(y_actual, tuple)
             and len(y_actual) == 2
@@ -143,19 +173,40 @@ class NNLossAdapter(nn.Module):
         target: torch.Tensor,
         mode: _Mode,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Reshape ``y_pred`` / ``target`` into the layout expected by ``mode``.
+
+        * **point** — squeeze trailing singleton ``H=1`` so both are ``[B, T]``
+        * **class** — flatten to ``(B*T, C)`` logits and ``(B*T,)`` long labels
+        * **gaussian_nll** — keep ``[B, T, 2]`` preds and ``[B, T]`` targets
+
+        Parameters
+        ----------
+        y_pred :
+            Raw network prediction tensor.
+        target :
+            Raw target tensor (single-target path only).
+        mode :
+            Adapter mode from :meth:`_infer_mode`.
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor]
+            Prepared ``(y_pred, target)`` ready for :meth:`_call_loss`.
+        """
         if mode == "point":
-            if y_pred.ndim == 3:
-                if y_pred.size(-1) != 1:
-                    raise ValueError(
-                        f"NNLossAdapter only supports point predictions (H=1). "
-                        f"Got y_pred shape {list(y_pred.shape)} with "
-                        f"H={y_pred.size(-1)}. "
-                        "For multi-horizon losses, use a ptf metrics loss instead."
-                    )
-                y_pred = y_pred.squeeze(-1)
+            if y_pred.ndim != 3:
+                return y_pred, target
+            if y_pred.size(-1) != 1:
+                raise ValueError(
+                    f"NNLossAdapter only supports point predictions (H=1). "
+                    f"Got y_pred shape {list(y_pred.shape)} with "
+                    f"H={y_pred.size(-1)}. "
+                    "For multi-horizon losses, use a ptf metrics loss instead."
+                )
+            y_pred = y_pred.squeeze(-1)
             return y_pred, target
 
-        if mode == "class":
+        elif mode == "class":
             if y_pred.ndim != 3:
                 raise ValueError(
                     "Classification losses expect logits of shape "
@@ -187,6 +238,28 @@ class NNLossAdapter(nn.Module):
         target: torch.Tensor,
         mode: _Mode,
     ) -> torch.Tensor:
+        """Invoke the wrapped ``torch.nn`` loss with mode-specific arguments.
+
+        * **gaussian_nll** — split mean / softplus(raw_var)+eps, call
+          ``loss(mean, target, var)``
+        * **class** + ``NLLLoss`` — apply ``log_softmax`` before the loss
+        * otherwise — ``loss(y_pred, target)``
+
+        Parameters
+        ----------
+        y_pred :
+            Prepared prediction tensor from :meth:`_prepare_inputs`.
+        target :
+            Prepared target tensor.
+        mode :
+            Adapter mode controlling the call signature.
+
+        Returns
+        -------
+        torch.Tensor
+            Loss as returned by the wrapped module (honoring its reduction,
+            unless temporarily overridden by :meth:`_compute_loss`).
+        """
         if mode == "gaussian_nll":
             mean = y_pred[..., 0]
             var = F.softplus(y_pred[..., 1]) + 1e-6
@@ -203,6 +276,28 @@ class NNLossAdapter(nn.Module):
         weight: torch.Tensor | None,
         mode: _Mode,
     ) -> torch.Tensor:
+        """Compute (optionally sample-weighted) loss for one target.
+
+        When ``weight`` is set, temporarily forces ``reduction="none"``,
+        multiplies elementwise, then reduces with the original reduction
+        (weighted mean via ``sum(loss*w)/sum(w)``, ``sum``, or unreduced).
+
+        Parameters
+        ----------
+        y_pred :
+            Prepared prediction tensor.
+        target :
+            Prepared target tensor.
+        weight :
+            Optional weights broadcastable to the unreduced loss.
+        mode :
+            Used to flatten class-mode weights to ``(B*T,)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Scalar or unreduced weighted loss.
+        """
         if weight is None:
             return self._call_loss(y_pred, target, mode)
 
@@ -238,8 +333,23 @@ class NNLossAdapter(nn.Module):
         return weighted_loss
 
     def to_prediction(self, y_pred: torch.Tensor, **kwargs) -> torch.Tensor:
-        """
-        Convert network prediction into a point prediction.
+        """Convert network output to a point forecast.
+
+        * **class** — ``argmax`` over the class dimension
+        * **gaussian_nll** — mean channel (index 0)
+        * **point** — squeeze trailing ``H=1`` when present
+
+        Parameters
+        ----------
+        y_pred :
+            Raw network prediction tensor.
+        **kwargs :
+            Accepted for API compatibility; ignored.
+
+        Returns
+        -------
+        torch.Tensor
+            Point prediction, typically ``[B, T]``.
         """
         del kwargs
         mode = self._mode
@@ -252,8 +362,24 @@ class NNLossAdapter(nn.Module):
         return y_pred
 
     def to_quantiles(self, y_pred: torch.Tensor, **kwargs) -> torch.Tensor:
-        """
-        Convert network prediction into a quantile prediction.
+        """Expose a quantile-shaped view of the point prediction.
+
+        Native ``torch.nn`` losses are not quantile models; this wraps
+        :meth:`to_prediction` and adds a trailing singleton dim when needed
+        so callers expecting ``[B, T, Q]`` still work.
+
+        Parameters
+        ----------
+        y_pred :
+            Raw network prediction tensor.
+        **kwargs :
+            Accepted for API compatibility; ignored.
+
+        Returns
+        -------
+        torch.Tensor
+            ``[B, T, 1]`` when the point forecast is ``[B, T]``, else the
+            point forecast unchanged.
         """
         del kwargs
         point = self.to_prediction(y_pred)

--- a/pytorch_forecasting/metrics/nn_loss_adapter.py
+++ b/pytorch_forecasting/metrics/nn_loss_adapter.py
@@ -1,85 +1,149 @@
+"""Adapter for native ``torch.nn`` loss modules in ptf-v2."""
+
+from __future__ import annotations
+
+import copy
+from typing import Literal
+
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+
+_Mode = Literal["point", "class", "gaussian_nll"]
+_CLASS_LOSSES = (nn.CrossEntropyLoss, nn.NLLLoss)
+_GAUSSIAN_NLL_LOSSES = (nn.GaussianNLLLoss,)
 
 
 class NNLossAdapter(nn.Module):
-    """Adapter to use PyTorch nn losses in ptf-v2.
+    """Adapt a ``torch.nn`` loss module to the ptf-v2 loss API.
 
-    This class wraps a standard PyTorch loss (nn.Module) to handle the specific
+    Wraps a standard PyTorch loss (nn.Module) to handle the specific
     input formats used in pytorch-forecasting v2, such as (target, weight) tuples
     and multi-target list of tensors.
 
-    Args:
-        loss (nn.Module): The PyTorch loss to wrap.
+    The reshape mode is inferred automatically from the wrapped loss type:
+
+    * **point** — same-shape ``[B, T]`` after squeeze (default)
+    * **class** — logits ``[B, T, C]`` vs labels ``[B, T]``
+      (``CrossEntropyLoss``, ``NLLLoss``)
+    * **gaussian_nll** — mean/var head ``[B, T, 2]`` (``GaussianNLLLoss``)
+
+    Parameters
+    ----------
+    loss :
+        Native PyTorch loss, e.g. ``nn.MSELoss()``.
     """
 
     def __init__(self, loss: nn.Module):
         super().__init__()
-        self._loss = loss
+        # deepcopy so we never mutate the caller's loss instance
+        self._loss = copy.deepcopy(loss)
+        self._reduction = getattr(loss, "reduction", "mean")
+        self._mode = self._infer_mode(self._loss)
+
+    @staticmethod
+    def _infer_mode(loss: nn.Module) -> _Mode:
+        if isinstance(loss, _CLASS_LOSSES):
+            return "class"
+        if isinstance(loss, _GAUSSIAN_NLL_LOSSES):
+            return "gaussian_nll"
+        return "point"
 
     def forward(
         self,
         y_pred: torch.Tensor | list[torch.Tensor],
-        y_actual: torch.Tensor | tuple[torch.Tensor | list[torch.Tensor], torch.Tensor],
+        y_actual: torch.Tensor
+        | list[torch.Tensor]
+        | tuple[torch.Tensor | list[torch.Tensor], torch.Tensor],
     ) -> torch.Tensor:
         """
         Forward pass of the adapter.
 
-        Args:
-            y_pred (torch.Tensor | list[torch.Tensor]): Model predictions.
-                Expected to be [B, T, N] for multi-target or
-                [B, T, 1] / [B, T] for single target.
-            y_actual (torch.Tensor | tuple): Actual values and optionally weights.
-                Can be a tensor, or a tuple (target, weight), where target
-                can be a list of tensors.
+        Parameters
+        ----------
+        y_pred :
+            Model predictions.
 
-        Returns:
-            torch.Tensor: The computed and reduced loss.
+            * point: ``[B, T, 1]`` / ``[B, T]``, or ``[B, T, N]`` for multi-target
+            * class: ``[B, T, C]`` logits
+            * gaussian_nll: ``[B, T, 2]`` as ``(mean, raw_variance)``
+        y_actual :
+            Targets, optionally as ``(target, weight)``. Multi-target uses a
+            list of ``[B, T]`` tensors (point mode only).
+
+        Returns
+        -------
+        torch.Tensor
+            Scalar (or unreduced) loss.
         """
-        # Handle y_actual as (target, weight) or just target
-        if isinstance(y_actual, (list, tuple)) and not isinstance(
-            y_actual, torch.Tensor
-        ):
-            if len(y_actual) == 2:
-                target, weight = y_actual
-            else:
-                target = y_actual[0]
-                weight = None
-        else:
-            target, weight = y_actual, None
+        target, weight = self._unpack_y_actual(y_actual)
+        mode = self._mode
 
+        # multi-target scenario
         if isinstance(target, list):
-            # Multi-target scenario
+            if mode != "point":
+                raise ValueError(
+                    f"Error in NNLossAdapter: Multi-target lists are only supported"
+                    f"for point losses, got {self._loss.__class__.__name__!r}."
+                )
             if not isinstance(y_pred, torch.Tensor):
                 raise ValueError(
                     f"NNLossAdapter expected y_pred to be a torch.Tensor for "
                     f"multi-target, but got {type(y_pred)}. Standard multi-target "
                     f"in ptf-v2 expects y_pred of shape [B, T, N]."
                 )
-
             # y_pred is [B, T, N], split along last dimension
-            y_preds = y_pred.split(1, dim=-1)
-            y_preds = [yp.squeeze(-1) for yp in y_preds]
-
+            y_preds = [yp.squeeze(-1) for yp in y_pred.split(1, dim=-1)]
             if len(y_preds) != len(target):
                 raise ValueError(
                     f"Number of predictions ({len(y_preds)}) does not match "
                     f"number of targets ({len(target)})."
                 )
 
-            total_loss = torch.tensor(0.0, device=y_pred.device)
+            total_loss = torch.tensor(0.0, device=y_pred.device, dtype=y_pred.dtype)
             for yp, t in zip(y_preds, target):
-                total_loss = total_loss + self._compute_loss(yp, t, weight)
+                total_loss = total_loss + self._compute_loss(yp, t, weight, mode)
             return total_loss
-        else:
-            # Single target scenario
-            if isinstance(y_pred, list):
-                # Error if list of predictions but single tensor target
-                raise ValueError(
-                    "NNLossAdapter does not support list of predictions "
-                    "with single target tensor."
-                )
 
+        # single-target scenario
+        if isinstance(y_pred, list):
+            raise ValueError(
+                "NNLossAdapter does not support list of predictions "
+                "with single target tensor."
+            )
+
+        y_pred, target = self._prepare_inputs(y_pred, target, mode)
+        return self._compute_loss(y_pred, target, weight, mode)
+
+    @staticmethod
+    def _unpack_y_actual(
+        y_actual: torch.Tensor | list[torch.Tensor] | tuple,
+    ) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | None]:
+        if (
+            isinstance(y_actual, tuple)
+            and len(y_actual) == 2
+            and torch.is_tensor(y_actual[1])
+        ):
+            return y_actual[0], y_actual[1]
+        # also allow (target, None) or len-2 list/tuple without weight tensor
+        if isinstance(y_actual, (list, tuple)) and not isinstance(
+            y_actual, torch.Tensor
+        ):
+            if len(y_actual) == 2 and (
+                y_actual[1] is None or torch.is_tensor(y_actual[1])
+            ):
+                return y_actual[0], y_actual[1]
+            if len(y_actual) == 1:
+                return y_actual[0], None
+        return y_actual, None
+
+    def _prepare_inputs(
+        self,
+        y_pred: torch.Tensor,
+        target: torch.Tensor,
+        mode: _Mode,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if mode == "point":
             if y_pred.ndim == 3:
                 if y_pred.size(-1) != 1:
                     raise ValueError(
@@ -89,25 +153,73 @@ class NNLossAdapter(nn.Module):
                         "For multi-horizon losses, use a ptf metrics loss instead."
                     )
                 y_pred = y_pred.squeeze(-1)
+            return y_pred, target
 
-            return self._compute_loss(y_pred, target, weight)
+        if mode == "class":
+            if y_pred.ndim != 3:
+                raise ValueError(
+                    "Classification losses expect logits of shape "
+                    f"(batch, time, classes), got {tuple(y_pred.shape)}."
+                )
+            if target.ndim != 2:
+                raise ValueError(
+                    "Classification targets must have shape (batch, time), "
+                    f"got {tuple(target.shape)}."
+                )
+            return y_pred.reshape(-1, y_pred.size(-1)), target.reshape(-1).long()
+
+        # gaussian_nll
+        if y_pred.ndim != 3 or y_pred.size(-1) != 2:
+            raise ValueError(
+                "GaussianNLLLoss expects predictions of shape "
+                f"(batch, time, 2) as (mean, raw_variance); got {tuple(y_pred.shape)}."
+            )
+        if target.ndim != 2:
+            raise ValueError(
+                "GaussianNLL targets must have shape (batch, time), "
+                f"got {tuple(target.shape)}."
+            )
+        return y_pred, target
+
+    def _call_loss(
+        self,
+        y_pred: torch.Tensor,
+        target: torch.Tensor,
+        mode: _Mode,
+    ) -> torch.Tensor:
+        if mode == "gaussian_nll":
+            mean = y_pred[..., 0]
+            var = F.softplus(y_pred[..., 1]) + 1e-6
+            return self._loss(mean, target, var)
+        if mode == "class" and isinstance(self._loss, nn.NLLLoss):
+            # NLLLoss expects log-probabilities
+            return self._loss(F.log_softmax(y_pred, dim=-1), target)
+        return self._loss(y_pred, target)
 
     def _compute_loss(
-        self, y_pred: torch.Tensor, target: torch.Tensor, weight: torch.Tensor | None
+        self,
+        y_pred: torch.Tensor,
+        target: torch.Tensor,
+        weight: torch.Tensor | None,
+        mode: _Mode,
     ) -> torch.Tensor:
-        """
-        Compute the loss for a single target, applying weights if provided.
-        """
         if weight is None:
-            return self._loss(y_pred, target)
+            return self._call_loss(y_pred, target, mode)
 
-        # Handle weighting
-        old_reduction = getattr(self._loss, "reduction", "mean")
-        self._loss.reduction = "none"
+        old_reduction = getattr(self._loss, "reduction", None)
+        if old_reduction is not None:
+            self._loss.reduction = "none"
         try:
-            loss = self._loss(y_pred, target)
+            loss = self._call_loss(y_pred, target, mode)
         finally:
-            self._loss.reduction = old_reduction
+            if old_reduction is not None:
+                self._loss.reduction = old_reduction
+
+        # class mode flattens to (B*T,); flatten matching weights
+        if mode == "class" and weight is not None:
+            weight = weight.reshape(-1)
+        elif mode == "gaussian_nll" and weight is not None and weight.ndim == 2:
+            pass  # already [B, T], matches per-element loss
 
         # Ensure weight has same dimensions as loss for multiplication
         if weight.ndim < loss.ndim:
@@ -122,23 +234,29 @@ class NNLossAdapter(nn.Module):
             return weighted_loss.sum() / weight.sum()
         elif old_reduction == "sum":
             return weighted_loss.sum()
-        else:
-            # 'none' or others
-            return weighted_loss
+        # 'none' or others
+        return weighted_loss
 
     def to_prediction(self, y_pred: torch.Tensor, **kwargs) -> torch.Tensor:
         """
         Convert network prediction into a point prediction.
         """
-        if y_pred.ndim == 3:
-            if y_pred.size(-1) == 1:
-                return y_pred.squeeze(-1)
+        del kwargs
+        mode = self._mode
+        if mode == "class" and y_pred.ndim == 3:
+            return y_pred.argmax(dim=-1)
+        if mode == "gaussian_nll" and y_pred.ndim == 3 and y_pred.size(-1) == 2:
+            return y_pred[..., 0]
+        if y_pred.ndim == 3 and y_pred.size(-1) == 1:
+            return y_pred.squeeze(-1)
         return y_pred
 
     def to_quantiles(self, y_pred: torch.Tensor, **kwargs) -> torch.Tensor:
         """
         Convert network prediction into a quantile prediction.
         """
-        if y_pred.ndim == 2:
-            return y_pred.unsqueeze(-1)
-        return y_pred
+        del kwargs
+        point = self.to_prediction(y_pred)
+        if point.ndim == 2:
+            return point.unsqueeze(-1)
+        return point

--- a/pytorch_forecasting/metrics/nn_loss_adapter.py
+++ b/pytorch_forecasting/metrics/nn_loss_adapter.py
@@ -15,7 +15,7 @@ class NNLossAdapter(nn.Module):
 
     def __init__(self, loss: nn.Module):
         super().__init__()
-        self.loss = loss
+        self._loss = loss
 
     def forward(
         self,
@@ -99,15 +99,15 @@ class NNLossAdapter(nn.Module):
         Compute the loss for a single target, applying weights if provided.
         """
         if weight is None:
-            return self.loss(y_pred, target)
+            return self._loss(y_pred, target)
 
         # Handle weighting
-        old_reduction = getattr(self.loss, "reduction", "mean")
-        self.loss.reduction = "none"
+        old_reduction = getattr(self._loss, "reduction", "mean")
+        self._loss.reduction = "none"
         try:
-            loss = self.loss(y_pred, target)
+            loss = self._loss(y_pred, target)
         finally:
-            self.loss.reduction = old_reduction
+            self._loss.reduction = old_reduction
 
         # Ensure weight has same dimensions as loss for multiplication
         if weight.ndim < loss.ndim:

--- a/pytorch_forecasting/models/base/_base_model.py
+++ b/pytorch_forecasting/models/base/_base_model.py
@@ -45,7 +45,7 @@ from pytorch_forecasting.metrics import (
     MultiHorizonMetric,
     MultiLoss,
     QuantileLoss,
-    convert_torchmetric_to_pytorch_forecasting_metric,
+    coerce_to_pytorch_forecasting_metric,
 )
 from pytorch_forecasting.metrics.base_metrics import Metric
 from pytorch_forecasting.models.nn.embeddings import MultiEmbedding
@@ -543,19 +543,13 @@ class BaseModel(InitialParameterRepresenterMixIn, LightningModule, TupleOutputMi
         if not hasattr(self, "loss"):
             if isinstance(loss, tuple | list):
                 self.loss = MultiLoss(
-                    metrics=[
-                        convert_torchmetric_to_pytorch_forecasting_metric(l)
-                        for l in loss
-                    ]
+                    metrics=[coerce_to_pytorch_forecasting_metric(l) for l in loss]
                 )
             else:
-                self.loss = convert_torchmetric_to_pytorch_forecasting_metric(loss)
+                self.loss = coerce_to_pytorch_forecasting_metric(loss)
         if not hasattr(self, "logging_metrics"):
             self.logging_metrics = nn.ModuleList(
-                [
-                    convert_torchmetric_to_pytorch_forecasting_metric(l)
-                    for l in logging_metrics
-                ]
+                [coerce_to_pytorch_forecasting_metric(l) for l in logging_metrics]
             )
         if not hasattr(self, "output_transformer"):
             self.output_transformer = output_transformer

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -17,7 +17,7 @@ from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 
 from pytorch_forecasting.callbacks.predict import PredictCallback
-from pytorch_forecasting.metrics import Metric, MultiLoss
+from pytorch_forecasting.metrics import Metric, MultiLoss, NNLossAdapter
 from pytorch_forecasting.utils._classproperty import classproperty
 
 
@@ -52,6 +52,11 @@ class BaseModel(LightningModule):
         lr_scheduler_params: dict | None = None,
     ):
         super().__init__()
+
+        # auto-wrap nn.Module losses that are not ptf metrics
+        if isinstance(loss, nn.Module) and not isinstance(loss, (Metric, MultiLoss)):
+            loss = NNLossAdapter(loss)
+
         self.loss = loss
         self.logging_metrics = logging_metrics if logging_metrics is not None else []
         self.optimizer = optimizer

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -76,7 +76,7 @@ class BaseModel(LightningModule):
         super().__init__()
 
         # wrap bare nn losses; recurse into MultiLoss children via the converter
-        self.loss = coerce_to_pytorch_forecasting_metric(loss)
+        self.loss = loss
         self.logging_metrics = nn.ModuleList(
             logging_metrics if logging_metrics is not None else []
         )
@@ -87,6 +87,9 @@ class BaseModel(LightningModule):
             lr_scheduler_params if lr_scheduler_params is not None else {}
         )
         self.model_name = self.__class__.__name__
+
+        self._loss = coerce_to_pytorch_forecasting_metric(self.loss)
+
         warn(
             f"The Model '{self.model_name}' is part of an experimental rework"
             "of the pytorch-forecasting model layer, scheduled for release with v2.0.0."
@@ -169,18 +172,18 @@ class BaseModel(LightningModule):
         """Converts raw model output to point forecasts."""
         # todo: add MultiLoss support
         try:
-            out = self.loss.to_prediction(out["prediction"], **kwargs)
+            out = self._loss.to_prediction(out["prediction"], **kwargs)
         except TypeError:  # in case passed kwargs do not exist
-            out = self.loss.to_prediction(out["prediction"])
+            out = self._loss.to_prediction(out["prediction"])
         return out
 
     def to_quantiles(self, out: dict[str, Any], **kwargs) -> torch.Tensor:
         """Converts raw model output to quantile forecasts."""
         # todo: add MultiLoss support
         try:
-            out = self.loss.to_quantiles(out["prediction"], **kwargs)
+            out = self._loss.to_quantiles(out["prediction"], **kwargs)
         except TypeError:  # in case passed kwargs do not exist
-            out = self.loss.to_quantiles(out["prediction"])
+            out = self._loss.to_quantiles(out["prediction"])
         return out
 
     def training_step(
@@ -204,7 +207,7 @@ class BaseModel(LightningModule):
         x, y = batch
         y_hat_dict = self(x)
         y_hat = y_hat_dict["prediction"]
-        loss = self.loss(y_hat, y)
+        loss = self._loss(y_hat, y)
         self.log(
             "train_loss", loss, on_step=True, on_epoch=True, prog_bar=True, logger=True
         )
@@ -232,7 +235,7 @@ class BaseModel(LightningModule):
         x, y = batch
         y_hat_dict = self(x)
         y_hat = y_hat_dict["prediction"]
-        loss = self.loss(y_hat, y)
+        loss = self._loss(y_hat, y)
         self.log(
             "val_loss", loss, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )
@@ -260,7 +263,7 @@ class BaseModel(LightningModule):
         x, y = batch
         y_hat_dict = self(x)
         y_hat = y_hat_dict["prediction"]
-        loss = self.loss(y_hat, y)
+        loss = self._loss(y_hat, y)
         self.log(
             "test_loss", loss, on_step=False, on_epoch=True, prog_bar=True, logger=True
         )

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -17,7 +17,10 @@ from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 
 from pytorch_forecasting.callbacks.predict import PredictCallback
-from pytorch_forecasting.metrics import Metric, MultiLoss, NNLossAdapter
+from pytorch_forecasting.metrics import (
+    Metric,
+    coerce_to_pytorch_forecasting_metric,
+)
 from pytorch_forecasting.utils._classproperty import classproperty
 
 
@@ -72,11 +75,8 @@ class BaseModel(LightningModule):
     ):
         super().__init__()
 
-        # auto-wrap nn.Module losses that are not ptf metrics
-        if isinstance(loss, nn.Module) and not isinstance(loss, (Metric, MultiLoss)):
-            loss = NNLossAdapter(loss)
-
-        self.loss = loss
+        # wrap bare nn losses; recurse into MultiLoss children via the converter
+        self.loss = coerce_to_pytorch_forecasting_metric(loss)
         self.logging_metrics = nn.ModuleList(
             logging_metrics if logging_metrics is not None else []
         )

--- a/pytorch_forecasting/models/base/_base_model_v2.py
+++ b/pytorch_forecasting/models/base/_base_model_v2.py
@@ -63,7 +63,7 @@ class BaseModel(LightningModule):
 
     def __init__(
         self,
-        loss: Metric,
+        loss: Metric | nn.Module,
         logging_metrics: list[nn.Module] | None = None,
         optimizer: Optimizer | str | None = "adam",
         optimizer_params: dict | None = None,

--- a/pytorch_forecasting/models/dlinear/_dlinear_pkg_v2.py
+++ b/pytorch_forecasting/models/dlinear/_dlinear_pkg_v2.py
@@ -45,6 +45,8 @@ class DLinear_pkg_v2(Base_pkg):
             Parameters to create testing instances of the class
         """
 
+        import torch.nn as nn
+
         from pytorch_forecasting.metrics import SMAPE
 
         params = [
@@ -56,11 +58,13 @@ class DLinear_pkg_v2(Base_pkg):
             ),
             dict(
                 moving_avg=5,
+                loss=nn.MSELoss(),
                 individual=False,
                 logging_metrics=[SMAPE()],
             ),
             dict(
                 optimizer="adamw",
+                loss=nn.HuberLoss(),
                 lr_scheduler="cosine_annealing",
                 lr_scheduler_params={"T_max": 5},
             ),

--- a/pytorch_forecasting/models/dlinear/_dlinear_v2.py
+++ b/pytorch_forecasting/models/dlinear/_dlinear_v2.py
@@ -124,8 +124,8 @@ class DLinear(TslibBaseModel):
 
         self.n_quantiles = None
 
-        if isinstance(self.loss, QuantileLoss):
-            self.n_quantiles = len(self.loss.quantiles)
+        if isinstance(self._loss, QuantileLoss):
+            self.n_quantiles = len(self._loss.quantiles)
 
         output_dim = self.prediction_length
 

--- a/pytorch_forecasting/models/samformer/_samformer_v2_pkg.py
+++ b/pytorch_forecasting/models/samformer/_samformer_v2_pkg.py
@@ -49,16 +49,17 @@ class Samformer_pkg_v2(Base_pkg):
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
 
+        import torch.nn as nn
+
         from pytorch_forecasting.metrics import QuantileLoss
 
         params = [
             {
-                # "loss": nn.MSELoss(),
+                "loss": nn.MSELoss(),
                 "hidden_size": 32,
                 "use_revin": False,
             },
             {
-                # "loss": nn.MSELoss(),
                 "hidden_size": 16,
                 "use_revin": True,
                 "out_channels": 1,

--- a/pytorch_forecasting/models/temporal_fusion_transformer/_tft_pkg_v2.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/_tft_pkg_v2.py
@@ -46,11 +46,18 @@ class TFT_pkg_v2(Base_pkg):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+        import torch.nn as nn
+
         params = [
             {},
             dict(
                 hidden_size=25,
                 attention_head_size=5,
+            ),
+            dict(
+                loss=nn.MSELoss(),
+                hidden_size=16,
+                attention_head_size=4,
             ),
             dict(datamodule_cfg=dict(max_encoder_length=5, max_prediction_length=3)),
             dict(

--- a/pytorch_forecasting/models/temporal_fusion_transformer/_tft_pkg_v2.py
+++ b/pytorch_forecasting/models/temporal_fusion_transformer/_tft_pkg_v2.py
@@ -59,6 +59,12 @@ class TFT_pkg_v2(Base_pkg):
                 hidden_size=16,
                 attention_head_size=4,
             ),
+            dict(
+                loss=nn.GaussianNLLLoss(),
+                output_size=2,
+                hidden_size=16,
+                attention_head_size=2,
+            ),
             dict(datamodule_cfg=dict(max_encoder_length=5, max_prediction_length=3)),
             dict(
                 hidden_size=24,

--- a/pytorch_forecasting/models/tide/_tide_dsipts/_tide_v2.py
+++ b/pytorch_forecasting/models/tide/_tide_dsipts/_tide_v2.py
@@ -86,7 +86,6 @@ class TIDE(BaseModel):
         self.optim = optim
         self.optim_config = optim_config
         self.scheduler_config = scheduler_config
-        self.loss = loss
 
         self.hidden_size = hidden_size  # r
         self.d_model = d_model  # r^tilde

--- a/pytorch_forecasting/models/tide/_tide_dsipts/_tide_v2_pkg.py
+++ b/pytorch_forecasting/models/tide/_tide_dsipts/_tide_v2_pkg.py
@@ -46,6 +46,8 @@ class TIDE_pkg_v2(Base_pkg):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+        import torch.nn as nn
+
         from pytorch_forecasting.metrics import MAE, MAPE
 
         params = [
@@ -55,6 +57,7 @@ class TIDE_pkg_v2(Base_pkg):
                 n_add_enc=1,
                 n_add_dec=1,
                 dropout_rate=0.1,
+                loss=nn.MSELoss(),
             ),
             dict(
                 hidden_size=32,

--- a/pytorch_forecasting/models/timexer/_timexer_pkg_v2.py
+++ b/pytorch_forecasting/models/timexer/_timexer_pkg_v2.py
@@ -48,6 +48,8 @@ class TimeXer_pkg_v2(Base_pkg):
             `MyClass(**params)` or `MyClass(**params[i])` creates a valid test instance.
             `create_test_instance` uses the first (or only) dictionary in `params`
         """
+        import torch.nn as nn
+
         from pytorch_forecasting.metrics import QuantileLoss
 
         params = [
@@ -55,6 +57,11 @@ class TimeXer_pkg_v2(Base_pkg):
             dict(
                 hidden_size=64,
                 n_heads=4,
+            ),
+            dict(
+                loss=nn.L1Loss(),
+                hidden_size=32,
+                n_heads=2,
             ),
             dict(datamodule_cfg=dict(context_length=12, prediction_length=3)),
             dict(

--- a/pytorch_forecasting/models/timexer/_timexer_v2.py
+++ b/pytorch_forecasting/models/timexer/_timexer_v2.py
@@ -197,8 +197,8 @@ class TimeXer(TslibBaseModel):
 
         self.n_quantiles = None
 
-        if hasattr(self.loss, "quantiles") and self.loss.quantiles is not None:
-            self.n_quantiles = len(self.loss.quantiles)
+        if hasattr(self._loss, "quantiles") and self._loss.quantiles is not None:
+            self.n_quantiles = len(self._loss.quantiles)
 
         if self.hidden_size % self.n_heads != 0:
             raise ValueError(

--- a/pytorch_forecasting/tests/test_nn_loss_adapter.py
+++ b/pytorch_forecasting/tests/test_nn_loss_adapter.py
@@ -1,0 +1,124 @@
+import pytest
+import torch
+import torch.nn as nn
+from pytorch_forecasting.metrics import NNLossAdapter, MAE, MultiLoss
+from pytorch_forecasting.models.base._base_model_v2 import BaseModel
+
+
+def test_nn_loss_adapter_single_target():
+    loss_fn = nn.MSELoss()
+    adapter = NNLossAdapter(loss_fn)
+    
+    y_pred = torch.randn(4, 5, 1)  # [B, T, H]
+    target = torch.randn(4, 5)     # [B, T]
+    
+    # Test without weights
+    loss = adapter(y_pred, target)
+    expected_loss = loss_fn(y_pred.squeeze(-1), target)
+    assert torch.allclose(loss, expected_loss)
+    
+    # Test with weights
+    weight = torch.rand(4, 5)
+    loss_weighted = adapter(y_pred, (target, weight))
+    
+    # Manual weighted mean
+    raw_loss = nn.MSELoss(reduction='none')(y_pred.squeeze(-1), target)
+    expected_weighted_loss = (raw_loss * weight).sum() / weight.sum()
+    assert torch.allclose(loss_weighted, expected_weighted_loss)
+
+def test_nn_loss_adapter_multi_target():
+    loss_fn = nn.MSELoss()
+    adapter = NNLossAdapter(loss_fn)
+    
+    y_pred = torch.randn(4, 5, 2)  # [B, T, N]
+    targets = [torch.randn(4, 5), torch.randn(4, 5)] # List of [B, T]
+    
+    # Test without weights
+    loss = adapter(y_pred, (targets, None))
+    expected_loss = (
+        loss_fn(y_pred[..., 0], targets[0]) + 
+        loss_fn(y_pred[..., 1], targets[1])
+    )
+    assert torch.allclose(loss, expected_loss)
+    
+    # Test with weights
+    weight = torch.rand(4, 5)
+    loss_weighted = adapter(y_pred, (targets, weight))
+    
+    # Manual weighted mean for each target then sum
+    raw_loss0 = nn.MSELoss(reduction='none')(y_pred[..., 0], targets[0])
+    raw_loss1 = nn.MSELoss(reduction='none')(y_pred[..., 1], targets[1])
+    expected_weighted_loss = (
+        (raw_loss0 * weight).sum() / weight.sum() +
+        (raw_loss1 * weight).sum() / weight.sum()
+    )
+    assert torch.allclose(loss_weighted, expected_weighted_loss)
+
+def test_nn_loss_adapter_h_error():
+    adapter = NNLossAdapter(nn.MSELoss())
+    y_pred = torch.randn(4, 5, 2) # H=2, but single target expected
+    target = torch.randn(4, 5)
+    
+    with pytest.raises(ValueError, match="only supports point predictions"):
+        adapter(y_pred, target)
+
+def test_nn_loss_adapter_mismatch_error():
+    adapter = NNLossAdapter(nn.MSELoss())
+    y_pred = torch.randn(4, 5, 2) # N=2
+    targets = [torch.randn(4, 5)] # N=1
+    
+    with pytest.raises(ValueError, match="does not match number of targets"):
+        adapter(y_pred, (targets, None))
+
+def test_base_model_auto_wrap():
+    class SimpleModel(BaseModel):
+        def forward(self, x):
+            return {"prediction": torch.randn(4, 5, 1)}
+    
+    # Should wrap
+    model = SimpleModel(loss=nn.MSELoss())
+    assert isinstance(model.loss, NNLossAdapter)
+    
+    # Should NOT wrap
+    model_ptf = SimpleModel(loss=MAE())
+    assert isinstance(model_ptf.loss, MAE)
+    
+    # Should NOT wrap MultiLoss
+    model_multi = SimpleModel(loss=MultiLoss([MAE()]))
+    assert isinstance(model_multi.loss, MultiLoss)
+
+def test_nn_loss_adapter_to_prediction():
+    adapter = NNLossAdapter(nn.MSELoss())
+    y_pred = torch.randn(4, 5, 1)
+    
+    out = adapter.to_prediction(y_pred)
+    assert out.shape == (4, 5)
+    assert torch.allclose(out, y_pred.squeeze(-1))
+    
+    y_pred_2d = torch.randn(4, 5)
+    out_2d = adapter.to_prediction(y_pred_2d)
+    assert out_2d.shape == (4, 5)
+    assert torch.allclose(out_2d, y_pred_2d)
+
+def test_nn_loss_adapter_reduction_sum():
+    loss_fn = nn.MSELoss(reduction='sum')
+    adapter = NNLossAdapter(loss_fn)
+    
+    y_pred = torch.randn(4, 5, 1)
+    target = torch.randn(4, 5)
+    weight = torch.rand(4, 5)
+    
+    loss = adapter(y_pred, (target, weight))
+    
+    raw_loss = nn.MSELoss(reduction='none')(y_pred.squeeze(-1), target)
+    expected_loss = (raw_loss * weight).sum()
+    assert torch.allclose(loss, expected_loss)
+    assert loss_fn.reduction == 'sum' # Check it was restored
+
+def test_nn_loss_adapter_list_pred_error():
+    adapter = NNLossAdapter(nn.MSELoss())
+    y_pred = [torch.randn(4, 5), torch.randn(4, 5)]
+    target = torch.randn(4, 5)
+
+    with pytest.raises(ValueError, match="does not support list of predictions with single target tensor"):
+        adapter(y_pred, target)

--- a/pytorch_forecasting/tests/test_nn_loss_adapter.py
+++ b/pytorch_forecasting/tests/test_nn_loss_adapter.py
@@ -1,124 +1,133 @@
 import pytest
 import torch
 import torch.nn as nn
-from pytorch_forecasting.metrics import NNLossAdapter, MAE, MultiLoss
+
+from pytorch_forecasting.metrics import MAE, MultiLoss, NNLossAdapter
 from pytorch_forecasting.models.base._base_model_v2 import BaseModel
 
 
 def test_nn_loss_adapter_single_target():
     loss_fn = nn.MSELoss()
     adapter = NNLossAdapter(loss_fn)
-    
+
     y_pred = torch.randn(4, 5, 1)  # [B, T, H]
-    target = torch.randn(4, 5)     # [B, T]
-    
+    target = torch.randn(4, 5)  # [B, T]
+
     # Test without weights
     loss = adapter(y_pred, target)
     expected_loss = loss_fn(y_pred.squeeze(-1), target)
     assert torch.allclose(loss, expected_loss)
-    
+
     # Test with weights
     weight = torch.rand(4, 5)
     loss_weighted = adapter(y_pred, (target, weight))
-    
+
     # Manual weighted mean
-    raw_loss = nn.MSELoss(reduction='none')(y_pred.squeeze(-1), target)
+    raw_loss = nn.MSELoss(reduction="none")(y_pred.squeeze(-1), target)
     expected_weighted_loss = (raw_loss * weight).sum() / weight.sum()
     assert torch.allclose(loss_weighted, expected_weighted_loss)
+
 
 def test_nn_loss_adapter_multi_target():
     loss_fn = nn.MSELoss()
     adapter = NNLossAdapter(loss_fn)
-    
+
     y_pred = torch.randn(4, 5, 2)  # [B, T, N]
-    targets = [torch.randn(4, 5), torch.randn(4, 5)] # List of [B, T]
-    
+    targets = [torch.randn(4, 5), torch.randn(4, 5)]  # List of [B, T]
+
     # Test without weights
     loss = adapter(y_pred, (targets, None))
-    expected_loss = (
-        loss_fn(y_pred[..., 0], targets[0]) + 
-        loss_fn(y_pred[..., 1], targets[1])
+    expected_loss = loss_fn(y_pred[..., 0], targets[0]) + loss_fn(
+        y_pred[..., 1], targets[1]
     )
     assert torch.allclose(loss, expected_loss)
-    
+
     # Test with weights
     weight = torch.rand(4, 5)
     loss_weighted = adapter(y_pred, (targets, weight))
-    
+
     # Manual weighted mean for each target then sum
-    raw_loss0 = nn.MSELoss(reduction='none')(y_pred[..., 0], targets[0])
-    raw_loss1 = nn.MSELoss(reduction='none')(y_pred[..., 1], targets[1])
-    expected_weighted_loss = (
-        (raw_loss0 * weight).sum() / weight.sum() +
-        (raw_loss1 * weight).sum() / weight.sum()
-    )
+    raw_loss0 = nn.MSELoss(reduction="none")(y_pred[..., 0], targets[0])
+    raw_loss1 = nn.MSELoss(reduction="none")(y_pred[..., 1], targets[1])
+    expected_weighted_loss = (raw_loss0 * weight).sum() / weight.sum() + (
+        raw_loss1 * weight
+    ).sum() / weight.sum()
     assert torch.allclose(loss_weighted, expected_weighted_loss)
+
 
 def test_nn_loss_adapter_h_error():
     adapter = NNLossAdapter(nn.MSELoss())
-    y_pred = torch.randn(4, 5, 2) # H=2, but single target expected
+    y_pred = torch.randn(4, 5, 2)  # H=2, but single target expected
     target = torch.randn(4, 5)
-    
+
     with pytest.raises(ValueError, match="only supports point predictions"):
         adapter(y_pred, target)
 
+
 def test_nn_loss_adapter_mismatch_error():
     adapter = NNLossAdapter(nn.MSELoss())
-    y_pred = torch.randn(4, 5, 2) # N=2
-    targets = [torch.randn(4, 5)] # N=1
-    
+    y_pred = torch.randn(4, 5, 2)  # N=2
+    targets = [torch.randn(4, 5)]  # N=1
+
     with pytest.raises(ValueError, match="does not match number of targets"):
         adapter(y_pred, (targets, None))
+
 
 def test_base_model_auto_wrap():
     class SimpleModel(BaseModel):
         def forward(self, x):
             return {"prediction": torch.randn(4, 5, 1)}
-    
+
     # Should wrap
     model = SimpleModel(loss=nn.MSELoss())
     assert isinstance(model.loss, NNLossAdapter)
-    
+
     # Should NOT wrap
     model_ptf = SimpleModel(loss=MAE())
     assert isinstance(model_ptf.loss, MAE)
-    
+
     # Should NOT wrap MultiLoss
     model_multi = SimpleModel(loss=MultiLoss([MAE()]))
     assert isinstance(model_multi.loss, MultiLoss)
 
+
 def test_nn_loss_adapter_to_prediction():
     adapter = NNLossAdapter(nn.MSELoss())
     y_pred = torch.randn(4, 5, 1)
-    
+
     out = adapter.to_prediction(y_pred)
     assert out.shape == (4, 5)
     assert torch.allclose(out, y_pred.squeeze(-1))
-    
+
     y_pred_2d = torch.randn(4, 5)
     out_2d = adapter.to_prediction(y_pred_2d)
     assert out_2d.shape == (4, 5)
     assert torch.allclose(out_2d, y_pred_2d)
 
+
 def test_nn_loss_adapter_reduction_sum():
-    loss_fn = nn.MSELoss(reduction='sum')
+    loss_fn = nn.MSELoss(reduction="sum")
     adapter = NNLossAdapter(loss_fn)
-    
+
     y_pred = torch.randn(4, 5, 1)
     target = torch.randn(4, 5)
     weight = torch.rand(4, 5)
-    
+
     loss = adapter(y_pred, (target, weight))
-    
-    raw_loss = nn.MSELoss(reduction='none')(y_pred.squeeze(-1), target)
+
+    raw_loss = nn.MSELoss(reduction="none")(y_pred.squeeze(-1), target)
     expected_loss = (raw_loss * weight).sum()
     assert torch.allclose(loss, expected_loss)
-    assert loss_fn.reduction == 'sum' # Check it was restored
+    assert loss_fn.reduction == "sum"  # Check it was restored
+
 
 def test_nn_loss_adapter_list_pred_error():
     adapter = NNLossAdapter(nn.MSELoss())
     y_pred = [torch.randn(4, 5), torch.randn(4, 5)]
     target = torch.randn(4, 5)
 
-    with pytest.raises(ValueError, match="does not support list of predictions with single target tensor"):
+    with pytest.raises(
+        ValueError,
+        match="does not support list of predictions with single target tensor",
+    ):
         adapter(y_pred, target)

--- a/pytorch_forecasting/tests/test_nn_loss_adapter.py
+++ b/pytorch_forecasting/tests/test_nn_loss_adapter.py
@@ -1,9 +1,125 @@
+"""Tests for :class:`~pytorch_forecasting.metrics.NNLossAdapter`.
+
+The adapter supports three families of ``torch.nn`` losses commonly used with
+forecasting models:
+
+* **point** — same-shape ``[B, T]`` after squeeze (``MSELoss``, ``L1Loss``, …)
+* **class** — logits ``[B, T, C]`` vs labels ``[B, T]`` (``CrossEntropyLoss``,
+  ``NLLLoss``)
+* **gaussian_nll** — mean/var head ``[B, T, 2]`` (``GaussianNLLLoss``)
+"""
+
 import pytest
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 from pytorch_forecasting.metrics import MAE, MultiLoss, NNLossAdapter
 from pytorch_forecasting.models.base._base_model_v2 import BaseModel
+
+POINT_NN_LOSSES = [
+    nn.MSELoss(),
+    nn.L1Loss(),
+    nn.SmoothL1Loss(),
+    nn.HuberLoss(),
+    nn.BCELoss(),
+    nn.BCEWithLogitsLoss(),
+    nn.PoissonNLLLoss(log_input=True),
+]
+
+CLASS_NN_LOSSES = [
+    nn.CrossEntropyLoss(),
+    nn.NLLLoss(),
+]
+
+
+def _point_tensors(loss_fn: nn.Module, batch=4, time=5):
+    """Build pred/target tensors suitable for a point nn loss."""
+    if isinstance(loss_fn, nn.BCELoss):
+        y_pred = torch.rand(batch, time, 1).clamp(1e-4, 1 - 1e-4)
+        target = torch.randint(0, 2, (batch, time), dtype=torch.float32)
+    elif isinstance(loss_fn, nn.BCEWithLogitsLoss):
+        y_pred = torch.randn(batch, time, 1)
+        target = torch.randint(0, 2, (batch, time), dtype=torch.float32)
+    elif isinstance(loss_fn, nn.PoissonNLLLoss):
+        y_pred = torch.randn(batch, time, 1)
+        target = torch.randint(0, 5, (batch, time), dtype=torch.float32)
+    else:
+        y_pred = torch.randn(batch, time, 1)
+        target = torch.randn(batch, time)
+    return y_pred, target
+
+
+@pytest.mark.parametrize("loss_fn", POINT_NN_LOSSES, ids=lambda x: type(x).__name__)
+def test_nn_loss_adapter_all_point_losses(loss_fn):
+    """Adapter works for common same-shape nn losses (with and without weights)."""
+    adapter = NNLossAdapter(loss_fn)
+    y_pred, target = _point_tensors(loss_fn)
+
+    loss = adapter(y_pred, target)
+    expected = loss_fn(y_pred.squeeze(-1), target)
+    assert loss.ndim == 0
+    assert torch.allclose(loss, expected)
+
+    weight = torch.rand_like(target)
+    loss_weighted = adapter(y_pred, (target, weight))
+    assert loss_weighted.ndim == 0
+    assert torch.isfinite(loss_weighted)
+
+
+@pytest.mark.parametrize("loss_fn", CLASS_NN_LOSSES, ids=lambda x: type(x).__name__)
+def test_nn_loss_adapter_all_class_losses(loss_fn):
+    """CrossEntropy / NLL accept logits [B, T, C] and integer labels [B, T]."""
+    adapter = NNLossAdapter(loss_fn)
+    n_classes = 4
+    y_pred = torch.randn(3, 5, n_classes, requires_grad=True)
+    target = torch.randint(0, n_classes, (3, 5))
+
+    loss = adapter(y_pred, target)
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+
+    flat_pred = y_pred.reshape(-1, n_classes)
+    flat_target = target.reshape(-1)
+    if isinstance(loss_fn, nn.CrossEntropyLoss):
+        expected = loss_fn(flat_pred, flat_target)
+    else:
+        expected = loss_fn(F.log_softmax(flat_pred, dim=-1), flat_target)
+    assert torch.allclose(loss, expected)
+
+    loss.backward()
+    assert y_pred.grad is not None
+
+    weight = torch.rand(3, 5)
+    loss_w = adapter(y_pred.detach(), (target, weight))
+    assert loss_w.ndim == 0
+    assert torch.isfinite(loss_w)
+
+
+def test_nn_loss_adapter_gaussian_nll():
+    """GaussianNLLLoss uses last dim as (mean, raw_variance)."""
+    adapter = NNLossAdapter(nn.GaussianNLLLoss())
+    y_pred = torch.randn(4, 5, 2, requires_grad=True)
+    target = torch.randn(4, 5)
+
+    loss = adapter(y_pred, target)
+    mean = y_pred[..., 0]
+    var = F.softplus(y_pred[..., 1]) + 1e-6
+    expected = nn.GaussianNLLLoss()(mean, target, var)
+    assert torch.allclose(loss, expected)
+
+    loss.backward()
+    assert y_pred.grad is not None
+    assert adapter.to_prediction(y_pred.detach()).shape == (4, 5)
+
+
+def test_nn_loss_adapter_point_rejects_multi_output_head():
+    adapter = NNLossAdapter(nn.MSELoss())
+    y_pred = torch.randn(4, 5, 2)
+    target = torch.randn(4, 5)
+
+    with pytest.raises(ValueError, match="H=1"):
+        adapter(y_pred, target)
 
 
 def test_nn_loss_adapter_single_target():
@@ -55,15 +171,6 @@ def test_nn_loss_adapter_multi_target():
     assert torch.allclose(loss_weighted, expected_weighted_loss)
 
 
-def test_nn_loss_adapter_h_error():
-    adapter = NNLossAdapter(nn.MSELoss())
-    y_pred = torch.randn(4, 5, 2)  # H=2, but single target expected
-    target = torch.randn(4, 5)
-
-    with pytest.raises(ValueError, match="only supports point predictions"):
-        adapter(y_pred, target)
-
-
 def test_nn_loss_adapter_mismatch_error():
     adapter = NNLossAdapter(nn.MSELoss())
     y_pred = torch.randn(4, 5, 2)  # N=2
@@ -104,6 +211,10 @@ def test_nn_loss_adapter_to_prediction():
     assert out_2d.shape == (4, 5)
     assert torch.allclose(out_2d, y_pred_2d)
 
+    ce_adapter = NNLossAdapter(nn.CrossEntropyLoss())
+    logits = torch.tensor([[[0.1, 2.0, 0.0], [3.0, 0.0, 0.0]]])
+    assert torch.equal(ce_adapter.to_prediction(logits), torch.tensor([[1, 0]]))
+
 
 def test_nn_loss_adapter_reduction_sum():
     loss_fn = nn.MSELoss(reduction="sum")
@@ -131,3 +242,53 @@ def test_nn_loss_adapter_list_pred_error():
         match="does not support list of predictions with single target tensor",
     ):
         adapter(y_pred, target)
+
+
+def test_tft_cross_entropy_on_discrete_target(tmp_path):
+    """TFT + CrossEntropyLoss works when the target is discrete class labels."""
+    from lightning.pytorch.loggers import TensorBoardLogger
+
+    from pytorch_forecasting.models.temporal_fusion_transformer._tft_pkg_v2 import (
+        TFT_pkg_v2,
+    )
+    from pytorch_forecasting.tests._data_scenarios import (
+        data_with_covariates_v2,
+        make_datasets_v2,
+    )
+
+    raw = data_with_covariates_v2()
+    # special_event_1 is binary col already present
+    raw["class_label"] = raw["special_event_1"].astype("int64")
+    n_classes = int(raw["class_label"].nunique())
+
+    datasets = make_datasets_v2(raw, target="class_label")
+    dm_cfg = {
+        "max_encoder_length": 4,
+        "max_prediction_length": 3,
+        "batch_size": 2,
+        "train_val_test_split": (0.8, 0.2),
+        "add_relative_time_idx": True,
+    }
+    pkg = TFT_pkg_v2(
+        model_cfg=dict(
+            loss=nn.CrossEntropyLoss(),
+            output_size=n_classes,
+            hidden_size=16,
+            attention_head_size=2,
+        ),
+        trainer_cfg={
+            "max_epochs": 1,
+            "limit_train_batches": 2,
+            "limit_val_batches": 1,
+            "accelerator": "cpu",
+            "enable_checkpointing": False,
+            "logger": TensorBoardLogger(str(tmp_path)),
+            "default_root_dir": str(tmp_path),
+        },
+        datamodule_cfg=dm_cfg,
+    )
+    pkg.fit(datasets["training_dataset"], save_ckpt=False)
+
+    pred = pkg.predict(datasets["validation_dataset"], mode="raw")
+    assert pred["prediction"].ndim == 3
+    assert pred["prediction"].shape[-1] == n_classes

--- a/pytorch_forecasting/tests/test_nn_loss_adapter.py
+++ b/pytorch_forecasting/tests/test_nn_loss_adapter.py
@@ -14,7 +14,13 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from pytorch_forecasting.metrics import MAE, MultiLoss, NNLossAdapter
+from pytorch_forecasting.metrics import (
+    MAE,
+    Metric,
+    MultiHorizonMetric,
+    MultiLoss,
+    NNLossAdapter,
+)
 from pytorch_forecasting.models.base._base_model_v2 import BaseModel
 
 POINT_NN_LOSSES = [
@@ -48,6 +54,12 @@ def _point_tensors(loss_fn: nn.Module, batch=4, time=5):
         y_pred = torch.randn(batch, time, 1)
         target = torch.randn(batch, time)
     return y_pred, target
+
+
+def test_nn_loss_adapter_is_metric():
+    adapter = NNLossAdapter(nn.MSELoss())
+    assert isinstance(adapter, Metric)
+    assert isinstance(adapter, MultiHorizonMetric)
 
 
 @pytest.mark.parametrize("loss_fn", POINT_NN_LOSSES, ids=lambda x: type(x).__name__)
@@ -126,57 +138,42 @@ def test_nn_loss_adapter_single_target():
     loss_fn = nn.MSELoss()
     adapter = NNLossAdapter(loss_fn)
 
-    y_pred = torch.randn(4, 5, 1)  # [B, T, H]
-    target = torch.randn(4, 5)  # [B, T]
+    y_pred = torch.randn(4, 5, 1)
+    target = torch.randn(4, 5)
 
-    # Test without weights
     loss = adapter(y_pred, target)
     expected_loss = loss_fn(y_pred.squeeze(-1), target)
     assert torch.allclose(loss, expected_loss)
 
-    # Test with weights
     weight = torch.rand(4, 5)
     loss_weighted = adapter(y_pred, (target, weight))
 
-    # Manual weighted mean
+    # MultiHorizonMetric weight semantics: sum(l*w) / sum(lengths)
     raw_loss = nn.MSELoss(reduction="none")(y_pred.squeeze(-1), target)
-    expected_weighted_loss = (raw_loss * weight).sum() / weight.sum()
+    expected_weighted_loss = (raw_loss * weight).sum() / raw_loss.numel()
     assert torch.allclose(loss_weighted, expected_weighted_loss)
 
 
-def test_nn_loss_adapter_multi_target():
-    loss_fn = nn.MSELoss()
-    adapter = NNLossAdapter(loss_fn)
+def test_nn_loss_adapter_multi_target_via_multiloss():
+    """Multi-target uses MultiLoss of adapters, not a stacked single adapter."""
+    ml = MultiLoss([NNLossAdapter(nn.MSELoss()), NNLossAdapter(nn.MSELoss())])
+    y_pred = [torch.randn(4, 5, 1), torch.randn(4, 5, 1)]
+    targets = [torch.randn(4, 5), torch.randn(4, 5)]
+    weight = torch.ones(4, 5)
 
-    y_pred = torch.randn(4, 5, 2)  # [B, T, N]
-    targets = [torch.randn(4, 5), torch.randn(4, 5)]  # List of [B, T]
-
-    # Test without weights
-    loss = adapter(y_pred, (targets, None))
-    expected_loss = loss_fn(y_pred[..., 0], targets[0]) + loss_fn(
-        y_pred[..., 1], targets[1]
+    loss = ml(y_pred, (targets, weight))
+    expected = nn.MSELoss()(y_pred[0].squeeze(-1), targets[0]) + nn.MSELoss()(
+        y_pred[1].squeeze(-1), targets[1]
     )
-    assert torch.allclose(loss, expected_loss)
-
-    # Test with weights
-    weight = torch.rand(4, 5)
-    loss_weighted = adapter(y_pred, (targets, weight))
-
-    # Manual weighted mean for each target then sum
-    raw_loss0 = nn.MSELoss(reduction="none")(y_pred[..., 0], targets[0])
-    raw_loss1 = nn.MSELoss(reduction="none")(y_pred[..., 1], targets[1])
-    expected_weighted_loss = (raw_loss0 * weight).sum() / weight.sum() + (
-        raw_loss1 * weight
-    ).sum() / weight.sum()
-    assert torch.allclose(loss_weighted, expected_weighted_loss)
+    assert torch.allclose(loss, expected)
 
 
-def test_nn_loss_adapter_mismatch_error():
+def test_nn_loss_adapter_rejects_target_list():
     adapter = NNLossAdapter(nn.MSELoss())
-    y_pred = torch.randn(4, 5, 2)  # N=2
-    targets = [torch.randn(4, 5)]  # N=1
+    y_pred = torch.randn(4, 5, 2)
+    targets = [torch.randn(4, 5), torch.randn(4, 5)]
 
-    with pytest.raises(ValueError, match="does not match number of targets"):
+    with pytest.raises(ValueError, match="MultiLoss"):
         adapter(y_pred, (targets, None))
 
 
@@ -185,15 +182,12 @@ def test_base_model_auto_wrap():
         def forward(self, x):
             return {"prediction": torch.randn(4, 5, 1)}
 
-    # Should wrap
     model = SimpleModel(loss=nn.MSELoss())
     assert isinstance(model.loss, NNLossAdapter)
 
-    # Should NOT wrap
     model_ptf = SimpleModel(loss=MAE())
     assert isinstance(model_ptf.loss, MAE)
 
-    # Should NOT wrap MultiLoss
     model_multi = SimpleModel(loss=MultiLoss([MAE()]))
     assert isinstance(model_multi.loss, MultiLoss)
 
@@ -207,7 +201,6 @@ def test_multiloss_mixed_ptf_and_nn_loss():
     assert isinstance(ml.metrics[1], NNLossAdapter)
 
     y_pred = [torch.randn(4, 5, 1), torch.randn(4, 5, 1)]
-    # MAPE is unstable near zero targets
     targets = [torch.randn(4, 5).abs() + 0.5, torch.randn(4, 5)]
     weight = torch.ones(4, 5)
 
@@ -223,6 +216,21 @@ def test_multiloss_mixed_ptf_and_nn_loss():
     assert isinstance(model.loss, MultiLoss)
     assert isinstance(model.loss.metrics[0], MAE)
     assert isinstance(model.loss.metrics[1], NNLossAdapter)
+
+
+def test_composite_metric_with_nn_loss_adapter():
+    """SMAPE() + 0.4 * NNLossAdapter(MSE) works like native metrics."""
+    from pytorch_forecasting.metrics import SMAPE
+    from pytorch_forecasting.metrics.base_metrics import CompositeMetric
+
+    composite = SMAPE() + 0.4 * NNLossAdapter(nn.MSELoss())
+    assert isinstance(composite, CompositeMetric)
+
+    y_pred = torch.randn(4, 5, 1)
+    target = torch.randn(4, 5).abs() + 0.5
+    loss = composite(y_pred, target)
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
 
 
 def test_nn_loss_adapter_to_prediction():
@@ -243,20 +251,18 @@ def test_nn_loss_adapter_to_prediction():
     assert torch.equal(ce_adapter.to_prediction(logits), torch.tensor([[1, 0]]))
 
 
-def test_nn_loss_adapter_reduction_sum():
-    loss_fn = nn.MSELoss(reduction="sum")
-    adapter = NNLossAdapter(loss_fn)
-
+def test_nn_loss_adapter_weighted_mean_matches_mhm():
+    """Weights follow MultiHorizonMetric: sum(l*w) / n_timesteps."""
+    adapter = NNLossAdapter(nn.MSELoss())
     y_pred = torch.randn(4, 5, 1)
     target = torch.randn(4, 5)
     weight = torch.rand(4, 5)
 
     loss = adapter(y_pred, (target, weight))
-
     raw_loss = nn.MSELoss(reduction="none")(y_pred.squeeze(-1), target)
-    expected_loss = (raw_loss * weight).sum()
-    assert torch.allclose(loss, expected_loss)
-    assert loss_fn.reduction == "sum"  # Check it was restored
+    expected = (raw_loss * weight).sum() / raw_loss.numel()
+    assert torch.allclose(loss, expected)
+    assert nn.MSELoss().reduction == "mean"  # caller's loss untouched
 
 
 def test_nn_loss_adapter_list_pred_error():
@@ -264,10 +270,7 @@ def test_nn_loss_adapter_list_pred_error():
     y_pred = [torch.randn(4, 5), torch.randn(4, 5)]
     target = torch.randn(4, 5)
 
-    with pytest.raises(
-        ValueError,
-        match="does not support list of predictions with single target tensor",
-    ):
+    with pytest.raises(ValueError, match="does not support list of predictions"):
         adapter(y_pred, target)
 
 
@@ -284,7 +287,6 @@ def test_tft_cross_entropy_on_discrete_target(tmp_path):
     )
 
     raw = data_with_covariates_v2()
-    # special_event_1 is binary col already present
     raw["class_label"] = raw["special_event_1"].astype("int64")
     n_classes = int(raw["class_label"].nunique())
 

--- a/pytorch_forecasting/tests/test_nn_loss_adapter.py
+++ b/pytorch_forecasting/tests/test_nn_loss_adapter.py
@@ -177,13 +177,13 @@ def test_base_model_auto_wrap():
             return {"prediction": torch.randn(4, 5, 1)}
 
     model = SimpleModel(loss=nn.MSELoss())
-    assert isinstance(model.loss, NNLossAdapter)
+    assert isinstance(model._loss, NNLossAdapter)
 
     model_ptf = SimpleModel(loss=MAE())
-    assert isinstance(model_ptf.loss, MAE)
+    assert isinstance(model_ptf._loss, MAE)
 
     model_multi = SimpleModel(loss=MultiLoss([MAE()]))
-    assert isinstance(model_multi.loss, MultiLoss)
+    assert isinstance(model_multi._loss, MultiLoss)
 
 
 def test_multiloss_mixed_ptf_and_nn_loss():
@@ -207,9 +207,9 @@ def test_multiloss_mixed_ptf_and_nn_loss():
             return {"prediction": torch.randn(4, 5, 1)}
 
     model = SimpleModel(loss=MultiLoss([MAE(), nn.L1Loss()]))
-    assert isinstance(model.loss, MultiLoss)
-    assert isinstance(model.loss.metrics[0], MAE)
-    assert isinstance(model.loss.metrics[1], NNLossAdapter)
+    assert isinstance(model._loss, MultiLoss)
+    assert isinstance(model._loss.metrics[0], MAE)
+    assert isinstance(model._loss.metrics[1], NNLossAdapter)
 
 
 def test_composite_metric_with_nn_loss_adapter():

--- a/pytorch_forecasting/tests/test_nn_loss_adapter.py
+++ b/pytorch_forecasting/tests/test_nn_loss_adapter.py
@@ -198,6 +198,33 @@ def test_base_model_auto_wrap():
     assert isinstance(model_multi.loss, MultiLoss)
 
 
+def test_multiloss_mixed_ptf_and_nn_loss():
+    """MultiLoss([ptf_metric, nn.MSELoss()]) wraps the nn child via NNLossAdapter."""
+    from pytorch_forecasting.metrics import MAPE
+
+    ml = MultiLoss([MAPE(), nn.MSELoss()])
+    assert isinstance(ml.metrics[0], MAPE)
+    assert isinstance(ml.metrics[1], NNLossAdapter)
+
+    y_pred = [torch.randn(4, 5, 1), torch.randn(4, 5, 1)]
+    # MAPE is unstable near zero targets
+    targets = [torch.randn(4, 5).abs() + 0.5, torch.randn(4, 5)]
+    weight = torch.ones(4, 5)
+
+    loss = ml(y_pred, (targets, weight))
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+
+    class SimpleModel(BaseModel):
+        def forward(self, x):
+            return {"prediction": torch.randn(4, 5, 1)}
+
+    model = SimpleModel(loss=MultiLoss([MAE(), nn.L1Loss()]))
+    assert isinstance(model.loss, MultiLoss)
+    assert isinstance(model.loss.metrics[0], MAE)
+    assert isinstance(model.loss.metrics[1], NNLossAdapter)
+
+
 def test_nn_loss_adapter_to_prediction():
     adapter = NNLossAdapter(nn.MSELoss())
     y_pred = torch.randn(4, 5, 1)

--- a/pytorch_forecasting/tests/test_nn_loss_adapter.py
+++ b/pytorch_forecasting/tests/test_nn_loss_adapter.py
@@ -56,12 +56,6 @@ def _point_tensors(loss_fn: nn.Module, batch=4, time=5):
     return y_pred, target
 
 
-def test_nn_loss_adapter_is_metric():
-    adapter = NNLossAdapter(nn.MSELoss())
-    assert isinstance(adapter, Metric)
-    assert isinstance(adapter, MultiHorizonMetric)
-
-
 @pytest.mark.parametrize("loss_fn", POINT_NN_LOSSES, ids=lambda x: type(x).__name__)
 def test_nn_loss_adapter_all_point_losses(loss_fn):
     """Adapter works for common same-shape nn losses (with and without weights)."""


### PR DESCRIPTION
<!--
Welcome to pytorch-forecasting, and thanks for contributing!
Please have a look at our contribution guide:
https://www.sktime.net/en/latest/get_involved/contributing.html
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/sktime/pytorch-forecasting/issues
-->
Fixes #1970


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
Followups and stacks on existing PR #2073 by @Nidhicodes

By @Nidhicodes:
- Introduces NNLossAdapter, a lightweight wrapper that adapts nn.Module losses to the ptf-v2 loss/metric API.
- Enables users to pass native PyTorch losses directly to models (e.g. DLinear(loss=nn.MSELoss())) without manual wrapping.
- Ensures compatibility with BaseModel.predict() by implementing to_prediction and to_quantiles.

The adapter:
- Handles (target, weight) inputs by applying weights internally while respecting the loss’s original reduction.
- Supports multi-target predictions by splitting [B, T, N] tensors and summing losses across targets.
- Enforces point-prediction-only usage (H=1) for losses that are not horizon-aware, with clear error messages otherwise.

Further updates:
- store in `self._loss` instead of `self.loss` 
- merge main
- integration tests with models
- fix for `tide` and other models where needed
- add support for non-point losses

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. If you have any questions, feel free to post
in the dev-chat channel on the sktime discord https://discord.com/invite/54ACzaFsn7. If we are slow to review (>3 working days), likewise feel free to ping us on discord. Thank you for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`