### PR TITLE
[MNT] ensure `check_tag` step gates the `pypi_release` workflow

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -34,6 +34,7 @@ jobs:
   build_wheels:
     name: Build wheels
     runs-on: ubuntu-latest
+    needs: [check_tag]
 
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
The `check_tag` step in the `pypi_release` workflow is supposed to prevent typos in version numbers, but currently does not act as a gate for the release.

This bug is fixed by adding the intended `needs` directive.