### PR TITLE
[DOC] add xLSTMTime_v2 API reference

### DIFF
--- a/docs/source/m_layer_v2.rst
+++ b/docs/source/m_layer_v2.rst
@@ -47,5 +47,6 @@ See the detailed API documentation for the V2 base classes and specific model im
    models.samformer._samformer_v2.Samformer
    models.tide._tide_dsipts._tide_v2.TIDE
    models.timexer._timexer_v2.TimeXer
+   models.xlstm._xlstm_v2.xLSTMTime_v2
    models.mlp._decodermlp_v2.DecoderMLP_v2
    models.softs._softs_v2.SOFTS

--- a/docs/source/pkg_v2.rst
+++ b/docs/source/pkg_v2.rst
@@ -99,5 +99,6 @@ See the detailed API documentation for the available V2 Package classes below:
    models.samformer._samformer_v2_pkg.Samformer_pkg_v2
    models.tide._tide_dsipts._tide_v2_pkg.TIDE_pkg_v2
    models.timexer._timexer_pkg_v2.TimeXer_pkg_v2
+   models.xlstm._xlstm_pkg_v2.xLSTMTime_pkg_v2
    models.mlp._decodermlp_pkg_v2.DecoderMLP_pkg_v2
    models.softs._softs_pkg_v2.SOFTS_pkg_v2


### PR DESCRIPTION
## Description

Adds the missing API reference for `xLSTMTime_v2` to the V2 model documentation.

## Changes

- Added `models.xlstm._xlstm_v2.xLSTMTime_v2` to the V2 model autosummary.
- No model implementation changes.

## Validation

- Verified `xLSTMTime_v2` imports successfully.
- Verified Sphinx generates the `xLSTMTime_v2` API reference.
- `git diff --check` passes.
- Full documentation build was attempted; it currently reports unrelated pre-existing documentation issues elsewhere in the repository.
- Closes #2384