### PR TITLE
[MNT] harden the PyPI release workflow against tag-name injection

### DIFF
--- a/.github/workflows/pypi_release.yml
+++ b/.github/workflows/pypi_release.yml
@@ -4,6 +4,12 @@ on:
   release:
     types: [published]
 
+# Least privilege by default. This workflow builds the artifact that is published
+# to PyPI, so the token it carries is the most valuable one in the repository.
+# `upload_wheels` declares its own `id-token: write` for Trusted Publishing.
+permissions:
+  contents: read
+
 jobs:
   check_tag:
     name: Check tag
@@ -17,8 +23,14 @@ jobs:
           python-version: '3.11'
 
       - shell: bash
+        # The tag name is passed through `env` rather than expanded directly into
+        # the script. A `${{ ... }}` expansion is substituted as text before bash
+        # sees it, so a tag containing shell metacharacters would run as code; as
+        # an environment variable it is only ever data.
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${RELEASE_TAG}"
           GH_TAG_NAME="${TAG#v}"
           PY_VERSION=$(python - <<'PY'
           import pathlib, tomllib


### PR DESCRIPTION
**LLM generated content, by Claude (Anthropic)** — drafted with Claude Code and reviewed by me before opening. I independently ran and verified the `zizmor` and PyYAML checks reported below.

### Reference Issues/PRs

No open issue — found while auditing the workflows with [zizmor](https://docs.zizmor.sh/). Touches the same file as #2376.

### What does this implement/fix? Explain your changes.

**1. Tag-name injection in `check_tag`**

```yaml
run: |
  TAG="${{ github.event.release.tag_name }}"
```

A `${{ ... }}` expression is substituted as *text* into the script before bash parses it. A tag name containing shell metacharacters is therefore executed, not compared. Passing the value through `env` makes it an ordinary shell variable, which is only ever data:

```yaml
env:
  RELEASE_TAG: ${{ github.event.release.tag_name }}
run: |
  TAG="${RELEASE_TAG}"
```

What makes this worth fixing is where the job sits rather than the job itself. `check_tag` gates `build_wheels`, which produces the artifact `upload_wheels` publishes to PyPI. Code executing anywhere in that chain can change what ships to users — and it runs on `release: published`, after a human has stopped watching.

The privilege required is a release creation, so this is not anonymous RCE; it is a way for one compromised or careless step to reach the publishing pipeline. That is exactly the class of thing worth closing in a release workflow, where the blast radius is every downstream install.

**2. No `permissions:` block**

The workflow declared none, so all four jobs inherited the repository default token scope. Added `permissions: contents: read` at workflow level.

`upload_wheels` is deliberately untouched: job-level `permissions` *replace* the default rather than extend it, so it keeps exactly its declared `id-token: write` for Trusted Publishing. `check_tag`, `build_wheels` and `pytest-nosoftdeps` only ever read the repository.

### Deliberately not included

zizmor also reports 22 `unpinned-uses` findings across the workflows (`actions/checkout@v7` and friends are tags, which are mutable). Pinning by digest is a real improvement, but it is a different change with a different trade-off — Dependabot is clearly managing these tags today (#2348, #2370) and switching to digests changes that workflow. Happy to open it separately if maintainers want it; it did not belong in a targeted fix.

### Did you add any tests for the change?

No test is possible for a workflow file. Verified instead:

- `zizmor --min-severity high .github/workflows/pypi_release.yml` — the `template-injection` finding on this file is **gone** (was 1, now 0). The remaining findings are all `unpinned-uses`, which this PR intentionally does not touch.
- Parsed the file with PyYAML to confirm the structure is unchanged: same four jobs, `upload_wheels` still carrying `{'id-token': 'write'}`, top level now `{'contents': 'read'}`.
- The change is behaviour-preserving: `TAG` holds the same string it did before, so the version comparison logic is untouched.

### Any other comments?

### PR checklist

- [x] The PR title starts with either `[ENH]`, `[MNT]`, `[DOC]`, or `[BUG]`.
- [x] Added the relevant description of the changes.

