### PR TITLE
[BUG] fixes correct passing of `index` in v2

### DIFF
--- a/docs/source/tutorials/ptf_V2_example.ipynb
+++ b/docs/source/tutorials/ptf_V2_example.ipynb
@@ -57,38 +57,59 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
    "metadata": {
-    "id": "RkgOT4kiy_RU"
+    "id": "RkgOT4kiy_RU",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:12.499333648Z",
+     "start_time": "2026-08-05T07:39:12.347281372Z"
+    }
    },
-   "outputs": [],
    "source": [
     "from pytorch_forecasting.data.examples import load_toydata"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 18
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 206
     },
     "id": "WX-FRdusJSVN",
-    "outputId": "2ad916b8-2fd9-4318-afb1-2bda84d284d7"
+    "outputId": "2ad916b8-2fd9-4318-afb1-2bda84d284d7",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:12.611019552Z",
+     "start_time": "2026-08-05T07:39:12.536303163Z"
+    }
    },
+   "source": [
+    "num_series = 100  # Number of individual time series to generate\n",
+    "seq_length = 50  # Length of each time series\n",
+    "data_df = load_toydata(num_series, seq_length)\n",
+    "data_df.head()"
+   ],
    "outputs": [
     {
      "data": {
-      "application/vnd.google.colaboratory.intrinsic+json": {
-       "summary": "{\n  \"name\": \"data_df\",\n  \"rows\": 4900,\n  \"fields\": [\n    {\n      \"column\": \"series_id\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 28,\n        \"min\": 0,\n        \"max\": 99,\n        \"num_unique_values\": 100,\n        \"samples\": [\n          83,\n          53,\n          70\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"time_idx\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 14,\n        \"min\": 0,\n        \"max\": 48,\n        \"num_unique_values\": 49,\n        \"samples\": [\n          13,\n          45,\n          47\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"x\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.6712252870750063,\n        \"min\": -1.2780952045426857,\n        \"max\": 1.3163602917006327,\n        \"num_unique_values\": 4900,\n        \"samples\": [\n          0.19335967827533446,\n          0.8492207493147326,\n          -0.9687640491099185\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"y\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.6753351884449413,\n        \"min\": -1.2780952045426857,\n        \"max\": 1.3163602917006327,\n        \"num_unique_values\": 4900,\n        \"samples\": [\n          0.6981263626070341,\n          0.7052787051636003,\n          -0.861386757323439\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"category\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 1,\n        \"min\": 0,\n        \"max\": 4,\n        \"num_unique_values\": 5,\n        \"samples\": [\n          1,\n          4,\n          2\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"future_known_feature\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.6741140972121411,\n        \"min\": -0.9991351502732795,\n        \"max\": 1.0,\n        \"num_unique_values\": 49,\n        \"samples\": [\n          0.26749882862458735,\n          -0.2107957994307797,\n          -0.01238866346289056\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"static_feature\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0.2792423704109133,\n        \"min\": 0.031153133884698536,\n        \"max\": 0.9662188410416612,\n        \"num_unique_values\": 100,\n        \"samples\": [\n          0.24602577096925082,\n          0.8680231736929984,\n          0.6913124004679789\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    },\n    {\n      \"column\": \"static_feature_cat\",\n      \"properties\": {\n        \"dtype\": \"number\",\n        \"std\": 0,\n        \"min\": 0,\n        \"max\": 2,\n        \"num_unique_values\": 3,\n        \"samples\": [\n          0,\n          1,\n          2\n        ],\n        \"semantic_type\": \"\",\n        \"description\": \"\"\n      }\n    }\n  ]\n}",
-       "type": "dataframe",
-       "variable_name": "data_df"
-      },
-      "text/html": [
+      "text/plain": [
+       "   series_id  time_idx         x         y  category  future_known_feature  \\\n",
+       "0          0         0 -0.059119  0.103793         0              1.000000   \n",
+       "1          0         1  0.103793  0.512749         0              0.995004   \n",
+       "2          0         2  0.512749  0.594269         0              0.980067   \n",
+       "3          0         3  0.594269  0.728941         0              0.955336   \n",
+       "4          0         4  0.728941  0.814091         0              0.921061   \n",
        "\n",
-       "  <div id=\"df-1832c3c5-7f87-4d94-b11a-f1f39dcbdc3e\" class=\"colab-df-container\">\n",
-       "    <div>\n",
+       "   static_feature  static_feature_cat  \n",
+       "0        0.384861                   0  \n",
+       "1        0.384861                   0  \n",
+       "2        0.384861                   0  \n",
+       "3        0.384861                   0  \n",
+       "4        0.384861                   0  "
+      ],
+      "text/html": [
+       "<div>\n",
        "<style scoped>\n",
        "    .dataframe tbody tr th:only-of-type {\n",
        "        vertical-align: middle;\n",
@@ -121,297 +142,68 @@
        "      <th>0</th>\n",
        "      <td>0</td>\n",
        "      <td>0</td>\n",
-       "      <td>-0.030643</td>\n",
-       "      <td>0.148280</td>\n",
+       "      <td>-0.059119</td>\n",
+       "      <td>0.103793</td>\n",
        "      <td>0</td>\n",
        "      <td>1.000000</td>\n",
-       "      <td>0.039213</td>\n",
+       "      <td>0.384861</td>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>0</td>\n",
        "      <td>1</td>\n",
-       "      <td>0.148280</td>\n",
-       "      <td>0.433029</td>\n",
+       "      <td>0.103793</td>\n",
+       "      <td>0.512749</td>\n",
        "      <td>0</td>\n",
        "      <td>0.995004</td>\n",
-       "      <td>0.039213</td>\n",
+       "      <td>0.384861</td>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>0</td>\n",
        "      <td>2</td>\n",
-       "      <td>0.433029</td>\n",
-       "      <td>0.742511</td>\n",
+       "      <td>0.512749</td>\n",
+       "      <td>0.594269</td>\n",
        "      <td>0</td>\n",
        "      <td>0.980067</td>\n",
-       "      <td>0.039213</td>\n",
+       "      <td>0.384861</td>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>0</td>\n",
        "      <td>3</td>\n",
-       "      <td>0.742511</td>\n",
-       "      <td>0.729270</td>\n",
+       "      <td>0.594269</td>\n",
+       "      <td>0.728941</td>\n",
        "      <td>0</td>\n",
        "      <td>0.955336</td>\n",
-       "      <td>0.039213</td>\n",
+       "      <td>0.384861</td>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>0</td>\n",
        "      <td>4</td>\n",
-       "      <td>0.729270</td>\n",
-       "      <td>0.628604</td>\n",
+       "      <td>0.728941</td>\n",
+       "      <td>0.814091</td>\n",
        "      <td>0</td>\n",
        "      <td>0.921061</td>\n",
-       "      <td>0.039213</td>\n",
+       "      <td>0.384861</td>\n",
        "      <td>0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "</div>\n",
-       "    <div class=\"colab-df-buttons\">\n",
-       "\n",
-       "  <div class=\"colab-df-container\">\n",
-       "    <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-1832c3c5-7f87-4d94-b11a-f1f39dcbdc3e')\"\n",
-       "            title=\"Convert this dataframe to an interactive table.\"\n",
-       "            style=\"display:none;\">\n",
-       "\n",
-       "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\" viewBox=\"0 -960 960 960\">\n",
-       "    <path d=\"M120-120v-720h720v720H120Zm60-500h600v-160H180v160Zm220 220h160v-160H400v160Zm0 220h160v-160H400v160ZM180-400h160v-160H180v160Zm440 0h160v-160H620v160ZM180-180h160v-160H180v160Zm440 0h160v-160H620v160Z\"/>\n",
-       "  </svg>\n",
-       "    </button>\n",
-       "\n",
-       "  <style>\n",
-       "    .colab-df-container {\n",
-       "      display:flex;\n",
-       "      gap: 12px;\n",
-       "    }\n",
-       "\n",
-       "    .colab-df-convert {\n",
-       "      background-color: #E8F0FE;\n",
-       "      border: none;\n",
-       "      border-radius: 50%;\n",
-       "      cursor: pointer;\n",
-       "      display: none;\n",
-       "      fill: #1967D2;\n",
-       "      height: 32px;\n",
-       "      padding: 0 0 0 0;\n",
-       "      width: 32px;\n",
-       "    }\n",
-       "\n",
-       "    .colab-df-convert:hover {\n",
-       "      background-color: #E2EBFA;\n",
-       "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-       "      fill: #174EA6;\n",
-       "    }\n",
-       "\n",
-       "    .colab-df-buttons div {\n",
-       "      margin-bottom: 4px;\n",
-       "    }\n",
-       "\n",
-       "    [theme=dark] .colab-df-convert {\n",
-       "      background-color: #3B4455;\n",
-       "      fill: #D2E3FC;\n",
-       "    }\n",
-       "\n",
-       "    [theme=dark] .colab-df-convert:hover {\n",
-       "      background-color: #434B5C;\n",
-       "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-       "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-       "      fill: #FFFFFF;\n",
-       "    }\n",
-       "  </style>\n",
-       "\n",
-       "    <script>\n",
-       "      const buttonEl =\n",
-       "        document.querySelector('#df-1832c3c5-7f87-4d94-b11a-f1f39dcbdc3e button.colab-df-convert');\n",
-       "      buttonEl.style.display =\n",
-       "        google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-       "\n",
-       "      async function convertToInteractive(key) {\n",
-       "        const element = document.querySelector('#df-1832c3c5-7f87-4d94-b11a-f1f39dcbdc3e');\n",
-       "        const dataTable =\n",
-       "          await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-       "                                                    [key], {});\n",
-       "        if (!dataTable) return;\n",
-       "\n",
-       "        const docLinkHtml = 'Like what you see? Visit the ' +\n",
-       "          '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-       "          + ' to learn more about interactive tables.';\n",
-       "        element.innerHTML = '';\n",
-       "        dataTable['output_type'] = 'display_data';\n",
-       "        await google.colab.output.renderOutput(dataTable, element);\n",
-       "        const docLink = document.createElement('div');\n",
-       "        docLink.innerHTML = docLinkHtml;\n",
-       "        element.appendChild(docLink);\n",
-       "      }\n",
-       "    </script>\n",
-       "  </div>\n",
-       "\n",
-       "\n",
-       "    <div id=\"df-846d0093-caf5-46ab-8a57-4a3a141ca666\">\n",
-       "      <button class=\"colab-df-quickchart\" onclick=\"quickchart('df-846d0093-caf5-46ab-8a57-4a3a141ca666')\"\n",
-       "                title=\"Suggest charts\"\n",
-       "                style=\"display:none;\">\n",
-       "\n",
-       "<svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-       "     width=\"24px\">\n",
-       "    <g>\n",
-       "        <path d=\"M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z\"/>\n",
-       "    </g>\n",
-       "</svg>\n",
-       "      </button>\n",
-       "\n",
-       "<style>\n",
-       "  .colab-df-quickchart {\n",
-       "      --bg-color: #E8F0FE;\n",
-       "      --fill-color: #1967D2;\n",
-       "      --hover-bg-color: #E2EBFA;\n",
-       "      --hover-fill-color: #174EA6;\n",
-       "      --disabled-fill-color: #AAA;\n",
-       "      --disabled-bg-color: #DDD;\n",
-       "  }\n",
-       "\n",
-       "  [theme=dark] .colab-df-quickchart {\n",
-       "      --bg-color: #3B4455;\n",
-       "      --fill-color: #D2E3FC;\n",
-       "      --hover-bg-color: #434B5C;\n",
-       "      --hover-fill-color: #FFFFFF;\n",
-       "      --disabled-bg-color: #3B4455;\n",
-       "      --disabled-fill-color: #666;\n",
-       "  }\n",
-       "\n",
-       "  .colab-df-quickchart {\n",
-       "    background-color: var(--bg-color);\n",
-       "    border: none;\n",
-       "    border-radius: 50%;\n",
-       "    cursor: pointer;\n",
-       "    display: none;\n",
-       "    fill: var(--fill-color);\n",
-       "    height: 32px;\n",
-       "    padding: 0;\n",
-       "    width: 32px;\n",
-       "  }\n",
-       "\n",
-       "  .colab-df-quickchart:hover {\n",
-       "    background-color: var(--hover-bg-color);\n",
-       "    box-shadow: 0 1px 2px rgba(60, 64, 67, 0.3), 0 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-       "    fill: var(--button-hover-fill-color);\n",
-       "  }\n",
-       "\n",
-       "  .colab-df-quickchart-complete:disabled,\n",
-       "  .colab-df-quickchart-complete:disabled:hover {\n",
-       "    background-color: var(--disabled-bg-color);\n",
-       "    fill: var(--disabled-fill-color);\n",
-       "    box-shadow: none;\n",
-       "  }\n",
-       "\n",
-       "  .colab-df-spinner {\n",
-       "    border: 2px solid var(--fill-color);\n",
-       "    border-color: transparent;\n",
-       "    border-bottom-color: var(--fill-color);\n",
-       "    animation:\n",
-       "      spin 1s steps(1) infinite;\n",
-       "  }\n",
-       "\n",
-       "  @keyframes spin {\n",
-       "    0% {\n",
-       "      border-color: transparent;\n",
-       "      border-bottom-color: var(--fill-color);\n",
-       "      border-left-color: var(--fill-color);\n",
-       "    }\n",
-       "    20% {\n",
-       "      border-color: transparent;\n",
-       "      border-left-color: var(--fill-color);\n",
-       "      border-top-color: var(--fill-color);\n",
-       "    }\n",
-       "    30% {\n",
-       "      border-color: transparent;\n",
-       "      border-left-color: var(--fill-color);\n",
-       "      border-top-color: var(--fill-color);\n",
-       "      border-right-color: var(--fill-color);\n",
-       "    }\n",
-       "    40% {\n",
-       "      border-color: transparent;\n",
-       "      border-right-color: var(--fill-color);\n",
-       "      border-top-color: var(--fill-color);\n",
-       "    }\n",
-       "    60% {\n",
-       "      border-color: transparent;\n",
-       "      border-right-color: var(--fill-color);\n",
-       "    }\n",
-       "    80% {\n",
-       "      border-color: transparent;\n",
-       "      border-right-color: var(--fill-color);\n",
-       "      border-bottom-color: var(--fill-color);\n",
-       "    }\n",
-       "    90% {\n",
-       "      border-color: transparent;\n",
-       "      border-bottom-color: var(--fill-color);\n",
-       "    }\n",
-       "  }\n",
-       "</style>\n",
-       "\n",
-       "      <script>\n",
-       "        async function quickchart(key) {\n",
-       "          const quickchartButtonEl =\n",
-       "            document.querySelector('#' + key + ' button');\n",
-       "          quickchartButtonEl.disabled = true;  // To prevent multiple clicks.\n",
-       "          quickchartButtonEl.classList.add('colab-df-spinner');\n",
-       "          try {\n",
-       "            const charts = await google.colab.kernel.invokeFunction(\n",
-       "                'suggestCharts', [key], {});\n",
-       "          } catch (error) {\n",
-       "            console.error('Error during call to suggestCharts:', error);\n",
-       "          }\n",
-       "          quickchartButtonEl.classList.remove('colab-df-spinner');\n",
-       "          quickchartButtonEl.classList.add('colab-df-quickchart-complete');\n",
-       "        }\n",
-       "        (() => {\n",
-       "          let quickchartButtonEl =\n",
-       "            document.querySelector('#df-846d0093-caf5-46ab-8a57-4a3a141ca666 button');\n",
-       "          quickchartButtonEl.style.display =\n",
-       "            google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-       "        })();\n",
-       "      </script>\n",
-       "    </div>\n",
-       "\n",
-       "    </div>\n",
-       "  </div>\n"
-      ],
-      "text/plain": [
-       "   series_id  time_idx         x         y  category  future_known_feature  \\\n",
-       "0          0         0 -0.030643  0.148280         0              1.000000   \n",
-       "1          0         1  0.148280  0.433029         0              0.995004   \n",
-       "2          0         2  0.433029  0.742511         0              0.980067   \n",
-       "3          0         3  0.742511  0.729270         0              0.955336   \n",
-       "4          0         4  0.729270  0.628604         0              0.921061   \n",
-       "\n",
-       "   static_feature  static_feature_cat  \n",
-       "0        0.039213                   0  \n",
-       "1        0.039213                   0  \n",
-       "2        0.039213                   0  \n",
-       "3        0.039213                   0  \n",
-       "4        0.039213                   0  "
+       "</div>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "num_series = 100  # Number of individual time series to generate\n",
-    "seq_length = 50  # Length of each time series\n",
-    "data_df = load_toydata(num_series, seq_length)\n",
-    "data_df.head()"
-   ]
+   "execution_count": 19
   },
   {
    "cell_type": "markdown",
@@ -455,35 +247,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
    "metadata": {
-    "id": "u8OPR0HntXqR"
+    "id": "u8OPR0HntXqR",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:12.684124367Z",
+     "start_time": "2026-08-05T07:39:12.633047360Z"
+    }
    },
-   "outputs": [],
    "source": [
     "from pytorch_forecasting.data.timeseries import TimeSeries"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 20
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "id": "6a_oy4VjtrHQ",
-    "outputId": "54678fb8-864e-4f32-eeb9-83697946a3e5"
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/content/pytorch-forecasting/pytorch_forecasting/data/timeseries/_timeseries_v2.py:105: UserWarning: TimeSeries is part of an experimental rework of the pytorch-forecasting data layer, scheduled for release with v2.0.0. The API is not stable and may change without prior warning. For beta testing, but not for stable production use. Feedback and suggestions are very welcome in pytorch-forecasting issue 1736, https://github.com/sktime/pytorch-forecasting/issues/1736\n",
-      "  warn(\n"
-     ]
+    "outputId": "54678fb8-864e-4f32-eeb9-83697946a3e5",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:12.788074701Z",
+     "start_time": "2026-08-05T07:39:12.699495600Z"
     }
-   ],
+   },
    "source": [
     "# create `TimeSeries` dataset that returns the raw data in terms of tensors\n",
     "dataset = TimeSeries(\n",
@@ -497,7 +286,18 @@
     "    unknown=[\"x\", \"category\"],\n",
     "    static=[\"static_feature\", \"static_feature_cat\"],\n",
     ")"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/aryan/pytorch-forecasting/pytorch_forecasting/data/timeseries/_timeseries_v2.py:104: UserWarning: TimeSeries is part of an experimental rework of the pytorch-forecasting data layer, scheduled for release with v2.0.0. The API is not stable and may change without prior warning. For beta testing, but not for stable production use. Feedback and suggestions are very welcome in pytorch-forecasting issue 1736, https://github.com/sktime/pytorch-forecasting/issues/1736\n",
+      "  warn(\n"
+     ]
+    }
+   ],
+   "execution_count": 21
   },
   {
    "cell_type": "markdown",
@@ -510,11 +310,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
    "metadata": {
-    "id": "MKPXPUcC5dTY"
+    "id": "MKPXPUcC5dTY",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:12.853298832Z",
+     "start_time": "2026-08-05T07:39:12.791768064Z"
+    }
    },
-   "outputs": [],
    "source": [
     "from sklearn.preprocessing import StandardScaler\n",
     "from pytorch_forecasting.data.encoders import (\n",
@@ -522,7 +324,9 @@
     "    TorchNormalizer,\n",
     ")\n",
     "from pytorch_forecasting.metrics import MAE, SMAPE"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 22
   },
   {
    "cell_type": "markdown",
@@ -545,11 +349,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
    "metadata": {
-    "id": "YGMShzfyttp_"
+    "id": "YGMShzfyttp_",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:12.901543111Z",
+     "start_time": "2026-08-05T07:39:12.854927319Z"
+    }
    },
-   "outputs": [],
    "source": [
     "datamodule_cfg = dict(\n",
     "    max_encoder_length=30,\n",
@@ -566,7 +372,9 @@
     "    },\n",
     "    target_normalizer=TorchNormalizer(),\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 23
   },
   {
    "cell_type": "markdown",
@@ -579,11 +387,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
    "metadata": {
-    "id": "q6Thm13ct7OV"
+    "id": "q6Thm13ct7OV",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:12.951208037Z",
+     "start_time": "2026-08-05T07:39:12.903126153Z"
+    }
    },
-   "outputs": [],
    "source": [
     "model_cfg = dict(\n",
     "    loss=MAE(),\n",
@@ -597,15 +407,19 @@
     "    attention_head_size=4,\n",
     "    dropout=0.1,\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 24
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
    "metadata": {
-    "id": "Stfuc_xCuON6"
+    "id": "Stfuc_xCuON6",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:13.000271484Z",
+     "start_time": "2026-08-05T07:39:12.952872181Z"
+    }
    },
-   "outputs": [],
    "source": [
     "trainer_cfg = dict(\n",
     "    max_epochs=5,\n",
@@ -614,20 +428,26 @@
     "    enable_progress_bar=True,\n",
     "    log_every_n_steps=10,\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 25
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
    "metadata": {
-    "id": "XS_ND8UAubdN"
+    "id": "XS_ND8UAubdN",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:13.048470458Z",
+     "start_time": "2026-08-05T07:39:13.002055172Z"
+    }
    },
-   "outputs": [],
    "source": [
     "from pytorch_forecasting.models.temporal_fusion_transformer._tft_pkg_v2 import (\n",
     "    TFT_pkg_v2,\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 26
   },
   {
    "cell_type": "markdown",
@@ -642,14 +462,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "id": "aOxng4Rguwj2",
-    "outputId": "2c50fcad-f990-4aae-f0bb-5dbdd6a87377"
+    "outputId": "2c50fcad-f990-4aae-f0bb-5dbdd6a87377",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:13.097978580Z",
+     "start_time": "2026-08-05T07:39:13.050435697Z"
+    }
    },
+   "source": [
+    "model_pkg = TFT_pkg_v2(\n",
+    "    model_cfg=model_cfg,\n",
+    "    trainer_cfg=trainer_cfg,\n",
+    "    datamodule_cfg=datamodule_cfg,\n",
+    ")"
+   ],
    "outputs": [
     {
      "name": "stdout",
@@ -659,17 +489,10 @@
      ]
     }
    ],
-   "source": [
-    "model_pkg = TFT_pkg_v2(\n",
-    "    model_cfg=model_cfg,\n",
-    "    trainer_cfg=trainer_cfg,\n",
-    "    datamodule_cfg=datamodule_cfg,\n",
-    ")"
-   ]
+   "execution_count": 27
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -755,157 +578,61 @@
      ]
     },
     "id": "c27Qj4QAvFwx",
-    "outputId": "21bbd594-d92e-498b-bd02-71829295c483"
+    "outputId": "21bbd594-d92e-498b-bd02-71829295c483",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:18.275463147Z",
+     "start_time": "2026-08-05T07:39:13.107591464Z"
+    }
    },
+   "source": [
+    "model_pkg.fit(dataset)  # You can also pass in a DataModule here"
+   ],
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/content/pytorch-forecasting/pytorch_forecasting/data/data_module.py:129: UserWarning: EncoderDecoderTimeSeriesDataModule is part of an experimental rework of the pytorch-forecasting data layer, scheduled for release with v2.0.0. The API is not stable and may change without prior warning. For beta testing, but not for stable production use. Feedback and suggestions are very welcome in pytorch-forecasting issue 1736, https://github.com/sktime/pytorch-forecasting/issues/1736\n",
+      "/home/aryan/pytorch-forecasting/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py:157: UserWarning: EncoderDecoderTimeSeriesDataModule is part of an experimental rework of the pytorch-forecasting data layer, scheduled for release with v2.0.0. The API is not stable and may change without prior warning. For beta testing, but not for stable production use. Feedback and suggestions are very welcome in pytorch-forecasting issue 1736, https://github.com/sktime/pytorch-forecasting/issues/1736\n",
       "  warn(\n",
-      "/content/pytorch-forecasting/pytorch_forecasting/models/base/_base_model_v2.py:64: UserWarning: The Model 'TFT' is part of an experimental reworkof the pytorch-forecasting model layer, scheduled for release with v2.0.0. The API is not stable and may change without prior warning. This class is intended for beta testing and as a basic skeleton, but not for stable production use. Feedback and suggestions are very welcome in pytorch-forecasting issue 1736, https://github.com/sktime/pytorch-forecasting/issues/1736\n",
+      "/home/aryan/pytorch-forecasting/pytorch_forecasting/models/base/_base_model_v2.py:85: UserWarning: The Model 'TFT' is part of an experimental reworkof the pytorch-forecasting model layer, scheduled for release with v2.0.0. The API is not stable and may change without prior warning. This class is intended for beta testing and as a basic skeleton, but not for stable production use. Feedback and suggestions are very welcome in pytorch-forecasting issue 1736, https://github.com/sktime/pytorch-forecasting/issues/1736\n",
       "  warn(\n",
-      "INFO: GPU available: True (cuda), used: True\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:GPU available: True (cuda), used: True\n",
-      "INFO: TPU available: False, using: 0 TPU cores\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:TPU available: False, using: 0 TPU cores\n",
-      "INFO: LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "INFO:lightning.pytorch.accelerators.cuda:LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "INFO: \n",
-      "  | Name                  | Type               | Params | Mode \n",
-      "---------------------------------------------------------------------\n",
-      "0 | loss                  | MAE                | 0      | train\n",
-      "1 | encoder_var_selection | Sequential         | 709    | train\n",
-      "2 | decoder_var_selection | Sequential         | 193    | train\n",
-      "3 | static_context_linear | Linear             | 192    | train\n",
-      "4 | lstm_encoder          | LSTM               | 51.5 K | train\n",
-      "5 | lstm_decoder          | LSTM               | 50.4 K | train\n",
-      "6 | self_attention        | MultiheadAttention | 16.6 K | train\n",
-      "7 | pre_output            | Linear             | 4.2 K  | train\n",
-      "8 | output_layer          | Linear             | 65     | train\n",
-      "---------------------------------------------------------------------\n",
+      "GPU available: True (cuda), used: True\n",
+      "TPU available: False, using: 0 TPU cores\n",
+      "/home/aryan/pytorch-forecasting/.venv/lib/python3.12/site-packages/lightning/pytorch/callbacks/model_checkpoint.py:881: Checkpoint directory /home/aryan/pytorch-forecasting/docs/source/tutorials/checkpoints exists and is not empty.\n",
+      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "\n",
+      "  | Name                  | Type               | Params | Mode  | FLOPs\n",
+      "-----------------------------------------------------------------------------\n",
+      "0 | loss                  | MAE                | 0      | train | 0    \n",
+      "1 | logging_metrics       | ModuleList         | 0      | train | 0    \n",
+      "2 | encoder_var_selection | Sequential         | 709    | train | 0    \n",
+      "3 | decoder_var_selection | Sequential         | 193    | train | 0    \n",
+      "4 | static_context_linear | Linear             | 192    | train | 0    \n",
+      "5 | lstm_encoder          | LSTM               | 51.5 K | train | 0    \n",
+      "6 | lstm_decoder          | LSTM               | 50.4 K | train | 0    \n",
+      "7 | self_attention        | MultiheadAttention | 16.6 K | train | 0    \n",
+      "8 | pre_output            | Linear             | 4.2 K  | train | 0    \n",
+      "9 | output_layer          | Linear             | 65     | train | 0    \n",
+      "-----------------------------------------------------------------------------\n",
       "123 K     Trainable params\n",
       "0         Non-trainable params\n",
       "123 K     Total params\n",
       "0.495     Total estimated model params size (MB)\n",
-      "18        Modules in train mode\n",
+      "21        Modules in train mode\n",
       "0         Modules in eval mode\n",
-      "INFO:lightning.pytorch.callbacks.model_summary:\n",
-      "  | Name                  | Type               | Params | Mode \n",
-      "---------------------------------------------------------------------\n",
-      "0 | loss                  | MAE                | 0      | train\n",
-      "1 | encoder_var_selection | Sequential         | 709    | train\n",
-      "2 | decoder_var_selection | Sequential         | 193    | train\n",
-      "3 | static_context_linear | Linear             | 192    | train\n",
-      "4 | lstm_encoder          | LSTM               | 51.5 K | train\n",
-      "5 | lstm_decoder          | LSTM               | 50.4 K | train\n",
-      "6 | self_attention        | MultiheadAttention | 16.6 K | train\n",
-      "7 | pre_output            | Linear             | 4.2 K  | train\n",
-      "8 | output_layer          | Linear             | 65     | train\n",
-      "---------------------------------------------------------------------\n",
-      "123 K     Trainable params\n",
-      "0         Non-trainable params\n",
-      "123 K     Total params\n",
-      "0.495     Total estimated model params size (MB)\n",
-      "18        Modules in train mode\n",
-      "0         Modules in eval mode\n"
+      "0         Total Flops\n"
      ]
     },
     {
      "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4ecdea6764d145118ab53e59451d2b0c",
-       "version_major": 2,
-       "version_minor": 0
-      },
       "text/plain": [
        "Sanity Checking: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
+      ],
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c52bb8ff12db4df3a05cf1da7b5470f7",
        "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Training: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "572629c64cfd46a983f1a8c6483a2cf1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "955c5e9c139148a1a352d17202fe097f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8d0747756fd2434399ae8d233a82d607",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "78f2d725dcb34deca5407c277c384d8d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3ab523d60fd249a7bcece32280872abd",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
+       "version_minor": 0,
+       "model_id": "f86280f6fc8c4a2c8ab4e3856c9aee4c"
+      }
      },
      "metadata": {},
      "output_type": "display_data"
@@ -914,31 +641,121 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO: `Trainer.fit` stopped: `max_epochs=5` reached.\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:`Trainer.fit` stopped: `max_epochs=5` reached.\n"
+      "/home/aryan/pytorch-forecasting/.venv/lib/python3.12/site-packages/lightning/pytorch/utilities/_pytree.py:21: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.\n",
+      "/home/aryan/pytorch-forecasting/.venv/lib/python3.12/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:434: The 'val_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=15` in the `DataLoader` to improve performance.\n",
+      "/home/aryan/pytorch-forecasting/.venv/lib/python3.12/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:434: The 'train_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=15` in the `DataLoader` to improve performance.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Training: |          | 0/? [00:00<?, ?it/s]"
+      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "eea42722ec684edf9f2fdb359fbb6c24"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Validation: |          | 0/? [00:00<?, ?it/s]"
+      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "03c7facffd38411f92086cf4cc60dcbd"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Validation: |          | 0/? [00:00<?, ?it/s]"
+      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "796ec3fc2be14366adc477ac2db83d2e"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Validation: |          | 0/? [00:00<?, ?it/s]"
+      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "9cc0eee3fcfc413b9c3dacf5c6dcf9ed"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Validation: |          | 0/? [00:00<?, ?it/s]"
+      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "0d61a8a016a44aab805805a4ad2b73ac"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Validation: |          | 0/? [00:00<?, ?it/s]"
+      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "e9849197023348ae84b6f876254f3d61"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "`Trainer.fit` stopped: `max_epochs=5` reached.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Artifacts saved in: /content/pytorch-forecasting/checkpoints\n"
+      "Artifacts saved in: /home/aryan/pytorch-forecasting/docs/source/tutorials/checkpoints\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "PosixPath('/content/pytorch-forecasting/checkpoints/best-epoch=3-step=168.ckpt')"
+       "PosixPath('/home/aryan/pytorch-forecasting/docs/source/tutorials/checkpoints/best-epoch=4-step=210-v3.ckpt')"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "model_pkg.fit(dataset)  # You can also pass in a DataModule here"
-   ]
+   "execution_count": 28
   },
   {
    "cell_type": "markdown",
@@ -955,7 +772,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -975,73 +791,87 @@
      ]
     },
     "id": "vTt5w73CvNuc",
-    "outputId": "24089add-49b9-410d-d0f3-50cd7426b35d"
+    "outputId": "24089add-49b9-410d-d0f3-50cd7426b35d",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:19.226801186Z",
+     "start_time": "2026-08-05T07:39:18.279125422Z"
+    }
    },
+   "source": [
+    "preds = model_pkg.predict(dataset, return_info=[\"index\", \"x\", \"y\"])\n",
+    "# You can also pass in a DataModule or Dataloader here"
+   ],
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/content/pytorch-forecasting/pytorch_forecasting/data/data_module.py:129: UserWarning: EncoderDecoderTimeSeriesDataModule is part of an experimental rework of the pytorch-forecasting data layer, scheduled for release with v2.0.0. The API is not stable and may change without prior warning. For beta testing, but not for stable production use. Feedback and suggestions are very welcome in pytorch-forecasting issue 1736, https://github.com/sktime/pytorch-forecasting/issues/1736\n",
+      "/home/aryan/pytorch-forecasting/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py:157: UserWarning: EncoderDecoderTimeSeriesDataModule is part of an experimental rework of the pytorch-forecasting data layer, scheduled for release with v2.0.0. The API is not stable and may change without prior warning. For beta testing, but not for stable production use. Feedback and suggestions are very welcome in pytorch-forecasting issue 1736, https://github.com/sktime/pytorch-forecasting/issues/1736\n",
       "  warn(\n",
-      "INFO: 💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-      "INFO: GPU available: True (cuda), used: True\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:GPU available: True (cuda), used: True\n",
-      "INFO: TPU available: False, using: 0 TPU cores\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:TPU available: False, using: 0 TPU cores\n",
-      "INFO: LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "INFO:lightning.pytorch.accelerators.cuda:LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n"
+      "💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
+      "GPU available: True (cuda), used: True\n",
+      "TPU available: False, using: 0 TPU cores\n",
+      "LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
+      "/home/aryan/pytorch-forecasting/.venv/lib/python3.12/site-packages/lightning/pytorch/utilities/_pytree.py:21: `isinstance(treespec, LeafSpec)` is deprecated, use `isinstance(treespec, TreeSpec) and treespec.is_leaf()` instead.\n",
+      "/home/aryan/pytorch-forecasting/.venv/lib/python3.12/site-packages/lightning/pytorch/trainer/connectors/data_connector.py:434: The 'predict_dataloader' does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` to `num_workers=15` in the `DataLoader` to improve performance.\n"
      ]
     },
     {
      "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c232241e3ca24eddb2dae0f9ceb7e114",
-       "version_major": 2,
-       "version_minor": 0
-      },
       "text/plain": [
        "Predicting: |          | 0/? [00:00<?, ?it/s]"
-      ]
+      ],
+      "application/vnd.jupyter.widget-view+json": {
+       "version_major": 2,
+       "version_minor": 0,
+       "model_id": "5cf7284a868a48379270f2b689b0a689"
+      }
      },
      "metadata": {},
      "output_type": "display_data"
     }
    ],
-   "source": [
-    "preds = model_pkg.predict(dataset, return_info=[\"index\", \"x\", \"y\"])\n",
-    "# You can also pass in a DataModule or Dataloader here"
-   ]
+   "execution_count": 29
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "id": "KANOUlepv0ty",
-    "outputId": "17ce66d0-5ba9-4a09-b5fc-9ecebb8bd470"
+    "outputId": "17ce66d0-5ba9-4a09-b5fc-9ecebb8bd470",
+    "ExecuteTime": {
+     "end_time": "2026-08-05T07:39:19.304036580Z",
+     "start_time": "2026-08-05T07:39:19.238060822Z"
+    }
    },
+   "source": [
+    "print(\"First Predicted Value:\")\n",
+    "print(\"Prediction:\", preds[\"prediction\"][0].item())\n",
+    "print(\"Actual:\", preds[\"y\"][0].item())"
+   ],
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "First Predicted Value:\n",
-      "Index: -0.0801810473203659\n",
-      "Prediction: 0.11192154139280319\n",
-      "Actual: -0.1557866632938385\n"
+      "First Predicted Value:\n"
+     ]
+    },
+    {
+     "ename": "RuntimeError",
+     "evalue": "a Tensor with 1900 elements cannot be converted to Scalar",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[31m---------------------------------------------------------------------------\u001B[39m",
+      "\u001B[31mRuntimeError\u001B[39m                              Traceback (most recent call last)",
+      "\u001B[36mCell\u001B[39m\u001B[36m \u001B[39m\u001B[32mIn[30]\u001B[39m\u001B[32m, line 2\u001B[39m\n\u001B[32m      1\u001B[39m \u001B[38;5;28mprint\u001B[39m(\u001B[33m\"\u001B[39m\u001B[33mFirst Predicted Value:\u001B[39m\u001B[33m\"\u001B[39m)\n\u001B[32m----> \u001B[39m\u001B[32m2\u001B[39m \u001B[38;5;28mprint\u001B[39m(\u001B[33m\"\u001B[39m\u001B[33mPrediction:\u001B[39m\u001B[33m\"\u001B[39m, \u001B[43mpreds\u001B[49m\u001B[43m[\u001B[49m\u001B[33;43m\"\u001B[39;49m\u001B[33;43mprediction\u001B[39;49m\u001B[33;43m\"\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m[\u001B[49m\u001B[32;43m0\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m.\u001B[49m\u001B[43mitem\u001B[49m\u001B[43m(\u001B[49m\u001B[43m)\u001B[49m)\n\u001B[32m      3\u001B[39m \u001B[38;5;28mprint\u001B[39m(\u001B[33m\"\u001B[39m\u001B[33mActual:\u001B[39m\u001B[33m\"\u001B[39m, preds[\u001B[33m\"\u001B[39m\u001B[33my\u001B[39m\u001B[33m\"\u001B[39m][\u001B[32m0\u001B[39m].item())\n",
+      "\u001B[31mRuntimeError\u001B[39m: a Tensor with 1900 elements cannot be converted to Scalar"
      ]
     }
    ],
-   "source": [
-    "print(\"First Predicted Value:\")\n",
-    "print(\"Index:\", preds[\"index\"][0].item())\n",
-    "print(\"Prediction:\", preds[\"prediction\"][0].item())\n",
-    "print(\"Actual:\", preds[\"y\"][0].item())"
-   ]
+   "execution_count": 30
   },
   {
    "cell_type": "markdown",
@@ -1122,18 +952,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
    "metadata": {
     "id": "JPD3y3qny5Dx"
    },
-   "outputs": [],
    "source": [
     "from pytorch_forecasting.data.timeseries import TimeSeries"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1141,16 +970,6 @@
     "id": "AxxPHK6AKSD2",
     "outputId": "7d8eea0b-6bfc-447c-b40b-f3c7e8bae4a4"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/content/pytorch-forecasting/pytorch_forecasting/data/timeseries/_timeseries_v2.py:105: UserWarning: TimeSeries is part of an experimental rework of the pytorch-forecasting data layer, scheduled for release with v2.0.0. The API is not stable and may change without prior warning. For beta testing, but not for stable production use. Feedback and suggestions are very welcome in pytorch-forecasting issue 1736, https://github.com/sktime/pytorch-forecasting/issues/1736\n",
-      "  warn(\n"
-     ]
-    }
-   ],
    "source": [
     "# create `TimeSeries` dataset that returns the raw data in terms of tensors\n",
     "dataset = TimeSeries(\n",
@@ -1164,7 +983,9 @@
     "    unknown=[\"x\", \"category\"],\n",
     "    static=[\"static_feature\", \"static_feature_cat\"],\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -1193,11 +1014,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "id": "DUWB4LrGyxrL"
    },
-   "outputs": [],
    "source": [
     "from sklearn.preprocessing import StandardScaler\n",
     "from pytorch_forecasting.data.data_module import EncoderDecoderTimeSeriesDataModule\n",
@@ -1205,11 +1024,12 @@
     "    NaNLabelEncoder,\n",
     "    TorchNormalizer,\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1217,16 +1037,6 @@
     "id": "5U5Lr_ZFKX0s",
     "outputId": "248cf4c4-b7e4-4210-c782-e142ced29189"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/content/pytorch-forecasting/pytorch_forecasting/data/data_module.py:129: UserWarning: EncoderDecoderTimeSeriesDataModule is part of an experimental rework of the pytorch-forecasting data layer, scheduled for release with v2.0.0. The API is not stable and may change without prior warning. For beta testing, but not for stable production use. Feedback and suggestions are very welcome in pytorch-forecasting issue 1736, https://github.com/sktime/pytorch-forecasting/issues/1736\n",
-      "  warn(\n"
-     ]
-    }
-   ],
    "source": [
     "# create the `data_module` that handles the dataloaders and preprocessing\n",
     "data_module = EncoderDecoderTimeSeriesDataModule(\n",
@@ -1245,7 +1055,9 @@
     "    },\n",
     "    target_normalizer=TorchNormalizer(),\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -1291,19 +1103,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "id": "xOsEucZnzCkN"
    },
-   "outputs": [],
    "source": [
     "from pytorch_forecasting.metrics import MAE, SMAPE\n",
     "from pytorch_forecasting.models.temporal_fusion_transformer._tft_v2 import TFT"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1311,16 +1122,6 @@
     "id": "9qbjnTxnyh4H",
     "outputId": "a486be25-1c41-4ef2-f2ce-8e5da9704594"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/content/pytorch-forecasting/pytorch_forecasting/models/base/_base_model_v2.py:64: UserWarning: The Model 'TFT' is part of an experimental reworkof the pytorch-forecasting model layer, scheduled for release with v2.0.0. The API is not stable and may change without prior warning. This class is intended for beta testing and as a basic skeleton, but not for stable production use. Feedback and suggestions are very welcome in pytorch-forecasting issue 1736, https://github.com/sktime/pytorch-forecasting/issues/1736\n",
-      "  warn(\n"
-     ]
-    }
-   ],
    "source": [
     "# Initialise the Model\n",
     "model = TFT(\n",
@@ -1337,7 +1138,9 @@
     "    metadata=data_module.metadata,  # pass the metadata from the datamodule to the model\n",
     "    # to initialise important params like `encoder_cont` etc\n",
     ")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -1360,18 +1163,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "id": "RTSmUu9RytS8"
    },
-   "outputs": [],
    "source": [
     "from lightning.pytorch import Trainer"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1459,174 +1261,6 @@
     "id": "aB_ayE_eykXp",
     "outputId": "bdcab291-96b3-4dd6-e997-09e08c95653f"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO: 💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-      "INFO: GPU available: True (cuda), used: True\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:GPU available: True (cuda), used: True\n",
-      "INFO: TPU available: False, using: 0 TPU cores\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:TPU available: False, using: 0 TPU cores\n",
-      "INFO: LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "INFO:lightning.pytorch.accelerators.cuda:LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "INFO: \n",
-      "  | Name                  | Type               | Params | Mode \n",
-      "---------------------------------------------------------------------\n",
-      "0 | loss                  | MAE                | 0      | train\n",
-      "1 | encoder_var_selection | Sequential         | 709    | train\n",
-      "2 | decoder_var_selection | Sequential         | 193    | train\n",
-      "3 | static_context_linear | Linear             | 192    | train\n",
-      "4 | lstm_encoder          | LSTM               | 51.5 K | train\n",
-      "5 | lstm_decoder          | LSTM               | 50.4 K | train\n",
-      "6 | self_attention        | MultiheadAttention | 16.6 K | train\n",
-      "7 | pre_output            | Linear             | 4.2 K  | train\n",
-      "8 | output_layer          | Linear             | 65     | train\n",
-      "---------------------------------------------------------------------\n",
-      "123 K     Trainable params\n",
-      "0         Non-trainable params\n",
-      "123 K     Total params\n",
-      "0.495     Total estimated model params size (MB)\n",
-      "18        Modules in train mode\n",
-      "0         Modules in eval mode\n",
-      "INFO:lightning.pytorch.callbacks.model_summary:\n",
-      "  | Name                  | Type               | Params | Mode \n",
-      "---------------------------------------------------------------------\n",
-      "0 | loss                  | MAE                | 0      | train\n",
-      "1 | encoder_var_selection | Sequential         | 709    | train\n",
-      "2 | decoder_var_selection | Sequential         | 193    | train\n",
-      "3 | static_context_linear | Linear             | 192    | train\n",
-      "4 | lstm_encoder          | LSTM               | 51.5 K | train\n",
-      "5 | lstm_decoder          | LSTM               | 50.4 K | train\n",
-      "6 | self_attention        | MultiheadAttention | 16.6 K | train\n",
-      "7 | pre_output            | Linear             | 4.2 K  | train\n",
-      "8 | output_layer          | Linear             | 65     | train\n",
-      "---------------------------------------------------------------------\n",
-      "123 K     Trainable params\n",
-      "0         Non-trainable params\n",
-      "123 K     Total params\n",
-      "0.495     Total estimated model params size (MB)\n",
-      "18        Modules in train mode\n",
-      "0         Modules in eval mode\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Training model...\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a553dd138d714a18af6c0713e1b43897",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Sanity Checking: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "86d1a5f363394cc18785ac88a22d76d3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Training: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "87c0a054bd0a4cc38bdaa2ef39bb30ae",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9d5419fc33de4216807044da7fe61524",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a9e0349ab6494ec09a6f909e152f685d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "83af6fa1a89c44398eaa18bc89031fa8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "803a672f660842f6ab949ea62fc9e44e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Validation: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO: `Trainer.fit` stopped: `max_epochs=5` reached.\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:`Trainer.fit` stopped: `max_epochs=5` reached.\n"
-     ]
-    }
-   ],
    "source": [
     "# Train the model\n",
     "print(\"\\nTraining model...\")\n",
@@ -1639,7 +1273,9 @@
     ")\n",
     "\n",
     "trainer.fit(model, data_module)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
@@ -1656,17 +1292,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "data_module.setup(stage=\"test\")\n",
     "test_dataloader = data_module.test_dataloader()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -1688,43 +1323,14 @@
     "id": "_b8o8e2Tmzbd",
     "outputId": "e437cf69-2d5f-4c5a-cf6c-4d0dcf31f444"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO: 💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:💡 Tip: For seamless cloud uploads and versioning, try installing [litmodels](https://pypi.org/project/litmodels/) to enable LitModelCheckpoint, which syncs automatically with the Lightning model registry.\n",
-      "INFO: GPU available: True (cuda), used: True\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:GPU available: True (cuda), used: True\n",
-      "INFO: TPU available: False, using: 0 TPU cores\n",
-      "INFO:lightning.pytorch.utilities.rank_zero:TPU available: False, using: 0 TPU cores\n",
-      "INFO: LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n",
-      "INFO:lightning.pytorch.accelerators.cuda:LOCAL_RANK: 0 - CUDA_VISIBLE_DEVICES: [0]\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "37994d5bc49f4e70985436884f91c290",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Predicting: |          | 0/? [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
    "source": [
     "preds = model.predict(test_dataloader, return_info=[\"index\", \"x\", \"y\"])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -1732,24 +1338,13 @@
     "id": "-ndMvbe0pLha",
     "outputId": "266ef096-374b-45f8-8ea0-4d283c588443"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "First Predicted Value:\n",
-      "Index: 0.11104673147201538\n",
-      "Prediction: -0.001255139708518982\n",
-      "Actual: 0.07348770648241043\n"
-     ]
-    }
-   ],
    "source": [
     "print(\"First Predicted Value:\")\n",
-    "print(\"Index:\", preds[\"index\"][0].item())\n",
     "print(\"Prediction:\", preds[\"prediction\"][0].item())\n",
     "print(\"Actual:\", preds[\"y\"][0].item())"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {

--- a/pytorch_forecasting/callbacks/predict.py
+++ b/pytorch_forecasting/callbacks/predict.py
@@ -70,8 +70,8 @@ class PredictCallback(BasePredictionWriter):
 
         self.predictions.append(move_to_device(detach(processed_output), "cpu"))
 
-        # Only pay the detach+copy cost if x or decoder_lengths are actually requested
-        needs_x = any(k in ("x", "decoder_lengths") for k in self.return_info)
+        # Only pay the detach+copy cost for keys that are derived from x
+        needs_x = any(k in ("x", "index", "decoder_lengths") for k in self.return_info)
         x_cpu = move_to_device(detach(x), "cpu") if needs_x else None
 
         for key in self.return_info:
@@ -81,12 +81,40 @@ class PredictCallback(BasePredictionWriter):
                 y_cpu = move_to_device(detach(y[0]), "cpu")
                 self.info[key].append(y_cpu)
             elif key == "index":
-                index_cpu = move_to_device(detach(y[1]), "cpu")
-                self.info[key].append(index_cpu)
+                self.info[key].append(self._extract_index(x_cpu))
             elif key == "decoder_lengths":
                 self.info[key].append(x_cpu["decoder_lengths"])
             else:
                 warn(f"Unknown return_info key: {key}")
+
+    @staticmethod
+    def _extract_index(x: dict[str, torch.Tensor]) -> torch.Tensor:
+        """Build the per-sample index of the predictions in a batch.
+
+        Parameters
+        ----------
+        x : dict[str, torch.Tensor]
+            Model inputs of the batch, already detached and on cpu.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(batch_size, 2)``  whose columns are the group identifier
+             of the series and the first position predicted by the window.
+        """
+        time_key = next(
+            (k for k in ("decoder_time_idx", "future_time_idx") if k in x), None
+        )
+
+        groups = x["groups"]
+        if groups.ndim == 1:
+            groups = groups.unsqueeze(-1)
+
+        time_idx = x[time_key]
+        if time_idx.ndim == 1:
+            time_idx = time_idx.unsqueeze(-1)
+
+        return torch.cat([groups.long(), time_idx[:, :1].long()], dim=-1)
 
     def on_predict_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
         """Collate all batch results into final tensors."""

--- a/pytorch_forecasting/callbacks/predict.py
+++ b/pytorch_forecasting/callbacks/predict.py
@@ -102,19 +102,15 @@ class PredictCallback(BasePredictionWriter):
             Tensor of shape ``(batch_size, 2)``  whose columns are the group identifier
              of the series and the first position predicted by the window.
         """
-        time_key = next(
-            (k for k in ("decoder_time_idx", "future_time_idx") if k in x), None
-        )
-
         groups = x["groups"]
         if groups.ndim == 1:
             groups = groups.unsqueeze(-1)
 
-        time_idx = x[time_key]
-        if time_idx.ndim == 1:
-            time_idx = time_idx.unsqueeze(-1)
+        start_idx = x["prediction_start_idx"]
+        if start_idx.ndim == 1:
+            start_idx = start_idx.unsqueeze(-1)
 
-        return torch.cat([groups.long(), time_idx[:, :1].long()], dim=-1)
+        return torch.cat([groups.long(), start_idx[:, :1].long()], dim=-1)
 
     def on_predict_epoch_end(self, trainer: Trainer, pl_module: LightningModule):
         """Collate all batch results into final tensors."""

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -614,9 +614,9 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                 * ``groups`` : tensor of shape (1,)
                   Group identifier for the time series instance.
                 * ``encoder_time_idx`` : tensor of shape (enc_length,)
-                  Time indices for the encoder sequence.
+                  Positions within the series selected by the encoder window.
                 * ``decoder_time_idx`` : tensor of shape (pred_length,)
-                  Time indices for the decoder sequence.
+                  Positions within the series selected by the decoder window.
                 * ``target_past`` : torch.Tensor of shape (enc_length,)
                   Historical target values for the encoder sequence.
                 * ``target_scale`` : tensor of shape (1,)
@@ -645,6 +645,8 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             end_idx = start_idx + enc_length + pred_length
             encoder_indices = slice(start_idx, start_idx + enc_length)
             decoder_indices = slice(start_idx + enc_length, end_idx)
+
+            positions = torch.arange(data["length"])
 
             target_past = data["target"][encoder_indices]
 
@@ -753,8 +755,8 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                 "decoder_target_lengths": torch.tensor(pred_length),
                 "groups": data["group"],
                 "target_past": target_past,
-                "encoder_time_idx": torch.arange(enc_length),
-                "decoder_time_idx": torch.arange(enc_length, enc_length + pred_length),
+                "encoder_time_idx": positions[encoder_indices],
+                "decoder_time_idx": positions[decoder_indices],
                 "target_scale": target_scale,
                 "encoder_mask": encoder_mask,
                 "decoder_mask": decoder_mask,

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -614,9 +614,11 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                 * ``groups`` : tensor of shape (1,)
                   Group identifier for the time series instance.
                 * ``encoder_time_idx`` : tensor of shape (enc_length,)
-                  Positions within the series selected by the encoder window.
+                  Time indices for the encoder sequence.
                 * ``decoder_time_idx`` : tensor of shape (pred_length,)
-                  Positions within the series selected by the decoder window.
+                  Time indices for the decoder sequence.
+                * ``prediction_start_idx`` : tensor of shape (1,)
+                  First position within the series that the decoder window predicts.
                 * ``target_past`` : torch.Tensor of shape (enc_length,)
                   Historical target values for the encoder sequence.
                 * ``target_scale`` : tensor of shape (1,)
@@ -755,8 +757,9 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                 "decoder_target_lengths": torch.tensor(pred_length),
                 "groups": data["group"],
                 "target_past": target_past,
-                "encoder_time_idx": positions[encoder_indices],
-                "decoder_time_idx": positions[decoder_indices],
+                "encoder_time_idx": torch.arange(enc_length),
+                "decoder_time_idx": torch.arange(enc_length, enc_length + pred_length),
+                "prediction_start_idx": positions[decoder_indices][:1],
                 "target_scale": target_scale,
                 "encoder_mask": encoder_mask,
                 "decoder_mask": decoder_mask,
@@ -1086,6 +1089,9 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             "target_past": torch.stack([x["target_past"] for x, _ in batch]),
             "encoder_time_idx": torch.stack([x["encoder_time_idx"] for x, _ in batch]),
             "decoder_time_idx": torch.stack([x["decoder_time_idx"] for x, _ in batch]),
+            "prediction_start_idx": torch.stack(
+                [x["prediction_start_idx"] for x, _ in batch]
+            ),
             "encoder_mask": torch.stack([x["encoder_mask"] for x, _ in batch]),
             "decoder_mask": torch.stack([x["decoder_mask"] for x, _ in batch]),
         }

--- a/pytorch_forecasting/data/data_module/_tslib_data_module.py
+++ b/pytorch_forecasting/data/data_module/_tslib_data_module.py
@@ -97,9 +97,9 @@ class _TslibDataset(Dataset):
             * ``groups`` : torch.Tensor of shape (1,)
                 Group identifier for the time series instance.
             * ``history_time_idx`` : torch.Tensor of shape (context_length,)
-                Time indices for the encoder sequence.
+                Positions within the series selected by the history window.
             * ``future_time_idx`` : torch.Tensor of shape (prediction_length,)
-                Time indices for the decoder sequence.
+                Positions within the series selected by the future window.
             * ``history_target`` : torch.Tensor of shape (context_length,)
                 Historical target values for the encoder sequence.
             * ``future_target`` : torch.Tensor of shape (prediction_length,)
@@ -142,6 +142,8 @@ class _TslibDataset(Dataset):
         end_idx = start_idx + context_length + prediction_length
         history_indices = slice(start_idx, start_idx + context_length)
         future_indices = slice(start_idx + context_length, end_idx)
+
+        positions = torch.arange(processed_data["target"].shape[0])
 
         metadata = self.data_module.metadata
 
@@ -192,9 +194,6 @@ class _TslibDataset(Dataset):
         history_target = processed_data["target"][history_indices]
         future_target = processed_data["target"][future_indices]
 
-        # history_time_idx = processed_data["timestep"][history_indices]
-        # future_time_idx = processed_data["timestep"][future_indices]
-
         x = {
             "history_cont": history_cont,
             "history_cat": history_cat,
@@ -205,10 +204,8 @@ class _TslibDataset(Dataset):
             "history_mask": history_mask,
             "future_mask": future_mask,
             "groups": processed_data["group"],
-            "history_time_idx": torch.arange(context_length),
-            "future_time_idx": torch.arange(
-                context_length, context_length + prediction_length
-            ),
+            "history_time_idx": positions[history_indices],
+            "future_time_idx": positions[future_indices],
             "history_target": history_target,
             "future_target": future_target,
             "future_target_len": torch.tensor(prediction_length),

--- a/pytorch_forecasting/data/data_module/_tslib_data_module.py
+++ b/pytorch_forecasting/data/data_module/_tslib_data_module.py
@@ -97,9 +97,11 @@ class _TslibDataset(Dataset):
             * ``groups`` : torch.Tensor of shape (1,)
                 Group identifier for the time series instance.
             * ``history_time_idx`` : torch.Tensor of shape (context_length,)
-                Positions within the series selected by the history window.
+                Time indices for the encoder sequence.
             * ``future_time_idx`` : torch.Tensor of shape (prediction_length,)
-                Positions within the series selected by the future window.
+                Time indices for the decoder sequence.
+            * ``prediction_start_idx`` : torch.Tensor of shape (1,)
+                First position within the series that the future window predicts.
             * ``history_target`` : torch.Tensor of shape (context_length,)
                 Historical target values for the encoder sequence.
             * ``future_target`` : torch.Tensor of shape (prediction_length,)
@@ -204,8 +206,11 @@ class _TslibDataset(Dataset):
             "history_mask": history_mask,
             "future_mask": future_mask,
             "groups": processed_data["group"],
-            "history_time_idx": positions[history_indices],
-            "future_time_idx": positions[future_indices],
+            "history_time_idx": torch.arange(context_length),
+            "future_time_idx": torch.arange(
+                context_length, context_length + prediction_length
+            ),
+            "prediction_start_idx": positions[future_indices][:1],
             "history_target": history_target,
             "future_target": future_target,
             "future_target_len": torch.tensor(prediction_length),
@@ -851,6 +856,9 @@ class TslibDataModule(LightningDataModule):
             "groups": torch.stack([x["groups"] for x, _ in batch]),
             "history_time_idx": torch.stack([x["history_time_idx"] for x, _ in batch]),
             "future_time_idx": torch.stack([x["future_time_idx"] for x, _ in batch]),
+            "prediction_start_idx": torch.stack(
+                [x["prediction_start_idx"] for x, _ in batch]
+            ),
             "history_target": torch.stack([x["history_target"] for x, _ in batch]),
             "future_target": torch.stack([x["future_target"] for x, _ in batch]),
             "future_target_len": torch.stack(


### PR DESCRIPTION
Fixes #2367 

Adds a new `prediction_start_idx` to the `collate_fn` that is returned when `return_info` has `index`.