### PR TITLE
[DOC] Add DecoderMLP usage example

### DIFF
--- a/pytorch_forecasting/models/mlp/_decodermlp.py
+++ b/pytorch_forecasting/models/mlp/_decodermlp.py
@@ -27,6 +27,53 @@ class DecoderMLP(BaseModelWithCovariates):
     """MLP on the decoder.
 
     MLP that predicts output only based on information available in the decoder.
+
+    Examples
+    --------
+    Train on a small synthetic time series and make predictions:
+
+    >>> import pandas as pd
+    >>> import torch
+    >>> from lightning.pytorch import Trainer
+    >>> from pytorch_forecasting import DecoderMLP, TimeSeriesDataSet
+    >>> _ = torch.manual_seed(0)
+    >>> data = pd.DataFrame(
+    ...     {
+    ...         "time_idx": range(12),
+    ...         "series": ["A"] * 12,
+    ...         "target": [float(i) for i in range(12)],
+    ...     }
+    ... )
+    >>> dataset = TimeSeriesDataSet(
+    ...     data,
+    ...     time_idx="time_idx",
+    ...     target="target",
+    ...     group_ids=["series"],
+    ...     max_encoder_length=4,
+    ...     max_prediction_length=2,
+    ...     time_varying_known_reals=["time_idx"],
+    ...     time_varying_unknown_reals=["target"],
+    ... )
+    >>> dataloader = dataset.to_dataloader(train=True, batch_size=4, num_workers=0)
+    >>> model = DecoderMLP.from_dataset(
+    ...     dataset, hidden_size=8, n_hidden_layers=1, dropout=0.0
+    ... )
+    >>> trainer_kwargs = dict(
+    ...     accelerator="cpu",
+    ...     logger=False,
+    ...     enable_progress_bar=False,
+    ...     enable_model_summary=False,
+    ... )
+    >>> trainer = Trainer(fast_dev_run=True, **trainer_kwargs)
+    >>> trainer.fit(model, train_dataloaders=dataloader)
+    >>> predictions = model.predict(
+    ...     dataset,
+    ...     fast_dev_run=True,
+    ...     batch_size=4,
+    ...     trainer_kwargs=trainer_kwargs,
+    ... )
+    >>> predictions.shape
+    torch.Size([4, 2])
     """
 
     @classmethod

--- a/pytorch_forecasting/models/mlp/_decodermlp_pkg.py
+++ b/pytorch_forecasting/models/mlp/_decodermlp_pkg.py
@@ -4,7 +4,16 @@ from pytorch_forecasting.models.base._base_object import _BasePtForecaster
 
 
 class DecoderMLP_pkg(_BasePtForecaster):
-    """DecoderMLP package container."""
+    """DecoderMLP package container.
+
+    Examples
+    --------
+    Resolve the package container to the user-facing model class:
+
+    >>> from pytorch_forecasting.models.mlp import DecoderMLP_pkg
+    >>> DecoderMLP_pkg.get_cls().__name__
+    'DecoderMLP'
+    """
 
     _tags = {
         "info:name": "DecoderMLP",


### PR DESCRIPTION
#### Reference Issues/PRs

Partially addresses #2377.

This is intentionally limited to the v1 `DecoderMLP` model. #2378 covers DeepAR and NBeats.

#### What does this implement/fix?

This PR adds a focused, runnable usage example to the v1 `DecoderMLP` docstring. The example demonstrates:

- deterministic synthetic time-series data preparation;
- `TimeSeriesDataSet` construction;
- `DecoderMLP.from_dataset()`;
- one-batch CPU training with `fast_dev_run=True`;
- prediction with a stable output-shape check.

It also adds a minimal package-container linkage example, following the documentation structure used for the other v1 models.

The example does not download external data, require a GPU, or change model behavior.

#### What should a reviewer concentrate their feedback on?

- Whether the example is sufficiently concise while still showing the complete core workflow.
- Whether the package-container linkage example matches the intended v1 documentation pattern.

#### Did you add any tests for the change?

The examples are executable doctests. Local validation completed on Windows, Python 3.12, and CPU:

- direct doctests: 16 examples passed;
- `tests/test_models/test_mlp.py`: 7 passed;
- DecoderMLP estimator suite: 32 passed;
- applicable pre-commit hooks, Ruff, and Ruff formatting passed;
- full Sphinx HTML build passed with no DecoderMLP-specific warnings.

#### Any other comments?

The change is limited to two DecoderMLP documentation files. No model weights, datasets, generated files, or unrelated formatting changes are included.

Thank you for taking the time to review this contribution.

#### PR checklist

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [x] Added/modified tests (the usage examples are executable doctests).
- [x] Used pre-commit hooks to ensure that the changed files comply with the configured hooks.
