### PR TITLE
[DOC] Add DLinear v2 tutorial notebook

### DIFF
--- a/docs/source/tutorials/dlinear_v2_example.ipynb
+++ b/docs/source/tutorials/dlinear_v2_example.ipynb
@@ -1,0 +1,187 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DLinear for v2 — package API walkthrough\n",
+    "\n",
+    "This notebook shows how to train and forecast with **DLinear** using the v2\n",
+    "`TimeSeries` + `TslibDataModule` stack via `DLinear_pkg_v2`.\n",
+    "\n",
+    "The v2 API is experimental and may change; see the [v2 tutorials index](../tutorials_v2.rst)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.preprocessing import StandardScaler\n",
+    "\n",
+    "from pytorch_forecasting.data.encoders import TorchNormalizer\n",
+    "from pytorch_forecasting.data.examples import load_toydata\n",
+    "from pytorch_forecasting.data.timeseries import TimeSeries\n",
+    "from pytorch_forecasting.metrics import MAE, SMAPE\n",
+    "from pytorch_forecasting.models.dlinear._dlinear_pkg_v2 import DLinear_pkg_v2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load toy data\n",
+    "\n",
+    "DLinear currently focuses on continuous features, so we keep only numeric\n",
+    "columns from `load_toydata`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_series = 100\n",
+    "seq_length = 50\n",
+    "data_df = load_toydata(num_series, seq_length)\n",
+    "data_df = data_df[\n",
+    "    [\n",
+    "        \"series_id\",\n",
+    "        \"time_idx\",\n",
+    "        \"x\",\n",
+    "        \"y\",\n",
+    "        \"future_known_feature\",\n",
+    "        \"static_feature\",\n",
+    "    ]\n",
+    "]\n",
+    "data_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a `TimeSeries` dataset\n",
+    "\n",
+    "`TimeSeries` is the D1 layer: it wraps the raw DataFrame and declares roles for\n",
+    "time, target, groups, and feature columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset = TimeSeries(\n",
+    "    data=data_df,\n",
+    "    time=\"time_idx\",\n",
+    "    target=\"y\",\n",
+    "    group=[\"series_id\"],\n",
+    "    num=[\"x\", \"future_known_feature\", \"static_feature\"],\n",
+    "    cat=[],\n",
+    "    known=[\"future_known_feature\"],\n",
+    "    unknown=[\"x\"],\n",
+    "    static=[\"static_feature\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure datamodule, model, and trainer\n",
+    "\n",
+    "`DLinear_pkg_v2` uses `TslibDataModule`, so datamodule kwargs are\n",
+    "`context_length` / `prediction_length` (not encoder/decoder lengths).\n",
+    "Include scalers and a target normalizer as in the other v2 tutorials."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "datamodule_cfg = dict(\n",
+    "    context_length=30,\n",
+    "    prediction_length=1,\n",
+    "    batch_size=32,\n",
+    "    add_relative_time_idx=True,\n",
+    "    scalers={\n",
+    "        \"x\": StandardScaler(),\n",
+    "        \"future_known_feature\": StandardScaler(),\n",
+    "        \"static_feature\": StandardScaler(),\n",
+    "    },\n",
+    "    target_normalizer=TorchNormalizer(),\n",
+    ")\n",
+    "\n",
+    "model_cfg = dict(\n",
+    "    loss=MAE(),\n",
+    "    logging_metrics=[MAE(), SMAPE()],\n",
+    "    optimizer=\"adam\",\n",
+    "    optimizer_params={\"lr\": 1e-3},\n",
+    "    moving_avg=25,\n",
+    "    individual=False,\n",
+    ")\n",
+    "\n",
+    "trainer_cfg = dict(\n",
+    "    max_epochs=5,\n",
+    "    accelerator=\"auto\",\n",
+    "    devices=1,\n",
+    "    enable_progress_bar=True,\n",
+    "    log_every_n_steps=10,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Fit and predict with `DLinear_pkg_v2`\n",
+    "\n",
+    "The package container wires the model, `TslibDataModule`, and Lightning trainer.\n",
+    "Pass the `TimeSeries` object to `fit` / `predict`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_pkg = DLinear_pkg_v2(\n",
+    "    model_cfg=model_cfg,\n",
+    "    trainer_cfg=trainer_cfg,\n",
+    "    datamodule_cfg=datamodule_cfg,\n",
+    ")\n",
+    "\n",
+    "model_pkg.fit(dataset)\n",
+    "preds = model_pkg.predict(dataset, return_info=[\"index\", \"x\", \"y\"])\n",
+    "preds[\"prediction\"][:3]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/tutorials_v2.rst
+++ b/docs/source/tutorials_v2.rst
@@ -15,3 +15,4 @@ The following tutorials for version 2 can be also found as `notebooks on GitHub 
 
    tutorials/ptf_V2_example
    tutorials/tslib_v2_example
+   tutorials/dlinear_v2_example


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #2390.

#### What does this implement/fix? Explain your changes.
Adds a DLinear v2 tutorial using `TimeSeries` + `TslibDataModule` via `DLinear_pkg_v2` (with scalers) and links it from `tutorials_v2.rst`.

#### Did you add any tests for the change?
No — documentation-only change.

#### PR checklist
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].
- [ ] Added/modified tests
- [x] Used pre-commit hooks when committing to ensure that code is compliant with hooks.