### PR TITLE
[MNT] Improve coverage of test framework for ptf-v2 and fix TiDE categorical embedding bug

### DIFF
--- a/pytorch_forecasting/base/_base_pkg.py
+++ b/pytorch_forecasting/base/_base_pkg.py
@@ -122,18 +122,25 @@ class Base_pkg(_BasePtForecasterV2):
         raise NotImplementedError("Subclasses must implement `get_datamodule_cls`.")
 
     @classmethod
-    def get_test_dataset_from(cls, **kwargs):
+    def get_test_dataset_from(cls, data_scenario="with_covariates", **kwargs):
         """
         Creates and returns D1 TimeSeries dataSet objects for testing.
         """
         from pytorch_forecasting.tests._data_scenarios import (
             data_with_covariates_v2,
             make_datasets_v2,
+            make_datasets_v2_with_categoricals,
+            make_datasets_v2_without_covariates,
         )
 
         raw_data = data_with_covariates_v2()
 
-        datasets_info = make_datasets_v2(raw_data, **kwargs)
+        if data_scenario == "without_covariates":
+            datasets_info = make_datasets_v2_without_covariates(raw_data, **kwargs)
+        elif data_scenario == "with_categoricals":
+            datasets_info = make_datasets_v2_with_categoricals(raw_data, **kwargs)
+        else:
+            datasets_info = make_datasets_v2(raw_data, **kwargs)
 
         return {
             "train": datasets_info["training_dataset"],

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -302,8 +302,17 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             metadata["static_categorical_features"] = 0
             metadata["static_continuous_features"] = 0
 
+        categorical_cardinalities = []
+        for idx in self.categorical_indices:
+            col = self.time_series_metadata["cols"]["x"][idx]
+            max_val = self.time_series_dataset.data[col].max()
+            cardinality = int(max_val) + 1 if not pd.isna(max_val) else 1
+            cardinality = max(1, cardinality)
+            categorical_cardinalities.append(cardinality)
+
         metadata.update(
             {
+                "categorical_cardinalities": categorical_cardinalities,
                 "max_encoder_length": self.max_encoder_length,
                 "max_prediction_length": self.max_prediction_length,
                 "min_encoder_length": self._min_encoder_length,

--- a/pytorch_forecasting/data/data_module/_tslib_data_module.py
+++ b/pytorch_forecasting/data/data_module/_tslib_data_module.py
@@ -510,10 +510,18 @@ class TslibDataModule(LightningDataModule):
         else:
             self.features = "M"
 
+        categorical_cardinalities = []
+        for col in feature_names.get("categorical", []):
+            max_val = self.time_series_dataset.data[col].max()
+            cardinality = int(max_val) + 1 if not pd.isna(max_val) else 1
+            cardinality = max(1, cardinality)
+            categorical_cardinalities.append(cardinality)
+
         metadata = {
             "feature_names": feature_names,
             "feature_indices": feature_indices,
             "n_features": n_features,
+            "categorical_cardinalities": categorical_cardinalities,
             "context_length": self.context_length,
             "prediction_length": self.prediction_length,
             "freq": self.freq,

--- a/pytorch_forecasting/models/tide/_tide_dsipts/_tide_v2.py
+++ b/pytorch_forecasting/models/tide/_tide_dsipts/_tide_v2.py
@@ -112,6 +112,9 @@ class TIDE(BaseModel):
         )
 
         # embedding categorical for both past and future
+        if not embs and metadata is not None:
+            embs = metadata.get("categorical_cardinalities", [])
+
         self.seq_len = self.past_steps + self.future_steps
         self.emb_cat_var = sub_nn.embedding_cat_variables(
             self.seq_len, self.future_steps, hidden_size, embs, self.device

--- a/pytorch_forecasting/tests/_data_scenarios.py
+++ b/pytorch_forecasting/tests/_data_scenarios.py
@@ -271,6 +271,159 @@ def make_datasets_v2(data_with_covariates, **kwargs):
     }
 
 
+def make_datasets_v2_without_covariates(data_with_covariates, **kwargs):
+    """Create datasets with only time, target, weight, and group features,
+    no covariates.
+    """
+    training_cutoff = "2016-09-01"
+    target_col = kwargs.get("target", "target")
+    group_cols = kwargs.get("group_ids", ["agency_encoded", "sku_encoded"])
+
+    training_data = data_with_covariates[
+        data_with_covariates.date < training_cutoff
+    ].copy()
+    validation_data = data_with_covariates.copy()
+
+    required_columns = ["time_idx", target_col, "weight"] + group_cols
+    training_data_clean = training_data[required_columns].copy()
+    validation_data_clean = validation_data[required_columns].copy()
+
+    training_dataset = TimeSeries(
+        data=training_data_clean,
+        time="time_idx",
+        target=[target_col],
+        group=group_cols,
+        weight="weight",
+        num=[],
+        cat=None,
+        known=[],
+        unknown=[],
+        static=group_cols,
+    )
+
+    validation_dataset = TimeSeries(
+        data=validation_data_clean,
+        time="time_idx",
+        target=[target_col],
+        group=group_cols,
+        weight="weight",
+        num=[],
+        cat=None,
+        known=[],
+        unknown=[],
+        static=group_cols,
+    )
+
+    training_max_time_idx = training_data["time_idx"].max() + 1
+
+    return {
+        "training_dataset": training_dataset,
+        "validation_dataset": validation_dataset,
+        "training_max_time_idx": training_max_time_idx,
+    }
+
+
+def make_datasets_v2_with_categoricals(data_with_covariates, **kwargs):
+    """Create datasets with categorical features."""
+    training_cutoff = "2016-09-01"
+    target_col = kwargs.get("target", "target")
+    group_cols = kwargs.get("group_ids", ["agency_encoded", "sku_encoded"])
+
+    known_features = [
+        "month",
+        "year",
+        "quarter",
+        "seasonal_1",
+        "seasonal_2",
+        "trend",
+    ]
+    unknown_features = [
+        "agency_feature_1",
+        "agency_feature_2",
+        "sku_feature_1",
+        "sku_feature_2",
+        "noise",
+        "log_volume",
+    ]
+
+    numerical_features = known_features + unknown_features
+    categorical_features = ["special_event_1", "special_event_2"]
+    static_features = group_cols
+
+    for col in numerical_features + group_cols + [target_col]:
+        if col in data_with_covariates.columns:
+            data_with_covariates[col] = pd.to_numeric(
+                data_with_covariates[col], errors="coerce"
+            ).fillna(0)
+
+    for col in categorical_features + group_cols:
+        if col in data_with_covariates.columns:
+            data_with_covariates[col] = data_with_covariates[col].astype("int64")
+
+    if "weight" in data_with_covariates.columns:
+        data_with_covariates["weight"] = pd.to_numeric(
+            data_with_covariates["weight"], errors="coerce"
+        ).fillna(1.0)
+
+    training_data = data_with_covariates[
+        data_with_covariates.date < training_cutoff
+    ].copy()
+    validation_data = data_with_covariates.copy()
+
+    required_columns = (
+        ["time_idx", target_col, "weight", "date"]
+        + group_cols
+        + numerical_features
+        + categorical_features
+    )
+
+    available_columns = [
+        col for col in required_columns if col in data_with_covariates.columns
+    ]
+
+    training_data_clean = training_data[available_columns].copy()
+    validation_data_clean = validation_data[available_columns].copy()
+
+    if "date" in training_data_clean.columns:
+        training_data_clean = training_data_clean.drop("date", axis=1)
+    if "date" in validation_data_clean.columns:
+        validation_data_clean = validation_data_clean.drop("date", axis=1)
+
+    training_dataset = TimeSeries(
+        data=training_data_clean,
+        time="time_idx",
+        target=[target_col],
+        group=group_cols,
+        weight="weight",
+        num=numerical_features,
+        cat=categorical_features,
+        known=known_features + categorical_features,
+        unknown=unknown_features,
+        static=static_features,
+    )
+
+    validation_dataset = TimeSeries(
+        data=validation_data_clean,
+        time="time_idx",
+        target=[target_col],
+        group=group_cols,
+        weight="weight",
+        num=numerical_features,
+        cat=categorical_features,
+        known=known_features + categorical_features,
+        unknown=unknown_features,
+        static=static_features,
+    )
+
+    training_max_time_idx = training_data["time_idx"].max() + 1
+
+    return {
+        "training_dataset": training_dataset,
+        "validation_dataset": validation_dataset,
+        "training_max_time_idx": training_max_time_idx,
+    }
+
+
 def dataloaders_with_different_encoder_decoder_length():
     return make_dataloaders(
         data_with_covariates(),

--- a/pytorch_forecasting/tests/test_all_v2/test_all_estimators_v2.py
+++ b/pytorch_forecasting/tests/test_all_v2/test_all_estimators_v2.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import shutil
 
+import pytest
 import torch
 
 from pytorch_forecasting.tests.test_all_estimators import (
@@ -29,18 +30,45 @@ class TestAllPtForecastersV2(EstimatorPackageConfig, EstimatorFixtureGenerator):
 
         run_doctest(object_class, name=f"class {object_class.__name__}")
 
+    @pytest.mark.parametrize(
+        "data_scenario",
+        ["with_covariates", "without_covariates", "with_categoricals"],
+    )
     def test_integration(
         self,
         object_pkg,
         trainer_kwargs,
         tmp_path,
+        data_scenario,
     ):
         pkg, test_data, dm_cfg = _setup_pkg_and_data(
-            object_pkg, trainer_kwargs, tmp_path
+            object_pkg, trainer_kwargs, tmp_path, data_scenario=data_scenario
         )
 
         _integration(pkg, test_data, dm_cfg)
 
+        shutil.rmtree(tmp_path, ignore_errors=True)
+
+    def test_uninitialized_predict_error(self, object_pkg):
+        """Test that predict raises RuntimeError if model is not initialized."""
+        pkg = object_pkg()
+        with pytest.raises(RuntimeError, match="Model is not initialized"):
+            pkg.predict(None)
+
+    def test_predict_save_to_dir(self, object_pkg, trainer_kwargs, tmp_path):
+        """Test that predict can save predictions to a specified directory."""
+        pkg, test_data, _ = _setup_pkg_and_data(object_pkg, trainer_kwargs, tmp_path)
+        pkg.fit(test_data["train"], save_ckpt=False)
+
+        output_dir = Path(tmp_path) / "predictions_out"
+        out = pkg.predict(
+            test_data["predict"], mode="prediction", output_dir=output_dir
+        )
+
+        assert out is None, "predict should return None when output_dir is specified"
+        assert (
+            output_dir / "predictions.pkl"
+        ).exists(), "predictions.pkl was not saved"
         shutil.rmtree(tmp_path, ignore_errors=True)
 
     def test_checkpointing(self, object_pkg, trainer_kwargs, tmp_path):

--- a/pytorch_forecasting/tests/test_all_v2/utils.py
+++ b/pytorch_forecasting/tests/test_all_v2/utils.py
@@ -11,6 +11,7 @@ def _setup_pkg_and_data(
     estimator_cls: type[Base_pkg],
     trainer_kwargs: dict[str, Any],
     tmp_path: str,
+    data_scenario: str = "with_covariates",
 ) -> tuple[Base_pkg, dict[str, TimeSeries], dict[str, Any]]:
     """
     Helper to initialize the Package, Datasets, and Configs.
@@ -50,7 +51,9 @@ def _setup_pkg_and_data(
         "logger": logger,
     }
 
-    test_data = estimator_cls.get_test_dataset_from(**default_datamodule_cfg)
+    test_data = estimator_cls.get_test_dataset_from(
+        data_scenario=data_scenario, **default_datamodule_cfg
+    )
 
     pkg = estimator_cls(
         model_cfg=model_cfg,


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #2328.

#### What does this implement/fix? Explain your changes.
This PR increases the test coverage of the V2 testing framework by introducing new data scenarios, parameterizing integration tests, adding validation-check tests, and resolving a categorical embedding bug in the TiDE V2 model.

**Specifically:**
1. **Diverse V2 Data Scenarios**: 
   * Added `make_datasets_v2_without_covariates` to verify estimator behaviors on datasets containing only targets and group IDs without any covariates.
   * Added `make_datasets_v2_with_categoricals` to verify estimators handling categorical features alongside continuous features.
2. **Parameterized Integration Tests**:
   * Parameterized V2 model integration tests in `test_all_estimators_v2.py` across three data scenarios: `with_covariates`, `without_covariates`, and `with_categoricals`.
3. **New Test Validation Cases**:
   * Added `test_uninitialized_predict_error` to assert that calling `.predict()` on an uninitialized model correctly raises a `RuntimeError`.
   * Added `test_predict_save_to_dir` to assert that calling `.predict()` with an `output_dir` successfully saves the prediction dictionary to a `predictions.pkl` file.
4. **Fixed TiDE Categorical Embedding Bug**:
   * Updated `TslibDataModule` and `EncoderDecoderTimeSeriesDataModule` metadata builders to compute and include `"categorical_cardinalities"` (derived from the dataset's unique values/max values).
   * Updated `TIDE` model constructor to automatically resolve categorical cardinalities from the datamodule metadata when `embs` is not explicitly provided. This prevents the `IndexError` on categorical feature embedding projection.

#### What should a reviewer concentrate their feedback on?
* Review the integration of `"categorical_cardinalities"` metadata propagation inside `TslibDataModule` and `EncoderDecoderTimeSeriesDataModule`.
* Inspect the fallback mechanism in `TIDE.__init__` that dynamically maps these cardinalities into embedding dimensions when `embs` is not explicitly supplied in model configuration.

#### Did you add any tests for the change?
Yes:
* Added parameterized integration tests for all V2 models across the three new and existing data scenarios (`with_covariates`, `without_covariates`, and `with_categoricals`).
* Added `test_uninitialized_predict_error` and `test_predict_save_to_dir` check cases in `test_all_estimators_v2.py`.

#### Any other comments?
All V2 estimators (DLinear, TimeXer, TFT, TiDE) were verified to pass the integration and validation test suites successfully (201 total tests passed).

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [x] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks. Install hooks with `pre-commit install`.
  To run hooks independent of commit, execute `pre-commit run --all-files`