### PR TITLE
[BUG] Normalize decoder targets with encoder statistics

### DIFF
--- a/docs/source/data_v2.rst
+++ b/docs/source/data_v2.rst
@@ -36,6 +36,20 @@ The D2 Layer sits on top of D1 and is implemented as a PyTorch Lightning ``Light
 * **Batching:** Creating and managing the ``train_dataloader``, ``val_dataloader``, and ``test_dataloader``.
 * **Model Initialization Metadata:** Dynamically collecting necessary architectural information (such as the number of categorical variables, embedding sizes, and vocabulary states) required to properly instantiate the Forecasting models in the Model Layer.
 
+Sequence-local target normalization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When :class:`~pytorch_forecasting.data.encoders.EncoderNormalizer` is used with
+:class:`~pytorch_forecasting.data.data_module.EncoderDecoderTimeSeriesDataModule`,
+its normalization parameters are fitted independently for each sample using
+only that sample's encoder target window. The fitted parameters are then reused
+to transform both ``target_past`` and the decoder target ``y``.
+
+The decoder target is not included when fitting the normalizer. This prevents
+future target leakage while ensuring that model inputs and supervised targets
+use the same scale. For multi-target data, this behavior applies only to target
+columns configured with a sequence-local normalizer.
+
 
 **Model Compatibility**
 

--- a/pytorch_forecasting/adapters/scaler_adapters.py
+++ b/pytorch_forecasting/adapters/scaler_adapters.py
@@ -183,11 +183,43 @@ class ScalerAdapter:
             Same shape as input.
         """
         if not self.is_multi:
-            return (
-                self.fit_transform(data, X)
-                if self.fit_per_sequence
-                else _to_tensor(data)
-            )
+            if self.fit_per_sequence:
+                self.fit(data, X)
+            return self.transform_sequence(data, X)
+
+        t = _to_tensor(data)
+        if t.ndim == 1:
+            t = t.unsqueeze(-1)
+
+        for idx, sub in enumerate(self._sub_adapters):
+            if sub.fit_per_sequence:
+                sub.fit(t[:, idx], X)
+        return self.transform_sequence(t, X)
+
+    def transform_sequence(
+        self, data: ArrayLike, X: pd.DataFrame = None
+    ) -> torch.Tensor:
+        """Transform only per-sequence normalizers using their fitted state.
+
+        Used after fitting on an encoder window to apply the same normalization
+        to its decoder window. Non-per-sequence normalizers are left unchanged
+        to match the behavior of ``fit_transform_sequence``.
+
+        Parameters
+        ----------
+        data : tensor, ndarray, or Series
+            Shape ``(sequence_length,)`` or
+            ``(sequence_length, n_targets)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Same shape as input.
+        """
+        if not self.is_multi:
+            if self.fit_per_sequence:
+                return self.transform(data, X)
+            return _to_tensor(data)
 
         t = _to_tensor(data)
         if t.ndim == 1:
@@ -196,6 +228,6 @@ class ScalerAdapter:
         columns = []
         for idx, sub in enumerate(self._sub_adapters):
             col = t[:, idx]
-            col = sub.fit_transform(col, X) if sub.fit_per_sequence else col
+            col = sub.transform(col, X) if sub.fit_per_sequence else col
             columns.append(col.unsqueeze(-1))
         return torch.cat(columns, dim=-1)

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -636,6 +636,9 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
             y : torch.Tensor or list of torch.Tensor
                 Target values for the decoder sequence.
+                When an ``EncoderNormalizer`` is configured, the target is
+                transformed using parameters fitted exclusively on the
+                corresponding encoder sequence.
                 If ``n_targets`` > 1, a list of tensors each of shape (pred_length,)
                 is returned. Otherwise, a tensor of shape (pred_length,) is returned.
             """
@@ -647,15 +650,14 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             decoder_indices = slice(start_idx + enc_length, end_idx)
 
             target_past = data["target"][encoder_indices]
+            target_future = data["target"][decoder_indices]
 
-            # apply encoder normalizer on target_past.
+            # Fit the encoder normalizer on target_past, then apply the fitted
+            # state to both the encoder and decoder targets.
             normalizer = self.data_module._target_normalizer
             if normalizer is not None and normalizer.fit_per_sequence:
-                target_past = (
-                    self.data_module._target_normalizer.fit_transform_sequence(
-                        target_past
-                    )
-                )
+                target_past = normalizer.fit_transform_sequence(target_past)
+                target_future = normalizer.transform_sequence(target_future)
 
             target_original_past = data["target_original"][encoder_indices]
             valid_mask = ~torch.isnan(target_original_past)
@@ -795,7 +797,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                         (1, 0), dtype=torch.float32
                     )
 
-            y = data["target"][decoder_indices]
+            y = target_future
 
             if y.shape[-1] > 1:
                 y = [y[:, i] for i in range(y.shape[-1])]

--- a/tests/test_data/test_data_module.py
+++ b/tests/test_data/test_data_module.py
@@ -626,6 +626,31 @@ def test_target_normalizers(sample_timeseries_data, normalizer):
         dm_with_norm._target_normalizer_fitted = False
 
 
+def test_encoder_normalizer_applies_to_decoder_target(sample_timeseries_data):
+    """Test that decoder targets use the encoder-fitted normalization."""
+    dm = EncoderDecoderTimeSeriesDataModule(
+        time_series_dataset=sample_timeseries_data,
+        max_encoder_length=15,
+        max_prediction_length=5,
+        batch_size=4,
+        target_normalizer=EncoderNormalizer(),
+    )
+    dm.setup(stage="fit")
+
+    dataset = dm.train_dataset
+    series_idx, start_idx, enc_length, pred_length = dataset.windows[0]
+    decoder_start = start_idx + enc_length
+    raw_decoder_target = dataset.preprocessed_data[series_idx]["target"][
+        decoder_start : decoder_start + pred_length
+    ].clone()
+
+    _, y = dataset[0]
+    expected = dm._target_normalizer.transform_sequence(raw_decoder_target).squeeze(-1)
+
+    torch.testing.assert_close(y, expected)
+    assert not torch.allclose(y, raw_decoder_target.squeeze(-1))
+
+
 @pytest.mark.parametrize(
     "scaler_type",
     [

--- a/tests/test_data/test_scaler_adapters.py
+++ b/tests/test_data/test_scaler_adapters.py
@@ -1,0 +1,37 @@
+import torch
+
+from pytorch_forecasting.adapters.scaler_adapters import ScalerAdapter
+from pytorch_forecasting.data.encoders import (
+    EncoderNormalizer,
+    MultiNormalizer,
+    TorchNormalizer,
+)
+
+
+def test_sequence_transform_leaves_global_normalizer_data_unchanged():
+    """Test that sequence transforms do not reapply global normalization."""
+    data = torch.tensor([1.0, 2.0, 3.0])
+    adapter = ScalerAdapter(TorchNormalizer())
+
+    transformed = adapter.transform_sequence(data)
+
+    torch.testing.assert_close(transformed, data)
+
+
+def test_sequence_transform_supports_one_dimensional_multi_normalizer_data():
+    """Test one-dimensional data with a single-target MultiNormalizer."""
+    encoder_data = torch.tensor([1.0, 2.0, 3.0])
+    decoder_data = torch.tensor([4.0, 5.0])
+    adapter = ScalerAdapter(MultiNormalizer([EncoderNormalizer()]))
+
+    transformed_encoder = adapter.fit_transform_sequence(encoder_data)
+    transformed_decoder = adapter.transform_sequence(decoder_data)
+
+    scale = encoder_data.std() + torch.finfo(encoder_data.dtype).eps
+    expected_encoder = (encoder_data - encoder_data.mean()) / scale
+    expected_decoder = (decoder_data - encoder_data.mean()) / scale
+
+    assert transformed_encoder.shape == (3, 1)
+    assert transformed_decoder.shape == (2, 1)
+    torch.testing.assert_close(transformed_encoder.squeeze(-1), expected_encoder)
+    torch.testing.assert_close(transformed_decoder.squeeze(-1), expected_decoder)


### PR DESCRIPTION
## Reference Issues/PRs

Fixes #2360.

## What does this implement/fix? Explain your changes.

`EncoderDecoderTimeSeriesDataModule` previously fitted
`EncoderNormalizer` on each encoder window and normalized `target_past`, but
returned the corresponding decoder target `y` without the sequence-local
normalization.

This PR:

- Adds `ScalerAdapter.transform_sequence()` to transform data using an
  already-fitted sequence-local normalizer.
- Fits normalization parameters exclusively on the encoder target window.
- Reuses those parameters to transform the decoder target.
- Preserves existing behavior for non-sequence normalizers and mixed
  multi-target configurations.
- Documents the normalization behavior in the v2 data documentation and API
  docstring.

The decoder target is never used when fitting the normalizer, preventing future
target leakage.

## What should a reviewer concentrate their feedback on?

- Whether `transform_sequence()` has the appropriate behavior for single and
  multi-target normalizers.
- Whether reusing encoder-fitted statistics for the decoder target is consistent
  with the intended `EncoderNormalizer` semantics.
- Whether mixed `MultiNormalizer` configurations continue to preserve the
  existing behavior for non-sequence target columns.

## Did you add any tests for the change?

Yes. Added `test_encoder_normalizer_applies_to_decoder_target`, which verifies
that:

- Decoder `y` uses the normalization parameters fitted on the encoder window.
- The normalized decoder target matches an independent transformation using the
  fitted state.
- The returned decoder target differs from the raw target.

The complete data-module test file passes:

- 43 tests passed
- Ruff checks passed
- `git diff --check` passed

## Any other comments?

The documentation now explicitly states that sequence-local normalization is
fitted exclusively on encoder observations and then reused for both
`target_past` and decoder `y`.

## PR checklist

- [x] The PR title starts with either `[ENH]`, `[MNT]`, `[DOC]`, or `[BUG]`.
- [x] Added/modified tests.
- [x] Used pre-commit hooks to ensure that the code complies with repository
      hooks.