### PR TITLE
[ENH] in suite tests, add test for docstring examples

### DIFF
--- a/pytorch_forecasting/tests/test_all_estimators.py
+++ b/pytorch_forecasting/tests/test_all_estimators.py
@@ -366,11 +366,33 @@ class TestAllPtForecasters(EstimatorPackageConfig, EstimatorFixtureGenerator):
 
     object_type_filter = "forecaster_pytorch_v1"
 
+    def test_class_has_doctest_example(self, object_class):
+        """Check that the class has a docstring, with doctest example in it."""
+        docstring = object_class.__doc__
+
+        assert docstring is not None, f"{object_class.__name__} has no docstring"
+        msg = f"{object_class.__name__} docstring has no doctest example"
+        assert ">>>" in docstring, msg
+
     def test_doctest_examples(self, object_class):
         """Runs doctests for estimator class."""
         from skbase.utils.doctest_run import run_doctest
 
         run_doctest(object_class, name=f"class {object_class.__name__}")
+
+    def test_pkg_has_doctest_example(self, object_pkg):
+        """Check that the package has a docstring, with doctest example in it."""
+        docstring = object_pkg.__doc__
+
+        assert docstring is not None, f"{object_pkg.__name__} has no docstring"
+        msg = f"{object_pkg.__name__} docstring has no doctest example"
+        assert ">>>" in docstring, msg
+
+    def test_pkg_doctest_examples(self, object_pkg):
+        """Runs doctests for the estimator package class."""
+        from skbase.utils.doctest_run import run_doctest
+
+        run_doctest(object_pkg, name=f"class {object_pkg.__name__}")
 
     def test_integration(
         self,

--- a/pytorch_forecasting/tests/test_all_v2/test_all_estimators_v2.py
+++ b/pytorch_forecasting/tests/test_all_v2/test_all_estimators_v2.py
@@ -23,11 +23,33 @@ class TestAllPtForecastersV2(EstimatorPackageConfig, EstimatorFixtureGenerator):
 
     object_type_filter = "forecaster_pytorch_v2"
 
+    def test_class_has_doctest_example(self, object_class):
+        """Check that the class has a docstring, with doctest example in it."""
+        docstring = object_class.__doc__
+
+        assert docstring is not None, f"{object_class.__name__} has no docstring"
+        msg = f"{object_class.__name__} docstring has no doctest example"
+        assert ">>>" in docstring, msg
+
     def test_doctest_examples(self, object_class):
         """Runs doctests for estimator class."""
         from skbase.utils.doctest_run import run_doctest
 
         run_doctest(object_class, name=f"class {object_class.__name__}")
+
+    def test_pkg_has_doctest_example(self, object_pkg):
+        """Check that the package has a docstring, with doctest example in it."""
+        docstring = object_pkg.__doc__
+
+        assert docstring is not None, f"{object_pkg.__name__} has no docstring"
+        msg = f"{object_pkg.__name__} docstring has no doctest example"
+        assert ">>>" in docstring, msg
+
+    def test_pkg_doctest_examples(self, object_pkg):
+        """Runs doctests for the estimator package class."""
+        from skbase.utils.doctest_run import run_doctest
+
+        run_doctest(object_pkg, name=f"class {object_pkg.__name__}")
 
     def test_integration(
         self,


### PR DESCRIPTION
This PR adds, in the v1 and v2 suite tests:

* a test `test_class_has_doctest_examples` which checks that the model class has a docstring code example (doctest)
* a test `test_pkg_has_doctest_example` which does the same for the respective package class, i.e., that it has a docstring code example (doctest)
* a test `test_pkg_doctest_examples` which tests that this docstring code example, for the package class, runs without exceptions and has expected output

In particular, this PR also closes a gap in test coverage, which left the doctests in the package classes untested.