### PR TITLE
[MNT] remove extraneous material from package wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ docs = [
 github-actions = ["pytest-github-actions-annotate-failures<0.4.3"]
 
 [tool.setuptools.packages.find]
-exclude = ["build_tools"]
+include = ["pytorch_forecasting", "pytorch_forecasting.*"]
 
 [build-system]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Mirror of https://github.com/sktime/sktime/issues/10891
Explicitly excludes folders from repository root that should not be shipped with release package wheels:

* `build_tools` (for maintainers only)
* `docs` (for developers with a clone only)
* `examples` (consumption via clone, binder/colab resp online docs only)

Mechanism: changing to explicit include (also future-proof) as opposed to widening exclude statement, in `tool.setuptools.packages.find`.