### PR TITLE
&Faakhir30 [ENH] Update Datamodules according to new API design

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,9 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: [v2-dev]
   pull_request:
-    branches: [main]
+    branches: [v2-dev]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/pytorch_forecasting/__init__.py
+++ b/pytorch_forecasting/__init__.py
@@ -9,7 +9,9 @@ from pytorch_forecasting.data import (
     GroupNormalizer,
     MultiNormalizer,
     NaNLabelEncoder,
+    TimeSeries,
     TimeSeriesDataSet,
+    TimeSeriesMetadata,
 )
 from pytorch_forecasting.metrics import (
     MAE,
@@ -66,7 +68,9 @@ from pytorch_forecasting.utils import (
 from pytorch_forecasting.utils._maint._show_versions import show_versions
 
 __all__ = [
+    "TimeSeries",
     "TimeSeriesDataSet",
+    "TimeSeriesMetadata",
     "GroupNormalizer",
     "EncoderNormalizer",
     "NaNLabelEncoder",

--- a/pytorch_forecasting/data/__init__.py
+++ b/pytorch_forecasting/data/__init__.py
@@ -6,6 +6,11 @@ utilities, and batching tools required to transform raw time series data
 into model-ready PyTorch datasets.
 """
 
+from pytorch_forecasting.data._metadata import (
+    EncDecDataModuleMetadata,
+    TimeSeriesMetadata,
+    TslibDataModuleMetadata,
+)
 from pytorch_forecasting.data.encoders import (
     EncoderNormalizer,
     GroupNormalizer,
@@ -14,16 +19,14 @@ from pytorch_forecasting.data.encoders import (
     TorchNormalizer,
 )
 from pytorch_forecasting.data.samplers import TimeSynchronizedBatchSampler
-from pytorch_forecasting.data.timeseries import (
-    TimeSeries,
-    TimeSeriesDataSet,
-    TimeSeriesMetadata,
-)
+from pytorch_forecasting.data.timeseries import TimeSeries, TimeSeriesDataSet
 
 __all__ = [
     "TimeSeriesDataSet",
     "TimeSeries",
     "TimeSeriesMetadata",
+    "EncDecDataModuleMetadata",
+    "TslibDataModuleMetadata",
     "NaNLabelEncoder",
     "GroupNormalizer",
     "TorchNormalizer",

--- a/pytorch_forecasting/data/__init__.py
+++ b/pytorch_forecasting/data/__init__.py
@@ -14,11 +14,16 @@ from pytorch_forecasting.data.encoders import (
     TorchNormalizer,
 )
 from pytorch_forecasting.data.samplers import TimeSynchronizedBatchSampler
-from pytorch_forecasting.data.timeseries import TimeSeries, TimeSeriesDataSet
+from pytorch_forecasting.data.timeseries import (
+    TimeSeries,
+    TimeSeriesDataSet,
+    TimeSeriesMetadata,
+)
 
 __all__ = [
     "TimeSeriesDataSet",
     "TimeSeries",
+    "TimeSeriesMetadata",
     "NaNLabelEncoder",
     "GroupNormalizer",
     "TorchNormalizer",

--- a/pytorch_forecasting/data/_metadata.py
+++ b/pytorch_forecasting/data/_metadata.py
@@ -1,0 +1,140 @@
+"""Typed schemas of the data layer."""
+
+from dataclasses import dataclass, fields
+
+
+class _DictLike:
+    """Mapping protocol for the metadata dataclasses."""
+
+    def __getitem__(self, key):
+        if key not in self:
+            raise KeyError(key)
+        return getattr(self, key)
+
+    def get(self, key, default=None):
+        return getattr(self, key) if key in self else default
+
+    def keys(self):
+        return [f.name for f in fields(self)]
+
+    def __contains__(self, key):
+        return key in self.keys()
+
+    def __iter__(self):
+        return iter(self.keys())
+
+
+@dataclass(frozen=True)
+class TimeSeriesMetadata(_DictLike):
+    """Schema of a :class:`~pytorch_forecasting.data.TimeSeries`.
+
+    Parameters
+    ----------
+    cols : dict
+        ``{"y": [...], "x": [...], "st": [...]}``, names of the target, feature
+        and static columns. List order is the column order of the corresponding
+        tensor dimension, and must not be reordered.
+    col_type : dict
+        maps column name to ``"F"`` (numerical) or ``"C"`` (categorical).
+    col_known : dict
+        maps column name to ``"K"`` (known in the future) or ``"U"`` (unknown).
+    is_prediction : bool, default=False
+        whether the described object holds predictions rather than input data.
+    """
+
+    cols: dict[str, list[str]]
+    col_type: dict[str, str]
+    col_known: dict[str, str]
+    is_prediction: bool = False
+
+    def __post_init__(self):
+        """Validation checks.
+
+        Raises
+        ------
+        ValueError
+            If ``cols`` does not have exactly the keys ``"y"``, ``"x"``, ``"st"``.
+        """
+        missing = {"y", "x", "st"} - set(self.cols)
+        if missing:
+            raise ValueError(
+                f"`cols` is missing required keys: {sorted(missing)}. It must "
+                'map "y", "x" and "st" to lists of column names.'
+            )
+
+
+@dataclass(frozen=True)
+class EncDecDataModuleMetadata(_DictLike):
+    """Shapes an encoder-decoder model needs in order to be constructed.
+
+    Parameters
+    ----------
+    encoder_cat : int
+        Number of categorical variables in the encoder.
+    encoder_cont : int
+        Number of continuous variables in the encoder.
+    decoder_cat : int
+        Number of categorical variables known in advance to the decoder.
+    decoder_cont : int
+        Number of continuous variables known in advance to the decoder.
+    target : int
+        Number of target variables.
+    static_categorical_features : int, default=0
+        Number of static categorical features.
+    static_continuous_features : int, default=0
+        Number of static continuous features.
+    max_encoder_length : int, default=0
+        Maximum encoder length.
+    max_prediction_length : int, default=0
+        Maximum prediction length.
+    min_encoder_length : int, default=0
+        Minimum encoder length.
+    min_prediction_length : int, default=0
+        Minimum prediction length.
+    """
+
+    encoder_cat: int
+    encoder_cont: int
+    decoder_cat: int
+    decoder_cont: int
+    target: int
+    static_categorical_features: int = 0
+    static_continuous_features: int = 0
+    max_encoder_length: int = 0
+    max_prediction_length: int = 0
+    min_encoder_length: int = 0
+    min_prediction_length: int = 0
+
+
+@dataclass(frozen=True)
+class TslibDataModuleMetadata(_DictLike):
+    """Shapes a tslib-style model needs in order to be constructed.
+
+    Parameters
+    ----------
+    feature_names : dict
+        Maps a feature group - ``"categorical"``, ``"continuous"``,
+        ``"static"``, ``"known"``, ``"unknown"``, ``"target"``, ``"all"`` - to
+        its column names.
+    feature_indices : dict
+        Maps the same groups, except ``"all"``, to their positions within the
+        feature tensor.
+    n_features : dict
+        Number of features in each group of ``feature_names``.
+    context_length : int
+        Length of the context window.
+    prediction_length : int
+        Length of the prediction window.
+    freq : str or None, default=None
+        Frequency of the time series.
+    features : str, default="MS"
+        Feature combination mode, one of ``"S"``, ``"M"``, ``"MS"``.
+    """
+
+    feature_names: dict[str, list[str]]
+    feature_indices: dict[str, list[int]]
+    n_features: dict[str, int]
+    context_length: int
+    prediction_length: int
+    freq: str | None = None
+    features: str = "MS"

--- a/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
+++ b/pytorch_forecasting/data/data_module/_encoder_decoder_data_module.py
@@ -7,6 +7,7 @@
 # into the memory.
 #######################################################################################
 
+import inspect
 from pathlib import Path
 import pickle
 from typing import Any, Optional, Union
@@ -20,6 +21,7 @@ import torch
 from torch.utils.data import DataLoader, Dataset
 
 from pytorch_forecasting.adapters import ScalerAdapter
+from pytorch_forecasting.data._metadata import EncDecDataModuleMetadata
 from pytorch_forecasting.data.encoders import (
     EncoderNormalizer,
     MultiNormalizer,
@@ -28,8 +30,17 @@ from pytorch_forecasting.data.encoders import (
 )
 from pytorch_forecasting.data.timeseries import TimeSeries
 from pytorch_forecasting.utils._coerce import _coerce_to_dict
+from pytorch_forecasting.utils._validation import (
+    _check_column_names,
+    _check_fractions,
+    _check_positive,
+    _check_type,
+    _check_within,
+)
 
 NORMALIZER = TorchNormalizer | EncoderNormalizer | NaNLabelEncoder
+
+_WRAP_HINT = "Wrap the data frame first, e.g. TimeSeries(df, time=..., target=...)."
 
 
 class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
@@ -42,8 +53,10 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
     Parameters
     ----------
-    time_series_dataset : TimeSeries
-        The dataset containing time series data.
+    time_series : TimeSeries, optional, default=None
+        The input data. If ``None``, the module is a configuration only: it carries
+        its parameters, and data is attached later with
+        :meth:`with_data`, which reuses any transforms already fitted here.
     max_encoder_length : int, default=30
         Maximum length of the encoder input sequence.
     min_encoder_length : Optional[int], default=None
@@ -111,7 +124,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
     def __init__(
         self,
-        time_series_dataset: TimeSeries,
+        time_series: TimeSeries | None = None,
         max_encoder_length: int = 30,
         min_encoder_length: int | None = None,
         max_prediction_length: int = 1,
@@ -136,7 +149,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         num_workers: int = 0,
         train_val_test_split: tuple = (0.7, 0.15, 0.15),
     ):
-        self.time_series_dataset = time_series_dataset
+        self.time_series = time_series
         self.max_encoder_length = max_encoder_length
         self.min_encoder_length = min_encoder_length
         self.max_prediction_length = max_prediction_length
@@ -153,6 +166,14 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.train_val_test_split = train_val_test_split
+
+        self._validate_init_params()
+
+        self._init_kwargs = {
+            name: getattr(self, name)
+            for name in inspect.signature(type(self).__init__).parameters
+            if name not in ("self", "time_series")
+        }
 
         warn(
             "EncoderDecoderTimeSeriesDataModule is part of an experimental "
@@ -181,28 +202,160 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             self._target_normalizer = ScalerAdapter(self.target_normalizer)
             self._auto_normalizer = False
 
-        self.time_series_metadata = time_series_dataset.get_metadata()
         self._min_prediction_length = min_prediction_length or max_prediction_length
         self._min_encoder_length = min_encoder_length or max_encoder_length
         self._categorical_encoders = _coerce_to_dict(categorical_encoders)
-        self.n_targets = len(self.time_series_metadata["cols"]["y"])
 
         self.categorical_indices = []
         self.continuous_indices = []
+        self._cont_scalers = []
         self._metadata = None
         self._target_normalizer_fitted = False
         self._feature_scalers_fitted = False
 
+        self._scalers = {
+            k: ScalerAdapter(v) for k, v in _coerce_to_dict(scalers).items()
+        }
+
+        # without data there is no schema, so column positions and target count
+        # cannot be derived yet
+        self.time_series_metadata = None
+        self.n_targets = None
+        if time_series is not None:
+            self._bind_time_series()
+
+    def _bind_time_series(self):
+        """Derive the schema-dependent state from the attached data."""
+        self.time_series_metadata = self.time_series.get_metadata()
+        self.n_targets = len(self.time_series_metadata["cols"]["y"])
+
+        self.categorical_indices = []
+        self.continuous_indices = []
         for idx, col in enumerate(self.time_series_metadata["cols"]["x"]):
             if self.time_series_metadata["col_type"].get(col) == "C":
                 self.categorical_indices.append(idx)
             else:
                 self.continuous_indices.append(idx)
 
-        self._scalers = {
-            k: ScalerAdapter(v) for k, v in _coerce_to_dict(scalers).items()
-        }
+        self._validate_against_schema()
         self._build_cont_scalers()
+
+    def _validate_against_schema(self):
+        """Check the parameters that can only be checked once data is attached.
+
+        Raises
+        ------
+        ValueError
+            If the number of target normalizers does not match the number of
+            targets, or if ``scalers`` names a column that is not a continuous
+            feature.
+        """
+        cols = self.time_series_metadata["cols"]
+        normalizers = self.target_normalizer
+
+        is_list = isinstance(normalizers, (list, tuple))
+        if is_list and len(normalizers) != self.n_targets:
+            raise ValueError(
+                f"`target_normalizer` has {len(normalizers)} normalizers but the "
+                f"data has {self.n_targets} target(s) ({cols['y']}). Pass one "
+                "per target, or a single normalizer for all of them."
+            )
+
+        _check_column_names(
+            {"scalers": list(self.scalers or {})},
+            [cols["x"][idx] for idx in self.continuous_indices],
+            allowed_label="continuous features",
+            hint="Scalers apply to continuous features only.",
+        )
+
+    def _validate_init_params(self):
+        """Check the constructor arguments.
+
+        Raises
+        ------
+        TypeError
+            If ``time_series`` is not a :class:`TimeSeries`.
+        ValueError
+            If a window length is not positive, a minimum length exceeds its
+            maximum, or ``train_val_test_split`` is not three non-negative
+            fractions summing to 1.
+        """
+        _check_type(
+            self.time_series,
+            TimeSeries,
+            "time_series",
+            allow_none=True,
+            hint=_WRAP_HINT,
+        )
+        _check_positive(self.max_encoder_length, "max_encoder_length")
+        _check_positive(self.max_prediction_length, "max_prediction_length")
+        _check_within(
+            self.min_encoder_length,
+            self.max_encoder_length,
+            "min_encoder_length",
+            "max_encoder_length",
+        )
+        _check_within(
+            self.min_prediction_length,
+            self.max_prediction_length,
+            "min_prediction_length",
+            "max_prediction_length",
+        )
+        _check_fractions(self.train_val_test_split, "train_val_test_split")
+
+    def _check_has_data(self, action: str):
+        """Raise if an operation needs data and none is attached.
+
+        Parameters
+        ----------
+        action : str
+            What was attempted, named in the error message.
+
+        Raises
+        ------
+        RuntimeError
+            If the module was constructed without data.
+        """
+        if self.time_series is None:
+            raise RuntimeError(
+                f"{type(self).__name__} was constructed without data, so "
+                f"{action} is not available. Attach data with "
+                "`.with_data(time_series)`, which returns a new module, or "
+                "pass `time_series` to the constructor."
+            )
+
+    def with_data(self, data: TimeSeries) -> "EncoderDecoderTimeSeriesDataModule":
+        """Return a copy of this module holding ``data``, without refitting.
+
+        Same parameters and same fitted transforms with new data.
+
+        Parameters
+        ----------
+        data : TimeSeries
+            The data to attach.
+
+        Returns
+        -------
+        EncoderDecoderTimeSeriesDataModule
+            A new module, configured identically, carrying the transforms
+            fitted on this one.
+
+        Raises
+        ------
+        TypeError
+            If ``data`` is not a :class:`TimeSeries`.
+        """
+        _check_type(data, TimeSeries, "data", hint=_WRAP_HINT)
+
+        new = type(self)(time_series=data, **self._init_kwargs)
+
+        new._target_normalizer = self._target_normalizer
+        new._target_normalizer_fitted = self._target_normalizer_fitted
+        new._auto_normalizer = self._auto_normalizer
+        new._scalers = self._scalers
+        new._feature_scalers_fitted = self._feature_scalers_fitted
+        new._build_cont_scalers()
+        return new
 
     def _build_cont_scalers(self):
         """Pre-resolve continuous feature scalers to (position, adapter) pairs."""
@@ -276,42 +429,28 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             ]
         )
 
-        target_count = len(self.time_series_metadata["cols"]["y"])
-        metadata = {
-            "encoder_cat": encoder_cat_count,
-            "encoder_cont": encoder_cont_count,
-            "decoder_cat": decoder_cat_count,
-            "decoder_cont": decoder_cont_count,
-            "target": target_count,
-        }
-        if self.time_series_metadata["cols"]["st"]:
-            static_cat_count = len(
-                [
-                    col
-                    for col in self.time_series_metadata["cols"]["st"]
-                    if self.time_series_metadata["col_type"].get(col) == "C"
-                ]
-            )
-            static_cont_count = (
-                len(self.time_series_metadata["cols"]["st"]) - static_cat_count
-            )
-
-            metadata["static_categorical_features"] = static_cat_count
-            metadata["static_continuous_features"] = static_cont_count
-        else:
-            metadata["static_categorical_features"] = 0
-            metadata["static_continuous_features"] = 0
-
-        metadata.update(
-            {
-                "max_encoder_length": self.max_encoder_length,
-                "max_prediction_length": self.max_prediction_length,
-                "min_encoder_length": self._min_encoder_length,
-                "min_prediction_length": self._min_prediction_length,
-            }
+        static_cols = self.time_series_metadata["cols"]["st"]
+        static_cat_count = len(
+            [
+                col
+                for col in static_cols
+                if self.time_series_metadata["col_type"].get(col) == "C"
+            ]
         )
 
-        return metadata
+        return EncDecDataModuleMetadata(
+            encoder_cat=encoder_cat_count,
+            encoder_cont=encoder_cont_count,
+            decoder_cat=decoder_cat_count,
+            decoder_cont=decoder_cont_count,
+            target=len(self.time_series_metadata["cols"]["y"]),
+            static_categorical_features=static_cat_count,
+            static_continuous_features=len(static_cols) - static_cat_count,
+            max_encoder_length=self.max_encoder_length,
+            max_prediction_length=self.max_prediction_length,
+            min_encoder_length=self._min_encoder_length,
+            min_prediction_length=self._min_prediction_length,
+        )
 
     @property
     def metadata(self):
@@ -340,6 +479,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         * ``min_encoder_length``: minimum encoder length
         * ``min_prediction_length``: minimum prediction length
         """
+        self._check_has_data("`metadata`")
         if self._metadata is None:
             self._metadata = self._prepare_metadata()
         return self._metadata
@@ -362,7 +502,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             DataFrame with group columns repeated for each timestep,
             or None if no group columns are defined.
         """
-        ts = self.time_series_dataset
+        ts = self.time_series
         if not ts._group:
             return None
 
@@ -463,7 +603,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         Sequence-local normalization (EncoderNormalizer) is deferred to
         __getitem__.
         """
-        sample = self.time_series_dataset[series_idx]
+        sample = self.time_series[series_idx]
         target, features, times, time_mask = self._coerce_sample(sample)
         split = self._split_features(features)
         target, target_original = self._normalize_target(target, series_idx)
@@ -497,7 +637,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         all_groups = []
         for idx in train_indices:
             series_idx = idx.item()
-            sample = self.time_series_dataset[idx]
+            sample = self.time_series[idx]
             target = sample["y"]
             all_targets.append(target)
             n_timesteps = len(target)
@@ -536,7 +676,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
             for idx in train_indices:
                 series_idx = idx.item()
-                sample = self.time_series_dataset[idx]
+                sample = self.time_series[idx]
                 feature_data = sample["x"][:, feat_idx]
                 feat_data.append(feature_data)
                 all_groups.append(
@@ -811,7 +951,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         List[Tuple[int, int, int, int]]
             A list of tuples, where each tuple consists of:
             - ``series_idx`` : int
-              Index of the time series in `time_series_dataset`.
+              Index of the time series in `time_series`.
             - ``start_idx`` : int
               Start index of the encoder window.
             - ``enc_length`` : int
@@ -823,7 +963,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
         for idx in indices:
             series_idx = idx.item()
-            sample = self.time_series_dataset[series_idx]
+            sample = self.time_series[series_idx]
             sequence_length = len(sample["y"])
 
             if sequence_length < self.max_encoder_length + self.max_prediction_length:
@@ -876,7 +1016,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         per_target = {name: [] for name in target_names}
 
         for idx in train_indices:
-            sample = self.time_series_dataset[idx.item()]
+            sample = self.time_series[idx.item()]
             target = sample["y"]
             for i, name in enumerate(target_names):
                 per_target[name].append(target[..., i] if target.ndim > 1 else target)
@@ -916,7 +1056,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             As returned by ``_compute_data_properties``.
         """
         target_names = self.time_series_metadata["cols"]["y"]
-        has_groups = bool(self.time_series_dataset._group)
+        has_groups = bool(self.time_series._group)
         use_encoder_normalizer = (
             self.max_encoder_length > 20 and self._min_encoder_length > 1
         )
@@ -952,7 +1092,9 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
 
     def _resolve_target_normalizer(self, train_indices: torch.Tensor) -> None:
         """Resolve target normalizer"""
-        if not self._auto_normalizer:
+        if not self._auto_normalizer or self._target_normalizer_fitted:
+            # an already fitted normalizer was carried over by `with_data`
+            # replacing it here would discard the training statistics
             return
         data_properties = self._compute_data_properties(train_indices)
         normalizer = self._get_auto_normalizer(data_properties)
@@ -963,7 +1105,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
         if hasattr(self, "_split_indices"):
             return
 
-        total_series = len(self.time_series_dataset)
+        total_series = len(self.time_series)
         self._split_indices = torch.randperm(total_series)
 
         self._train_size = int(self.train_val_test_split[0] * total_series)
@@ -1008,6 +1150,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
             - ``"predict"`` : Prepares the dataset for inference.
             - ``None`` : Prepares ``fit`` datasets.
         """
+        self._check_has_data("`setup`")
         self._ensure_split()
 
         if stage is None or stage == "fit":
@@ -1030,7 +1173,7 @@ class EncoderDecoderTimeSeriesDataModule(LightningDataModule):
                     self._make_dataset(self._test_indices)
                 )
         elif stage == "predict":
-            predict_indices = torch.arange(len(self.time_series_dataset))
+            predict_indices = torch.arange(len(self.time_series))
             self._predict_preprocessed, self.predict_windows, self.predict_dataset = (
                 self._make_dataset(predict_indices)
             )

--- a/pytorch_forecasting/data/data_module/_tslib_data_module.py
+++ b/pytorch_forecasting/data/data_module/_tslib_data_module.py
@@ -3,6 +3,7 @@ Experimental data module for integrating `tslib` time series deep learning libra
 """
 
 from collections.abc import Callable
+import inspect
 from typing import Any, Optional
 import warnings
 
@@ -13,6 +14,7 @@ from sklearn.preprocessing import RobustScaler, StandardScaler
 import torch
 from torch.utils.data import DataLoader, Dataset
 
+from pytorch_forecasting.data._metadata import TslibDataModuleMetadata
 from pytorch_forecasting.data.encoders import (
     EncoderNormalizer,
     NaNLabelEncoder,
@@ -20,8 +22,15 @@ from pytorch_forecasting.data.encoders import (
 )
 from pytorch_forecasting.data.timeseries._timeseries_v2 import TimeSeries
 from pytorch_forecasting.utils._coerce import _coerce_to_dict
+from pytorch_forecasting.utils._validation import (
+    _check_fractions,
+    _check_positive,
+    _check_type,
+)
 
 NORMALIZER = TorchNormalizer | EncoderNormalizer | NaNLabelEncoder
+
+_WRAP_HINT = "Wrap the data frame first, e.g. TimeSeries(df, time=..., target=...)."
 
 
 class _TslibDataset(Dataset):
@@ -245,9 +254,10 @@ class TslibDataModule(LightningDataModule):
 
     Parameters
     ----------
-    time_series_dataset: TimeSeries
-        The time series dataset to be used for training and validation. This is the
-        newly implemented D1 layer.
+    time_series: TimeSeries, optional, default=None
+        The input data. If ``None``, the module is a configuration only: it carries
+        its parameters, and data is attached later with
+        :meth:`with_data`, which reuses any transforms already fitted here.
     context_length: int
         The length of the context window for the model. This is the number of time steps
         used as input to the model.
@@ -289,9 +299,9 @@ class TslibDataModule(LightningDataModule):
 
     def __init__(
         self,
-        time_series_dataset: TimeSeries,
-        context_length: int,
-        prediction_length: int,
+        time_series: TimeSeries | None = None,
+        context_length: int = 30,
+        prediction_length: int = 1,
         freq: str = "h",
         add_relative_time_idx: bool = False,
         add_target_scales: bool = False,
@@ -314,12 +324,16 @@ class TslibDataModule(LightningDataModule):
     ) -> None:
         super().__init__()
 
-        self.time_series_dataset = time_series_dataset
+        self.time_series = time_series
         self.context_length = context_length
         self.prediction_length = prediction_length
         self.freq = freq
         self.add_relative_time_idx = add_relative_time_idx
         self.add_target_scales = add_target_scales
+        self.target_normalizer = target_normalizer
+        self.scalers = scalers
+        self.shuffle = shuffle
+        self.window_stride = window_stride
         self.batch_size = batch_size
         self.num_workers = num_workers
         self.train_val_test_split = train_val_test_split
@@ -327,6 +341,15 @@ class TslibDataModule(LightningDataModule):
             collate_fn if collate_fn is not None else self.__class__.collate_fn
         )  # noqa: E501
         self.kwargs = kwargs
+
+        self._validate_init_params()
+
+        self._init_kwargs = {
+            name: getattr(self, name)
+            for name in inspect.signature(type(self).__init__).parameters
+            if name not in ("self", "time_series", "kwargs")
+        }
+        self._init_kwargs.update(self.kwargs)
 
         warnings.warn(
             "TslibDataModule is experimental and subject to change. "
@@ -341,9 +364,6 @@ class TslibDataModule(LightningDataModule):
 
         self._metadata = None
 
-        self.scalers = scalers or {}
-        self.shuffle = shuffle
-
         self.continuous_indices = []
         self.categorical_indices = []
 
@@ -351,11 +371,20 @@ class TslibDataModule(LightningDataModule):
         self.val_dataset = None
         self.test_dataset = None
 
-        self.window_stride = window_stride
+        # without data there is no schema, so column positions and target count
+        # cannot be derived yet
+        self.time_series_metadata = None
+        self.n_targets = None
+        if time_series is not None:
+            self._bind_time_series()
 
-        self.time_series_metadata = time_series_dataset.get_metadata()
+    def _bind_time_series(self):
+        """Derive the schema-dependent state from the attached data."""
+        self.time_series_metadata = self.time_series.get_metadata()
         self.n_targets = len(self.time_series_metadata["cols"]["y"])
 
+        self.categorical_indices = []
+        self.continuous_indices = []
         for idx, col in enumerate(self.time_series_metadata["cols"]["x"]):
             if self.time_series_metadata["col_type"].get(col) == "C":
                 self.categorical_indices.append(idx)
@@ -363,6 +392,74 @@ class TslibDataModule(LightningDataModule):
                 self.continuous_indices.append(idx)
 
         self._validate_indices()
+
+    def _validate_init_params(self):
+        """Check the constructor arguments.
+
+        Raises
+        ------
+        TypeError
+            If ``time_series`` is not a :class:`TimeSeries`.
+        ValueError
+            If a window length is not positive, ``window_stride`` is not
+            positive, or ``train_val_test_split`` is not three non-negative
+            fractions summing to 1.
+        """
+        _check_type(
+            self.time_series,
+            TimeSeries,
+            "time_series",
+            allow_none=True,
+            hint=_WRAP_HINT,
+        )
+        _check_positive(self.context_length, "context_length")
+        _check_positive(self.prediction_length, "prediction_length")
+        _check_positive(self.window_stride, "window_stride")
+        _check_fractions(self.train_val_test_split, "train_val_test_split")
+
+    def _check_has_data(self, action: str):
+        """Raise if an operation needs data and none is attached.
+
+        Parameters
+        ----------
+        action : str
+            What was attempted, named in the error message.
+
+        Raises
+        ------
+        RuntimeError
+            If the module was constructed without data.
+        """
+        if self.time_series is None:
+            raise RuntimeError(
+                f"{type(self).__name__} was constructed without data, so "
+                f"{action} is not available. Attach data with "
+                "`.with_data(time_series)`, which returns a new module, or "
+                "pass `time_series` to the constructor."
+            )
+
+    def with_data(self, data: TimeSeries) -> "TslibDataModule":
+        """Return a copy of this module holding ``data``, without refitting.
+
+        Same parameters, new data.
+
+        Parameters
+        ----------
+        data : TimeSeries
+            The data to attach.
+
+        Returns
+        -------
+        TslibDataModule
+            A new module, configured identically.
+
+        Raises
+        ------
+        TypeError
+            If ``data`` is not a :class:`TimeSeries`.
+        """
+        _check_type(data, TimeSeries, "data", hint=_WRAP_HINT)
+        return type(self)(time_series=data, **self._init_kwargs)
 
     def _validate_indices(self):
         """
@@ -404,7 +501,7 @@ class TslibDataModule(LightningDataModule):
                 UserWarning,
             )
 
-    def _prepare_metadata(self) -> dict[str, Any]:
+    def _prepare_metadata(self) -> TslibDataModuleMetadata:
         """
         Prepare metadata for `tslib` time series data module.
 
@@ -510,20 +607,18 @@ class TslibDataModule(LightningDataModule):
         else:
             self.features = "M"
 
-        metadata = {
-            "feature_names": feature_names,
-            "feature_indices": feature_indices,
-            "n_features": n_features,
-            "context_length": self.context_length,
-            "prediction_length": self.prediction_length,
-            "freq": self.freq,
-            "features": self.features,
-        }
-
-        return metadata
+        return TslibDataModuleMetadata(
+            feature_names=feature_names,
+            feature_indices=feature_indices,
+            n_features=n_features,
+            context_length=self.context_length,
+            prediction_length=self.prediction_length,
+            freq=self.freq,
+            features=self.features,
+        )
 
     @property
-    def metadata(self) -> dict[str, Any]:
+    def metadata(self) -> TslibDataModuleMetadata:
         """ "
         Compute the metadata via the `_prepare_metadata` method.
         This method is called when the `metadata` property is accessed for the first.
@@ -533,6 +628,7 @@ class TslibDataModule(LightningDataModule):
             Metadata for the data module. Refer to the `_prepare_metadata` method for
             the keys and values in the metadata dictionary.
         """
+        self._check_has_data("`metadata`")
         if self._metadata is None:
             self._metadata = self._prepare_metadata()
         return self._metadata
@@ -559,7 +655,7 @@ class TslibDataModule(LightningDataModule):
         - Splits data into categorical and continuous features, which are grouped based on the indices.
         """  # noqa: E501
 
-        series = self.time_series_dataset[idx]
+        series = self.time_series[idx]
         if series is None:
             raise ValueError(f"series at index {idx} is None. Check the dataset.")
         target = series["y"]
@@ -639,7 +735,7 @@ class TslibDataModule(LightningDataModule):
 
         for idx in indices:
             series_idx = idx.item() if isinstance(idx, torch.Tensor) else idx
-            sample = self.time_series_dataset[series_idx]
+            sample = self.time_series[series_idx]
             sequence_length = len(sample["t"])
 
             if sequence_length < min_seq_length:
@@ -687,7 +783,8 @@ class TslibDataModule(LightningDataModule):
         # Currently, it only supports random splits.
         # Handle the case where the dataset is empty.
 
-        total_series = len(self.time_series_dataset)
+        self._check_has_data("`setup`")
+        total_series = len(self.time_series)
 
         if total_series == 0:
             raise ValueError(
@@ -725,14 +822,14 @@ class TslibDataModule(LightningDataModule):
                 self._val_windows = self._create_windows(self._val_indices)
 
                 self.train_dataset = _TslibDataset(
-                    dataset=self.time_series_dataset,
+                    dataset=self.time_series,
                     data_module=self,
                     windows=self._train_windows,
                     add_relative_time_idx=self.add_relative_time_idx,
                 )
 
                 self.val_dataset = _TslibDataset(
-                    dataset=self.time_series_dataset,
+                    dataset=self.time_series,
                     data_module=self,
                     windows=self._val_windows,
                     add_relative_time_idx=self.add_relative_time_idx,
@@ -742,18 +839,18 @@ class TslibDataModule(LightningDataModule):
                 self._test_windows = self._create_windows(self._test_indices)
 
                 self.test_dataset = _TslibDataset(
-                    dataset=self.time_series_dataset,
+                    dataset=self.time_series,
                     data_module=self,
                     windows=self._test_windows,
                     add_relative_time_idx=self.add_relative_time_idx,
                 )
 
         elif stage == "predict":
-            predict_indices = torch.arange(len(self.time_series_dataset))
+            predict_indices = torch.arange(len(self.time_series))
             self._predict_windows = self._create_windows(predict_indices)
 
             self.predict_dataset = _TslibDataset(
-                dataset=self.time_series_dataset,
+                dataset=self.time_series,
                 data_module=self,
                 windows=self._predict_windows,
                 add_relative_time_idx=self.add_relative_time_idx,

--- a/pytorch_forecasting/data/timeseries/__init__.py
+++ b/pytorch_forecasting/data/timeseries/__init__.py
@@ -5,11 +5,15 @@ from pytorch_forecasting.data.timeseries._timeseries import (
     _find_end_indices,
     check_for_nonfinite,
 )
-from pytorch_forecasting.data.timeseries._timeseries_v2 import TimeSeries
+from pytorch_forecasting.data.timeseries._timeseries_v2 import (
+    TimeSeries,
+    TimeSeriesMetadata,
+)
 
 __all__ = [
     "_find_end_indices",
     "check_for_nonfinite",
     "TimeSeriesDataSet",
     "TimeSeries",
+    "TimeSeriesMetadata",
 ]

--- a/pytorch_forecasting/data/timeseries/__init__.py
+++ b/pytorch_forecasting/data/timeseries/__init__.py
@@ -5,15 +5,11 @@ from pytorch_forecasting.data.timeseries._timeseries import (
     _find_end_indices,
     check_for_nonfinite,
 )
-from pytorch_forecasting.data.timeseries._timeseries_v2 import (
-    TimeSeries,
-    TimeSeriesMetadata,
-)
+from pytorch_forecasting.data.timeseries._timeseries_v2 import TimeSeries
 
 __all__ = [
     "_find_end_indices",
     "check_for_nonfinite",
     "TimeSeriesDataSet",
     "TimeSeries",
-    "TimeSeriesMetadata",
 ]

--- a/pytorch_forecasting/data/timeseries/_timeseries_v2.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries_v2.py
@@ -78,24 +78,16 @@ class TimeSeries:
 
     Notes
     -----
-    This is a datatype, not a ``torch.utils.data.Dataset``. It implements
-    ``__len__`` and ``__getitem__`` so that a data module can iterate series out
-    of it, but it must not be handed to a ``DataLoader``.
-
     Columns that are not passed are inferred:
 
     * ``target`` is the last column of ``data``.
     * ``time`` is the first column not already used as ``group``, ``target``,
       ``static`` or ``weight``. If no such column exists, ``ValueError``
       is raised - pass ``time`` explicitly.
-    * ``num`` and ``cat`` are the dtype split (``"fi"`` numerical,
-      ``"Obc"`` categorical) over all columns that are not ``group``, ``time``
-      or ``weight``. Each is inferred only if not passed, so passing ``cat=[]``
-      still infers ``num``.
+    * ``num`` and ``cat`` are the dtype split over all columns that are not ``group``,
+      ``time`` or ``weight``.
 
-    Parameters are stored on same-named attributes exactly as passed; the
-    coerced and inferred values live on their underscored counterparts and are
-    reported by ``get_metadata``.
+    Parameters are stored on same-named attributes exactly as passed.
 
     Examples
     --------

--- a/pytorch_forecasting/data/timeseries/_timeseries_v2.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries_v2.py
@@ -1,31 +1,72 @@
 """
-Timeseries dataset - v2 prototype.
+Timeseries datatype.
 
 Beta version, experimental - use for testing but not in production.
 """
 
+from dataclasses import dataclass, fields, replace
 from warnings import warn
 
 import numpy as np
 import pandas as pd
 import torch
-from torch.utils.data import Dataset
 
 from pytorch_forecasting.utils._coerce import _coerce_to_list
 
 #######################################################################################
-# Disclaimer: This dataset class is still work in progress and experimental, please
+# Disclaimer: This datatype is still work in progress and experimental, please
 # use with care. This class is a basic skeleton of how the data-handling pipeline may
 # look like in the future.
-# This is the D1 layer that is a "Raw Dataset Layer" mainly for raw data ingestion
-# and turning the data to tensors.
+# This class is the standard input and output type of the v2 API - a data
+# frame plus its schema.
 # For now, this pipeline handles the simplest situation: The whole data can be loaded
 # into the memory.
 #######################################################################################
 
 
-class TimeSeries(Dataset):
-    """PyTorch Dataset for time series data stored in pandas DataFrame.
+@dataclass(frozen=True)
+class TimeSeriesMetadata:
+    """Schema of a :class:`TimeSeries`.
+
+    Parameters
+    ----------
+    cols : dict
+        ``{"y": [...], "x": [...], "st": [...]}``, names of the target, feature
+        and static columns. List order is the column order of the corresponding
+        tensor dimension, and must not be reordered.
+    col_type : dict
+        maps column name to ``"F"`` (numerical) or ``"C"`` (categorical).
+    col_known : dict
+        maps column name to ``"K"`` (known in the future) or ``"U"`` (unknown).
+    is_prediction : bool, default=False
+        whether the described object holds predictions rather than input data.
+    """
+
+    cols: dict[str, list[str]]
+    col_type: dict[str, str]
+    col_known: dict[str, str]
+    is_prediction: bool = False
+
+    def __getitem__(self, key):
+        if key not in self:
+            raise KeyError(key)
+        return getattr(self, key)
+
+    def get(self, key, default=None):
+        return getattr(self, key) if key in self else default
+
+    def keys(self):
+        return [f.name for f in fields(self)]
+
+    def __contains__(self, key):
+        return key in self.keys()
+
+    def __iter__(self):
+        return iter(self.keys())
+
+
+class TimeSeries:
+    """Time series data stored in a pandas DataFrame, plus its schema.
 
     Parameters
     ----------
@@ -62,7 +103,7 @@ class TimeSeries(Dataset):
         list of categorical variables in ``data``,
         list may also contain list of str, which are then grouped together
         (e.g. useful for product categories).
-    known : list of str, optional, default = all variables
+    known : list of str, optional, default = no variables
         list of variables that change over time and are known in the future,
         list may also contain list of str, which are then grouped together
         (e.g. useful for special days or promotion categories).
@@ -70,9 +111,39 @@ class TimeSeries(Dataset):
         list of variables that are not known in the future,
         list may also contain list of str, which are then grouped together
         (e.g. useful for weather categories).
-    static : list of str, optional, default = all variables not in known, unknown
+    static : list of str, optional, default = no variables
         list of variables that do not change over time,
         list may also contain list of str, which are then grouped together.
+
+    Notes
+    -----
+    This is a datatype, not a ``torch.utils.data.Dataset``. It implements
+    ``__len__`` and ``__getitem__`` so that a data module can iterate series out
+    of it, but it must not be handed to a ``DataLoader``.
+
+    Columns that are not passed are inferred:
+
+    * ``target`` is the last column of ``data``.
+    * ``time`` is the first column not already used as ``group``, ``target``,
+      ``static`` or ``weight``. If no such column exists, ``ValueError``
+      is raised - pass ``time`` explicitly.
+    * ``num`` and ``cat`` are the dtype split (``"fi"`` numerical,
+      ``"Obc"`` categorical) over all columns that are not ``group``, ``time``
+      or ``weight``. Each is inferred only if not passed, so passing ``cat=[]``
+      still infers ``num``.
+
+    Parameters are stored on same-named attributes exactly as passed; the
+    coerced and inferred values live on their underscored counterparts and are
+    reported by ``get_metadata``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from pytorch_forecasting.data.timeseries import TimeSeries
+    >>> df = pd.DataFrame({"time_idx": [0, 1, 2], "target": [1.0, 2.0, 3.0]})
+    >>> ts = TimeSeries(df)
+    >>> len(ts)
+    1
     """
 
     def __init__(
@@ -113,9 +184,7 @@ class TimeSeries(Dataset):
             UserWarning,
         )
 
-        super().__init__()
-
-        # handle defaults, coercion, and derived attributes
+        self._time = time
         self._target = _coerce_to_list(target)
         self._group = _coerce_to_list(group)
         self._num = _coerce_to_list(num)
@@ -124,17 +193,15 @@ class TimeSeries(Dataset):
         self._unknown = _coerce_to_list(unknown)
         self._static = _coerce_to_list(static)
 
+        self._infer_columns()
+
         self.feature_cols = [
             col
             for col in data.columns
-            if col not in [self.time] + self._group + [self.weight] + self._target
+            if col not in [self._time] + self._group + [self.weight] + self._target
         ]
         if self._group:
-            group_arg = (
-                self._group[0]
-                if isinstance(self._group, (list, tuple)) and len(self._group) == 1
-                else self._group
-            )
+            group_arg = self._group[0] if len(self._group) == 1 else self._group
             self._groups = self.data.groupby(group_arg).groups
             self._group_ids = list(self._groups.keys())
         else:
@@ -145,20 +212,45 @@ class TimeSeries(Dataset):
 
         self._prepare_metadata()
 
-        # overwrite __init__ params for upwards compatibility with AS PRs
-        # todo: should we avoid this and ensure classes are dataclass-like?
-        self.group = self._group
-        self.target = self._target
-        self.num = self._num
-        self.cat = self._cat
-        self.known = self._known
-        self.unknown = self._unknown
-        self.static = self._static
+    def _infer_columns(self):
+        """Fill in the column roles that were not passed by the user.
+
+        Writes to the underscored attributes only. A role counts as "not passed"
+        when its public attribute, which holds the unmodified argument, is None.
+
+        Raises
+        ------
+        ValueError
+            If no time column was passed and none can be inferred.
+        """
+        cols = list(self.data.columns)
+
+        if self.target is None:
+            self._target = [cols[-1]]
+
+        if self._time is None:
+            used = set(self._group + self._target + self._static + [self.weight])
+            self._time = next((col for col in cols if col not in used), None)
+            if self._time is None:
+                raise ValueError(
+                    f"Could not infer a time column: all columns of `data` "
+                    f"({cols}) are already used as group, target, static or "
+                    "weight. Pass `time` explicitly."
+                )
+
+        if self.num is None or self.cat is None:
+            index_like = set(self._group + [self._time, self.weight])
+            for col in cols:
+                if col in index_like:
+                    continue
+                kind = self.data[col].dtype.kind
+                if self.num is None and kind in "fi":
+                    self._num.append(col)
+                elif self.cat is None and kind in "Obc":
+                    self._cat.append(col)
 
     def _prepare_metadata(self):
         """Prepare metadata for the dataset.
-
-        The function returns metadata that contains:
 
         * ``cols``: dict { 'y': list[str], 'x': list[str], 'st': list[str] }
           Names of columns for y, x, and static features.
@@ -172,21 +264,16 @@ class TimeSeries(Dataset):
           maps column names to "K" (future known) or "U" (future unknown).
           Column names not occurring are assumed "K".
         """
-        self.metadata = {
-            "cols": {
+        all_cols = self._target + self.feature_cols + self._static
+        self.metadata = TimeSeriesMetadata(
+            cols={
                 "y": self._target,
                 "x": self.feature_cols,
                 "st": self._static,
             },
-            "col_type": {},
-            "col_known": {},
-        }
-
-        all_cols = self._target + self.feature_cols + self._static
-        for col in all_cols:
-            self.metadata["col_type"][col] = "C" if col in self._cat else "F"
-
-            self.metadata["col_known"][col] = "K" if col in self._known else "U"
+            col_type={col: "C" if col in self._cat else "F" for col in all_cols},
+            col_known={col: "K" if col in self._known else "U" for col in all_cols},
+        )
 
     def __len__(self) -> int:
         """Return number of time series in the dataset."""
@@ -221,21 +308,19 @@ class TimeSeries(Dataset):
         weights : torch.Tensor of shape (n_timepoints,), optional
             Only included if weights are not `None`.
         """
-        time = self.time
+        time = self._time
         feature_cols = self.feature_cols
-        _target = self._target
-        _known = self._known
-        _static = self._static
-        _group = self._group
-        _groups = self._groups
-        _group_ids = self._group_ids
+        target = self._target
+        known = self._known
+        static = self._static
+        group = self._group
         weight = self.weight
         data_future = self.data_future
 
-        group_id = _group_ids[index]
+        group_id = self._group_ids[index]
 
-        if _group:
-            mask = _groups[group_id]
+        if group:
+            mask = self._groups[group_id]
             data = self.data.loc[mask]
         else:
             data = self.data
@@ -244,7 +329,7 @@ class TimeSeries(Dataset):
 
         # PyTorch wants writeable arrays
         data_vals = data[time].to_numpy(copy=True)
-        data_tgt_vals = data[_target].to_numpy(copy=True)
+        data_tgt_vals = data[target].to_numpy(copy=True)
         data_feat_vals = data[feature_cols].to_numpy(copy=True)
 
         result = {
@@ -254,18 +339,14 @@ class TimeSeries(Dataset):
             "group": torch.tensor([self._group_to_idx[group_id]], dtype=torch.long),
             # PyTorch wants writeable arrays
             "st": torch.tensor(
-                data[_static].iloc[0].to_numpy(copy=True) if _static else []
+                data[static].iloc[0].to_numpy(copy=True) if static else []
             ),
             "cutoff_time": cutoff_time,
         }
 
         if data_future is not None:
-            if _group:
-                group_arg = (
-                    self._group[0]
-                    if isinstance(self._group, (list, tuple)) and len(self._group) == 1
-                    else self._group
-                )
+            if group:
+                group_arg = group[0] if len(group) == 1 else group
                 future_mask = self.data_future.groupby(group_arg).groups[group_id]
                 future_data = self.data_future.loc[future_mask]
             else:
@@ -279,7 +360,7 @@ class TimeSeries(Dataset):
 
             num_timepoints = len(combined_times)
             x_merged = np.full((num_timepoints, len(feature_cols)), np.nan)
-            y_merged = np.full((num_timepoints, len(_target)), np.nan)
+            y_merged = np.full((num_timepoints, len(target)), np.nan)
 
             current_time_indices = {t: i for i, t in enumerate(combined_times)}
             for i, t in enumerate(data_vals):
@@ -290,7 +371,7 @@ class TimeSeries(Dataset):
             for i, t in enumerate(data_fut_vals):
                 if t in current_time_indices:
                     idx = current_time_indices[t]
-                    for j, col in enumerate(_known):
+                    for j, col in enumerate(known):
                         if col in feature_cols:
                             feature_idx = feature_cols.index(col)
                             # PyTorch wants writeable arrays
@@ -330,15 +411,92 @@ class TimeSeries(Dataset):
 
         return result
 
-    def get_metadata(self) -> dict:
+    def get_metadata(self) -> TimeSeriesMetadata:
         """Return metadata about the dataset.
 
         Returns
         -------
-        Dict
-            Dictionary containing:
+        TimeSeriesMetadata
+            Schema containing:
             - cols: column names for y, x, and static features
             - col_type: mapping of columns to their types (F/C)
             - col_known: mapping of columns to their future known status (K/U)
+            - is_prediction: whether the data are predictions
         """
         return self.metadata
+
+    def to_pandas(self) -> pd.DataFrame:
+        """Return the data as a single data frame.
+
+        Returns
+        -------
+        pd.DataFrame
+            ``data``, with ``data_future`` appended if it was passed.
+        """
+        if self.data_future is None:
+            return self.data
+        return pd.concat([self.data, self.data_future], ignore_index=True)
+
+    @classmethod
+    def from_tensors(
+        cls,
+        tensors: dict[str, torch.Tensor],
+        metadata: TimeSeriesMetadata | dict | None = None,
+        group_starts: list[int] | None = None,
+        groups: np.ndarray | list | None = None,
+    ) -> "TimeSeries":
+        """Construct a ``TimeSeries`` of predictions from model output tensors.
+
+        Parameters
+        ----------
+        tensors : dict of str to torch.Tensor
+            must contain ``"y"``, of shape ``(n, n_targets)`` or ``(n,)``.
+            May contain ``"t"``, of shape ``(n,)``; defaults to ``arange(n)``.
+        metadata : TimeSeriesMetadata or dict, optional
+            schema the tensors were produced against; only ``cols["y"]`` is used,
+            to name the target columns. Without
+            usable names, targets are called ``y0``, ``y1``, ...
+        group_starts : list of int, optional
+            row offsets at which each series begins.
+        groups : np.ndarray or list, optional
+            per-row series labels. Takes precedence over ``group_starts``.
+            With neither, all rows are one series.
+
+        Returns
+        -------
+        TimeSeries
+            with columns ``_series``, ``_time_idx`` and one per target, and
+            ``metadata.is_prediction`` set to ``True``.
+        """
+        y = tensors["y"]
+        if y.ndim == 1:
+            y = y.unsqueeze(-1)
+        y = y.detach().cpu().numpy()
+        n_rows, n_targets = y.shape
+
+        target = list(metadata["cols"]["y"]) if metadata is not None else []
+        if len(target) != n_targets:
+            target = [f"y{i}" for i in range(n_targets)]
+
+        t = tensors.get("t")
+        if t is None:
+            t = np.arange(n_rows)
+        else:
+            t = t.detach().cpu().numpy().reshape(-1)
+
+        if groups is not None:
+            series = np.asarray(groups).reshape(-1)
+        elif group_starts is not None:
+            series = np.zeros(n_rows, dtype=int)
+            series[np.asarray(group_starts, dtype=int)[1:]] = 1
+            series = np.cumsum(series)
+        else:
+            series = np.zeros(n_rows, dtype=int)
+
+        df = pd.DataFrame({"_series": series, "_time_idx": t})
+        for i, col in enumerate(target):
+            df[col] = y[:, i]
+
+        obj = cls(df, time="_time_idx", target=target, group=["_series"])
+        obj.metadata = replace(obj.metadata, is_prediction=True)
+        return obj

--- a/pytorch_forecasting/data/timeseries/_timeseries_v2.py
+++ b/pytorch_forecasting/data/timeseries/_timeseries_v2.py
@@ -4,14 +4,16 @@ Timeseries datatype.
 Beta version, experimental - use for testing but not in production.
 """
 
-from dataclasses import dataclass, fields, replace
+from dataclasses import replace
 from warnings import warn
 
 import numpy as np
 import pandas as pd
 import torch
 
+from pytorch_forecasting.data._metadata import TimeSeriesMetadata
 from pytorch_forecasting.utils._coerce import _coerce_to_list
+from pytorch_forecasting.utils._validation import _check_column_names, _check_type
 
 #######################################################################################
 # Disclaimer: This datatype is still work in progress and experimental, please
@@ -22,47 +24,6 @@ from pytorch_forecasting.utils._coerce import _coerce_to_list
 # For now, this pipeline handles the simplest situation: The whole data can be loaded
 # into the memory.
 #######################################################################################
-
-
-@dataclass(frozen=True)
-class TimeSeriesMetadata:
-    """Schema of a :class:`TimeSeries`.
-
-    Parameters
-    ----------
-    cols : dict
-        ``{"y": [...], "x": [...], "st": [...]}``, names of the target, feature
-        and static columns. List order is the column order of the corresponding
-        tensor dimension, and must not be reordered.
-    col_type : dict
-        maps column name to ``"F"`` (numerical) or ``"C"`` (categorical).
-    col_known : dict
-        maps column name to ``"K"`` (known in the future) or ``"U"`` (unknown).
-    is_prediction : bool, default=False
-        whether the described object holds predictions rather than input data.
-    """
-
-    cols: dict[str, list[str]]
-    col_type: dict[str, str]
-    col_known: dict[str, str]
-    is_prediction: bool = False
-
-    def __getitem__(self, key):
-        if key not in self:
-            raise KeyError(key)
-        return getattr(self, key)
-
-    def get(self, key, default=None):
-        return getattr(self, key) if key in self else default
-
-    def keys(self):
-        return [f.name for f in fields(self)]
-
-    def __contains__(self, key):
-        return key in self.keys()
-
-    def __iter__(self):
-        return iter(self.keys())
 
 
 class TimeSeries:
@@ -193,6 +154,8 @@ class TimeSeries:
         self._unknown = _coerce_to_list(unknown)
         self._static = _coerce_to_list(static)
 
+        self._validate_data()
+        self._validate_columns()
         self._infer_columns()
 
         self.feature_cols = [
@@ -211,6 +174,52 @@ class TimeSeries:
         self._group_to_idx = {gid: i for i, gid in enumerate(self._group_ids)}
 
         self._prepare_metadata()
+
+    def _validate_data(self):
+        """Check the data frames, before anything indexes into them.
+
+        Raises
+        ------
+        TypeError
+            If ``data`` or ``data_future`` is not a ``pandas.DataFrame``.
+        ValueError
+            If ``data`` has no columns.
+        """
+        _check_type(self.data, pd.DataFrame, "data")
+        _check_type(self.data_future, pd.DataFrame, "data_future", allow_none=True)
+
+        if len(self.data.columns) == 0:
+            raise ValueError("`data` has no columns.")
+
+    def _validate_columns(self):
+        """Check that every column named by the user exists in ``data``.
+
+        Raises
+        ------
+        ValueError
+            If a named column is not in ``data``, or if the same column is
+            given as both known and unknown.
+        """
+        _check_column_names(
+            {
+                "time": self._time,
+                "target": self._target,
+                "group": self._group,
+                "weight": self.weight,
+                "num": self._num,
+                "cat": self._cat,
+                "known": self._known,
+                "unknown": self._unknown,
+                "static": self._static,
+            },
+            self.data.columns,
+        )
+
+        both = set(self._known) & set(self._unknown)
+        if both:
+            raise ValueError(
+                f"columns given as both `known` and `unknown`: {sorted(both)}."
+            )
 
     def _infer_columns(self):
         """Fill in the column roles that were not passed by the user.
@@ -467,12 +476,37 @@ class TimeSeries:
         TimeSeries
             with columns ``_series``, ``_time_idx`` and one per target, and
             ``metadata.is_prediction`` set to ``True``.
+
+        Raises
+        ------
+        ValueError
+            If ``"y"`` is missing, is not 1- or 2-dimensional, or if ``t`` or
+            ``groups`` does not have one entry per row of ``y``.
         """
+        if "y" not in tensors:
+            raise ValueError(
+                '`tensors` must contain "y", the predicted values. Got keys: '
+                f"{sorted(tensors)}."
+            )
+
         y = tensors["y"]
         if y.ndim == 1:
             y = y.unsqueeze(-1)
+        elif y.ndim != 2:
+            raise ValueError(
+                "`tensors['y']` must have shape (n,) or (n, n_targets), got "
+                f"shape {tuple(y.shape)}. Reshape it first, e.g. "
+                "y.reshape(-1, 1)."
+            )
         y = y.detach().cpu().numpy()
         n_rows, n_targets = y.shape
+
+        for name, value in (("t", tensors.get("t")), ("groups", groups)):
+            if value is not None and len(value) != n_rows:
+                raise ValueError(
+                    f"`{name}` must have one entry per row of `y` ({n_rows}), "
+                    f"got {len(value)}."
+                )
 
         target = list(metadata["cols"]["y"]) if metadata is not None else []
         if len(target) != n_targets:

--- a/pytorch_forecasting/models/samformer/_samformer_v2.py
+++ b/pytorch_forecasting/models/samformer/_samformer_v2.py
@@ -67,7 +67,9 @@ class Samformer(BaseModel):
             lr_scheduler_params=lr_scheduler_params,
         )
 
-        self.save_hyperparameters(ignore=["loss", "logging_metrics", "optimizer"])
+        self.save_hyperparameters(
+            ignore=["loss", "logging_metrics", "optimizer", "metadata"]
+        )
         self.metadata = metadata
         self.n_quantiles = 1
 

--- a/pytorch_forecasting/utils/_validation.py
+++ b/pytorch_forecasting/utils/_validation.py
@@ -1,0 +1,125 @@
+"""Validation checks."""
+
+
+def _check_type(value, expected, name, allow_none=False, hint=""):
+    """Raise ``TypeError`` unless ``value`` is an instance of ``expected``.
+
+    Parameters
+    ----------
+    value : object
+        The value to check.
+    expected : type or tuple of type
+        Acceptable type(s).
+    name : str
+        Parameter name, quoted in the message.
+    allow_none : bool, default=False
+        Whether ``None`` is acceptable.
+    hint : str, default=""
+        Sentence appended to the message, telling the user what to do.
+    """
+    if value is None and allow_none:
+        return
+    if isinstance(value, expected):
+        return
+
+    types = expected if isinstance(expected, tuple) else (expected,)
+    wanted = " or ".join(t.__name__ for t in types)
+    raise TypeError(
+        f"`{name}` must be {wanted}, got {type(value).__name__}."
+        + (f" {hint}" if hint else "")
+    )
+
+
+def _check_positive(value, name, allow_none=False):
+    """Raise ``ValueError`` unless ``value`` is at least 1.
+
+    Parameters
+    ----------
+    value : int or None
+        The value to check.
+    name : str
+        Parameter name, quoted in the message.
+    allow_none : bool, default=False
+        Whether ``None`` is acceptable.
+    """
+    if value is None and allow_none:
+        return
+    if value < 1:
+        raise ValueError(f"`{name}` must be at least 1, got {value}.")
+
+
+def _check_within(value, upper, name, upper_name, allow_none=True):
+    """Raise ``ValueError`` unless ``value`` lies in ``[1, upper]``.
+
+    Parameters
+    ----------
+    value : int or None
+        The value to check.
+    upper : int
+        Inclusive upper bound.
+    name, upper_name : str
+        Parameter names, quoted in the message.
+    allow_none : bool, default=True
+        Whether ``None`` is acceptable.
+    """
+    if value is None and allow_none:
+        return
+    if value < 1 or value > upper:
+        raise ValueError(
+            f"`{name}` must be between 1 and `{upper_name}` ({upper}), " f"got {value}."
+        )
+
+
+def _check_fractions(value, name, lengths=(2, 3)):
+    """Raise ``ValueError`` unless ``value`` is fractions summing to at most 1.
+
+    Parameters
+    ----------
+    value : sequence of float
+        The value to check.
+    name : str
+        Parameter name, quoted in the message.
+    lengths : tuple of int, default=(2, 3)
+        Acceptable numbers of entries.
+    """
+    if len(value) not in lengths or any(fraction < 0 for fraction in value):
+        wanted = " or ".join(str(length) for length in lengths)
+        raise ValueError(
+            f"`{name}` must be {wanted} non-negative fractions, got {value!r}."
+        )
+    if sum(value) > 1 + 1e-6:
+        raise ValueError(
+            f"`{name}` must sum to at most 1, got {value!r} "
+            f"summing to {sum(value)}."
+        )
+
+
+def _check_column_names(named, allowed, allowed_label="columns of `data`", hint=""):
+    """Raise ``ValueError`` if any parameter names a column that does not exist.
+
+    Parameters
+    ----------
+    named : dict of str to (str, iterable of str, or None)
+        Maps parameter name to the column name(s) it requested. ``None`` is
+        skipped and a bare string is treated as a single name.
+    allowed : iterable of str
+        Column names that exist.
+    allowed_label : str, default="columns of `data`"
+        How ``allowed`` is described in the message.
+    hint : str, default=""
+        Sentence appended to the message.
+    """
+    allowed = list(allowed)
+    for param, requested in named.items():
+        if requested is None:
+            continue
+        if isinstance(requested, str):
+            requested = [requested]
+
+        unknown = [col for col in requested if col not in allowed]
+        if unknown:
+            raise ValueError(
+                f"`{param}` names {allowed_label} that do not exist: "
+                f"{unknown}. Available: {sorted(allowed)}."
+                + (f" {hint}" if hint else "")
+            )

--- a/tests/test_data/test_data_module.py
+++ b/tests/test_data/test_data_module.py
@@ -100,7 +100,6 @@ def test_init(sample_timeseries_data):
     assert dm.batch_size == 8
     assert dm.train_val_test_split == (0.7, 0.15, 0.15)
 
-    assert isinstance(dm.time_series_metadata, dict)
     assert "cols" in dm.time_series_metadata
 
 

--- a/tests/test_data/test_data_module.py
+++ b/tests/test_data/test_data_module.py
@@ -15,11 +15,20 @@ from pytorch_forecasting.data.encoders import EncoderNormalizer, TorchNormalizer
 from pytorch_forecasting.data.timeseries import TimeSeries
 
 
-@pytest.fixture
-def sample_timeseries_data():
-    """Create a sample time series dataset with only numerical values."""
-    num_groups = 10
-    seq_length = 100
+def make_timeseries(offset=0.0, scale=1.0, seed=None, num_groups=10, seq_length=100):
+    """Create a sample time series dataset with only numerical values.
+
+    Parameters
+    ----------
+    offset, scale : float, default=0.0, 1.0
+        Shift and spread applied to the target, so that two series with
+        distinguishable distributions can be built.
+    seed : int, optional
+        Seed for the random parts, for tests that need reproducible data.
+    num_groups, seq_length : int, default=10, 100
+        Number of series, and time steps per series.
+    """
+    rng = np.random.default_rng(seed)
 
     groups = []
     times = []
@@ -34,13 +43,13 @@ def sample_timeseries_data():
             groups.append(g)
             times.append(pd.Timestamp("2020-01-01") + pd.Timedelta(days=t))
 
-            value = 10 + 0.1 * t + 5 * np.sin(t / 10) + g * 2 + np.random.normal(0, 1)
-            values.append(value)
+            value = 10 + 0.1 * t + 5 * np.sin(t / 10) + g * 2 + rng.normal(0, 1)
+            values.append(value * scale + offset)
 
-            categorical_feature.append(np.random.choice([0, 1, 2]))
+            categorical_feature.append(rng.choice([0, 1, 2]))
 
-            continuous_feature1.append(np.random.normal(g, 1))
-            continuous_feature2.append(value * 0.5 + np.random.normal(0, 0.5))
+            continuous_feature1.append(rng.normal(g, 1))
+            continuous_feature2.append(value * 0.5 + rng.normal(0, 0.5))
 
             known_future.append(t % 7)
 
@@ -56,7 +65,7 @@ def sample_timeseries_data():
         }
     )
 
-    time_series = TimeSeries(
+    return TimeSeries(
         data=df,
         time="time",
         target="target",
@@ -66,14 +75,18 @@ def sample_timeseries_data():
         known=["known_future"],
     )
 
-    return time_series
+
+@pytest.fixture
+def sample_timeseries_data():
+    """Create a sample time series dataset with only numerical values."""
+    return make_timeseries()
 
 
 @pytest.fixture
 def data_module(sample_timeseries_data):
     """Create a data module instance."""
     dm = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=sample_timeseries_data,
+        time_series=sample_timeseries_data,
         max_encoder_length=24,
         max_prediction_length=12,
         batch_size=4,
@@ -87,7 +100,7 @@ def test_init(sample_timeseries_data):
 
     Verifies hyperparameter assignment and basic time_series_metadata creation."""
     dm = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=sample_timeseries_data,
+        time_series=sample_timeseries_data,
         max_encoder_length=24,
         max_prediction_length=12,
         batch_size=8,
@@ -334,7 +347,7 @@ def test_variable_encoder_lengths(sample_timeseries_data):
 
     Ensures random length behavior is respected and functional."""
     dm = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=sample_timeseries_data,
+        time_series=sample_timeseries_data,
         max_encoder_length=24,
         min_encoder_length=12,
         max_prediction_length=12,
@@ -398,7 +411,7 @@ def test_with_static_features():
     )
 
     dm = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=ts,
+        time_series=ts,
         max_encoder_length=2,
         max_prediction_length=1,
         batch_size=2,
@@ -426,7 +439,7 @@ def test_with_static_features():
 def test_different_train_val_test_split(sample_timeseries_data):
     """Test with different train/val/test split ratios."""
     dm = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=sample_timeseries_data,
+        time_series=sample_timeseries_data,
         max_encoder_length=24,
         max_prediction_length=12,
         batch_size=4,
@@ -479,7 +492,7 @@ def test_multivariate_target(normalizer_list):
         num=["feature1", "feature2"],
     )
     dm = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=ts,
+        time_series=ts,
         max_encoder_length=10,
         max_prediction_length=5,
         batch_size=4,
@@ -541,7 +554,7 @@ def test_multivariate_target_scale(normalizer_list):
         num=["feature1"],
     )
     dm = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=ts,
+        time_series=ts,
         max_encoder_length=10,
         max_prediction_length=5,
         batch_size=4,
@@ -594,7 +607,7 @@ def test_target_normalizers(sample_timeseries_data, normalizer):
     - Target is actually scaled.
     """
     dm_no_norm = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=sample_timeseries_data,
+        time_series=sample_timeseries_data,
         max_encoder_length=15,
         max_prediction_length=5,
         batch_size=4,
@@ -603,7 +616,7 @@ def test_target_normalizers(sample_timeseries_data, normalizer):
     dm_no_norm.setup(stage="fit")
 
     dm_with_norm = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=sample_timeseries_data,
+        time_series=sample_timeseries_data,
         max_encoder_length=15,
         max_prediction_length=5,
         batch_size=4,
@@ -652,7 +665,7 @@ def test_feature_scaling(sample_timeseries_data, scaler_type):
     }
 
     dm_no_scale = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=sample_timeseries_data,
+        time_series=sample_timeseries_data,
         max_encoder_length=24,
         max_prediction_length=12,
         batch_size=4,
@@ -661,7 +674,7 @@ def test_feature_scaling(sample_timeseries_data, scaler_type):
     dm_no_scale.setup(stage="fit")
 
     dm_with_scale = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=sample_timeseries_data,
+        time_series=sample_timeseries_data,
         max_encoder_length=24,
         max_prediction_length=12,
         batch_size=4,
@@ -706,7 +719,7 @@ def test_group_normalizer_uses_groups():
         num=["feature1"],
     )
     dm = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=ts,
+        time_series=ts,
         max_encoder_length=10,
         max_prediction_length=5,
         batch_size=4,
@@ -725,3 +738,60 @@ def test_group_normalizer_uses_groups():
         mean1 = target1["target"].mean().abs()
         assert mean0 < 1.0, "Group 0 target should be normalized near 0"
         assert mean1 < 1.0, "Group 1 target should be normalized near 0"
+
+
+def test_with_data_does_not_refit_transforms():
+    """Prediction data must be scaled with the statistics from training."""
+    train = make_timeseries(seed=0)
+    shifted = make_timeseries(offset=1000.0, seed=1)
+
+    dm = EncoderDecoderTimeSeriesDataModule(
+        time_series=train,
+        max_encoder_length=10,
+        max_prediction_length=5,
+        batch_size=4,
+        target_normalizer="auto",
+    )
+    dm.setup("fit")
+
+    x_train, _ = next(iter(dm.train_dataloader()))
+    assert abs(float(x_train["target_past"].mean())) < 5
+
+    predict_dm = dm.with_data(shifted)
+    predict_dm.setup("predict")
+    scaled = float(next(iter(predict_dm.predict_dataloader()))[0]["target_past"].mean())
+
+    assert 20 < scaled < 500, (
+        f"target_past mean {scaled:.1f}: expected the training statistics to be "
+        "reused; near 0 means they were refitted on the new data, near 1000 "
+        "means they were lost"
+    )
+
+
+def test_data_less_module_becomes_usable_with_data():
+    """A module built without data is a configuration, usable once given data."""
+    config = EncoderDecoderTimeSeriesDataModule(
+        max_encoder_length=10,
+        max_prediction_length=5,
+        batch_size=4,
+    )
+
+    dm = config.with_data(make_timeseries(seed=0))
+    dm.setup("fit")
+    x, y = next(iter(dm.train_dataloader()))
+
+    # the configuration carried over: window lengths shape the batch
+    assert x["encoder_cont"].shape[0] == 4
+    assert x["encoder_cont"].shape[1] == 10
+    assert x["decoder_cont"].shape[1] == 5
+
+
+def test_data_less_module_reports_what_is_missing():
+    """Operations needing data must ask for it."""
+    config = EncoderDecoderTimeSeriesDataModule(max_encoder_length=10)
+
+    with pytest.raises(RuntimeError, match="without data"):
+        config.metadata
+
+    with pytest.raises(RuntimeError, match="without data"):
+        config.setup("fit")

--- a/tests/test_data/test_timeseries_v2.py
+++ b/tests/test_data/test_timeseries_v2.py
@@ -2,8 +2,9 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+from torch.utils.data import Dataset
 
-from pytorch_forecasting.data.timeseries import TimeSeries
+from pytorch_forecasting.data.timeseries import TimeSeries, TimeSeriesMetadata
 
 
 @pytest.fixture
@@ -51,7 +52,7 @@ def test_init_basic(sample_data):
     ts = TimeSeries(data=sample_data, time="timestamp", target="target_value")
 
     assert ts.time == "timestamp"
-    assert ts.target == ["target_value"]
+    assert ts.metadata["cols"]["y"] == ["target_value"]
     assert len(ts.feature_cols) == 6  # All columns except timestamp, target_value
     assert len(ts) == 1  # Single group by default
 
@@ -92,107 +93,61 @@ def test_init_with_features_categorization(sample_data):
     assert ts.metadata["col_type"]["feature2"] == "F"
 
 
-def test_init_with_known_unknown(sample_data):
-    """Test known and unknown features classification.
+def test_infer_target_and_time(sample_data):
+    """Test the minimal call, where every column role is inferred.
 
-    Checks if the known and unknown feature categorization is correctly set
-    and stored in metadata."""
+    ``TimeSeries(data)`` is the documented minimal usage: the target defaults to
+    the last column and the time to the first unused one."""
+    ts = TimeSeries(data=sample_data)
+
+    assert ts.metadata["cols"]["y"] == ["static_feat"]  # last column
+    assert ts._time == "timestamp"  # first column not otherwise used
+
+
+def test_infer_time_skips_used_columns(sample_data):
+    """Test that time inference skips columns already used in another role."""
     ts = TimeSeries(
         data=sample_data,
-        time="timestamp",
         target="target_value",
-        known=["feature1"],
-        unknown=["feature2", "feature3"],
-    )
-
-    assert ts.known == ["feature1"]
-    assert ts.unknown == ["feature2", "feature3"]
-    assert ts.metadata["col_known"]["feature1"] == "K"
-    assert ts.metadata["col_known"]["feature2"] == "U"
-
-
-def test_init_with_weight(sample_data):
-    """Test initialization with weight parameter.
-
-    Verifies that the weight column is stored correctly and excluded
-    from the feature columns."""
-    ts = TimeSeries(
-        data=sample_data, time="timestamp", target="target_value", weight="weight"
-    )
-
-    assert ts.weight == "weight"
-    assert "weight" not in ts.feature_cols
-
-
-def test_getitem_basic(sample_data):
-    """Test __getitem__ with basic configuration.
-
-    Checks the output structure of a single time series without grouping,
-    ensuring x, y are tensors of correct shapes."""
-    ts = TimeSeries(data=sample_data, time="timestamp", target="target_value")
-
-    result = ts[0]
-    assert torch.is_tensor(result["y"])
-    assert torch.is_tensor(result["x"])
-    assert "t" in result
-    assert "cutoff_time" in result
-    assert len(result["y"]) == 10  # 10 data points
-    assert result["y"].shape == (10, 1)  # One target variable
-    assert result["x"].shape[1] == 6  # Six feature columns
-
-
-def test_getitem_with_groups(sample_data):
-    """Test __getitem__ with groups parameter.
-
-    Verifies the per-group access using index and checks that each group
-    has the correct number of time steps."""
-    ts = TimeSeries(
-        data=sample_data, time="timestamp", target="target_value", group=["group_id"]
-    )
-
-    # group (1)
-    result_g1 = ts[0]
-    assert len(result_g1["t"]) == 5  # 5 data points in group 1
-
-    # group (2)
-    result_g2 = ts[1]
-    assert len(result_g2["t"]) == 5  # 5 data points in group 2
-
-
-def test_getitem_with_static(sample_data):
-    """Test __getitem__ with static features.
-
-    Ensures static features are included in the output and correctly
-    mapped per group."""
-    ts = TimeSeries(
-        data=sample_data,
-        time="timestamp",
-        target="target_value",
-        group=["group_id"],
+        group=["timestamp"],
         static=["static_feat"],
+        weight="weight",
     )
 
-    result_g1 = ts[0]
-    result_g2 = ts[1]
-
-    assert torch.is_tensor(result_g1["st"])
-    assert result_g1["st"].item() == 10  # Static feature for group 1
-    assert result_g2["st"].item() == 20  # Static feature for group 2
+    assert ts._time == "feature1"
 
 
-def test_getitem_with_weight(sample_data):
-    """Test __getitem__ with weight parameter.
+def test_infer_num_cat_from_dtypes():
+    """Test the dtype split used when num and cat are not given.
 
-    Validates that weights are correctly returned in the output and have the
-    expected length and type."""
-    ts = TimeSeries(
-        data=sample_data, time="timestamp", target="target_value", weight="weight"
+    Numeric columns become ``"F"`` and object/categorical ones ``"C"``, for
+    every column that is not group, time or weight."""
+    df = pd.DataFrame(
+        {
+            "time_idx": [0, 1, 2],
+            "value": [1.0, 2.0, 3.0],
+            "category": ["a", "b", "a"],
+            "target": [4.0, 5.0, 6.0],
+        }
     )
 
-    result = ts[0]
-    assert "weights" in result
-    assert torch.is_tensor(result["weights"])
-    assert len(result["weights"]) == 10
+    ts = TimeSeries(data=df, time="time_idx", target="target")
+
+    assert ts.metadata["col_type"]["value"] == "F"
+    assert ts.metadata["col_type"]["target"] == "F"
+    assert ts.metadata["col_type"]["category"] == "C"
+
+
+def test_infer_num_only_when_cat_given():
+    """Test that num and cat are inferred independently.
+
+    Passing ``cat=[]`` must not suppress inference of ``num``."""
+    df = pd.DataFrame({"time_idx": [0, 1], "value": [1.0, 2.0], "target": [3.0, 4.0]})
+
+    ts = TimeSeries(data=df, time="time_idx", target="target", cat=[])
+
+    assert ts._num == ["value", "target"]
+    assert ts._cat == []
 
 
 def test_with_future_data(sample_data, future_data):
@@ -339,61 +294,70 @@ def test_empty_groups():
     assert len(ts) == 1  # Only one group
 
 
-def test_metadata_structure(sample_data):
-    """Test the structure of metadata.
-
-    Ensures the metadata dictionary includes the expected keys and
-    correct mappings of feature roles."""
+def test_to_pandas_with_future_data(sample_data, future_data):
+    """Test that to_pandas appends the future frame when there is one."""
     ts = TimeSeries(
         data=sample_data,
+        data_future=future_data,
         time="timestamp",
         target="target_value",
-        num=["feature1", "feature2", "feature3"],
-        cat=[],  # No categorical features
-        static=["static_feat"],
-        known=["feature1"],
-        unknown=["feature2", "feature3"],
+        group=["group_id"],
     )
 
-    metadata = ts.get_metadata()
-
-    assert "cols" in metadata
-    assert "col_type" in metadata
-    assert "col_known" in metadata
-
-    assert metadata["cols"]["y"] == ["target_value"]
-    assert set(metadata["cols"]["x"]) == {
-        "feature1",
-        "feature2",
-        "feature3",
-        "group_id",
-        "weight",
-        "static_feat",
-    }
-    assert metadata["cols"]["st"] == ["static_feat"]
-
-    assert metadata["col_type"]["feature1"] == "F"
-    assert metadata["col_type"]["feature2"] == "F"
-
-    assert metadata["col_known"]["feature1"] == "K"
-    assert metadata["col_known"]["feature2"] == "U"
+    df = ts.to_pandas()
+    assert len(df) == len(sample_data) + len(future_data)
 
 
-def test_group_index():
-    """Ensure group indices are contiguous and deterministic.
+def test_from_tensors_minimal():
+    """Test lifting bare model output back into a TimeSeries.
 
-    Regression guard: older code used `hash(str(group_id))`, which could yield
-    non-contiguous ids and unstable mappings.
-    """
+    This is the output path: a model returns tensors, and they must become the
+    same type the user passed in."""
+    preds = TimeSeries.from_tensors({"y": torch.arange(6.0)})
 
-    data = []
-    for gid in ["aa", "bb", "cc", "dd"]:
-        for t in range(3):
-            data.append({"gid": gid, "time": t, "target": t})
+    df = preds.to_pandas()
+    assert list(df.columns) == ["_series", "_time_idx", "y0"]
+    assert list(df["_time_idx"]) == list(range(6))
+    assert preds.metadata.is_prediction
+    assert len(preds) == 1  # one series
 
-    df = pd.DataFrame(data)
-    ts = TimeSeries(data=df, time="time", target="target", group=["gid"])
 
-    group_indices = [int(ts[i]["group"][0]) for i in range(len(ts))]
+def test_from_tensors_names_targets_from_metadata(sample_data):
+    """Test that target names carry over from the schema they were produced by."""
+    md = TimeSeries(
+        data=sample_data, time="timestamp", target="target_value"
+    ).get_metadata()
 
-    assert group_indices == list(range(len(ts)))
+    preds = TimeSeries.from_tensors({"y": torch.zeros(4, 1)}, metadata=md)
+
+    assert preds.target == ["target_value"]
+
+
+def test_from_tensors_ignores_mismatched_metadata(sample_data):
+    """Test the fallback when the last axis does not hold targets.
+
+    In quantile mode the last axis holds quantiles, not targets, so the target
+    names must not be used to label it."""
+    md = TimeSeries(
+        data=sample_data, time="timestamp", target="target_value"
+    ).get_metadata()
+
+    preds = TimeSeries.from_tensors({"y": torch.zeros(4, 3)}, metadata=md)
+
+    assert preds.target == ["y0", "y1", "y2"]
+
+
+def test_from_tensors_with_groups():
+    """Test per-row series labels."""
+    preds = TimeSeries.from_tensors({"y": torch.zeros(6)}, groups=[0, 0, 0, 1, 1, 1])
+
+    assert len(preds) == 2
+
+
+def test_from_tensors_with_time():
+    """Test that a supplied time index is used instead of a positional one."""
+    preds = TimeSeries.from_tensors(
+        {"y": torch.zeros(3), "t": torch.tensor([10, 11, 12])}
+    )
+
+    assert list(preds.to_pandas()["_time_idx"]) == [10, 11, 12]

--- a/tests/test_data/test_timeseries_v2.py
+++ b/tests/test_data/test_timeseries_v2.py
@@ -2,9 +2,8 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
-from torch.utils.data import Dataset
 
-from pytorch_forecasting.data.timeseries import TimeSeries, TimeSeriesMetadata
+from pytorch_forecasting.data.timeseries import TimeSeries
 
 
 @pytest.fixture
@@ -91,30 +90,6 @@ def test_init_with_features_categorization(sample_data):
     assert ts.static == ["static_feat"]
     assert ts.metadata["col_type"]["feature1"] == "F"
     assert ts.metadata["col_type"]["feature2"] == "F"
-
-
-def test_infer_target_and_time(sample_data):
-    """Test the minimal call, where every column role is inferred.
-
-    ``TimeSeries(data)`` is the documented minimal usage: the target defaults to
-    the last column and the time to the first unused one."""
-    ts = TimeSeries(data=sample_data)
-
-    assert ts.metadata["cols"]["y"] == ["static_feat"]  # last column
-    assert ts._time == "timestamp"  # first column not otherwise used
-
-
-def test_infer_time_skips_used_columns(sample_data):
-    """Test that time inference skips columns already used in another role."""
-    ts = TimeSeries(
-        data=sample_data,
-        target="target_value",
-        group=["timestamp"],
-        static=["static_feat"],
-        weight="weight",
-    )
-
-    assert ts._time == "feature1"
 
 
 def test_infer_num_cat_from_dtypes():
@@ -259,21 +234,6 @@ def test_different_future_groups(sample_data):
     assert 3 not in ts._group_ids
 
 
-def test_multiple_targets(sample_data):
-    """Test handling of multiple target variables.
-
-    Verifies that multiple target columns are handled and returned
-    as the correct shape in the output."""
-    sample_data["target_value2"] = np.cos(np.arange(10)) + 5
-
-    ts = TimeSeries(
-        data=sample_data, time="timestamp", target=["target_value", "target_value2"]
-    )
-
-    result = ts[0]
-    assert result["y"].shape == (10, 2)  # Two target variables
-
-
 def test_empty_groups():
     """Test handling of empty groups.
 
@@ -306,58 +266,3 @@ def test_to_pandas_with_future_data(sample_data, future_data):
 
     df = ts.to_pandas()
     assert len(df) == len(sample_data) + len(future_data)
-
-
-def test_from_tensors_minimal():
-    """Test lifting bare model output back into a TimeSeries.
-
-    This is the output path: a model returns tensors, and they must become the
-    same type the user passed in."""
-    preds = TimeSeries.from_tensors({"y": torch.arange(6.0)})
-
-    df = preds.to_pandas()
-    assert list(df.columns) == ["_series", "_time_idx", "y0"]
-    assert list(df["_time_idx"]) == list(range(6))
-    assert preds.metadata.is_prediction
-    assert len(preds) == 1  # one series
-
-
-def test_from_tensors_names_targets_from_metadata(sample_data):
-    """Test that target names carry over from the schema they were produced by."""
-    md = TimeSeries(
-        data=sample_data, time="timestamp", target="target_value"
-    ).get_metadata()
-
-    preds = TimeSeries.from_tensors({"y": torch.zeros(4, 1)}, metadata=md)
-
-    assert preds.target == ["target_value"]
-
-
-def test_from_tensors_ignores_mismatched_metadata(sample_data):
-    """Test the fallback when the last axis does not hold targets.
-
-    In quantile mode the last axis holds quantiles, not targets, so the target
-    names must not be used to label it."""
-    md = TimeSeries(
-        data=sample_data, time="timestamp", target="target_value"
-    ).get_metadata()
-
-    preds = TimeSeries.from_tensors({"y": torch.zeros(4, 3)}, metadata=md)
-
-    assert preds.target == ["y0", "y1", "y2"]
-
-
-def test_from_tensors_with_groups():
-    """Test per-row series labels."""
-    preds = TimeSeries.from_tensors({"y": torch.zeros(6)}, groups=[0, 0, 0, 1, 1, 1])
-
-    assert len(preds) == 2
-
-
-def test_from_tensors_with_time():
-    """Test that a supplied time index is used instead of a positional one."""
-    preds = TimeSeries.from_tensors(
-        {"y": torch.zeros(3), "t": torch.tensor([10, 11, 12])}
-    )
-
-    assert list(preds.to_pandas()["_time_idx"]) == [10, 11, 12]

--- a/tests/test_models/test_tft_v2.py
+++ b/tests/test_models/test_tft_v2.py
@@ -311,7 +311,7 @@ def timeseries_obj_for_test(sample_pandas_data_for_test):
 def data_module_for_test(timeseries_obj_for_test):
     """Initialize and sets up an EncoderDecoderTimeSeriesDataModule."""
     dm = EncoderDecoderTimeSeriesDataModule(
-        time_series_dataset=timeseries_obj_for_test,
+        time_series=timeseries_obj_for_test,
         batch_size=BATCH_SIZE_TEST,
         max_encoder_length=MAX_ENCODER_LENGTH_TEST,
         max_prediction_length=MAX_PREDICTION_LENGTH_TEST,

--- a/tests/test_models/test_timexer_v2.py
+++ b/tests/test_models/test_timexer_v2.py
@@ -176,7 +176,7 @@ def basic_timeseries_dataset(sample_multivariate_data):
 def basic_tslib_data_module(basic_timeseries_dataset):
     """Create a basic TslibDataModule for testing."""
     return TslibDataModule(
-        time_series_dataset=basic_timeseries_dataset,
+        time_series=basic_timeseries_dataset,
         batch_size=2,
         context_length=12,
         prediction_length=8,


### PR DESCRIPTION
Stacks on #2410 (and #2313 in coming commits FYI @Faakhir30 )
Also see #2407, #2398

This PR is aimed at `v2-dev` instead of `main`, so that we dont break current user code until this design is complete and stable. See #2407 for details. So I had to update the branch target in the workflows for the tests to run (which might fail due to the changes)

## Note
The tutorials will fail for sure, will update the notebook in one of the branchs stacked over this PR.
Still need to add the `Forecaster` and tests - will add the notebook and docs changes on the upcoming branches as the vignette is incomplete without `forecaster` which is not in this PR.


## Changes
- All metadata dataclasses (like `EncDecDataModuleMetadata`, `TimeSeriesMetadata` etc) are added to `_metadata.py`
- a new util for validation checks in `utils/_validation`
- Update the tests (needed to make some changes like updating the param name) in standalone model tests for v2 as well
   - Also had to add `metadata` in `ignore` of `save_hyperparameters` of `Samformer`. See [this comment](https://github.com/sktime/pytorch-forecasting/pull/2423#discussion_r4045987106)
- Updates to datamodules (currently duplicate in both classes)
  - Uses `EncDecDataModuleMetadata` (in case of `EncoderDecoderTImeSeriesDatamodule`) and tslib dm has its own metadata dataclass.
  - Data validation.
  - `with_data` method to create a new dm instance using the already present params (like already fitted scalers - only to create the transformed data).
     - Like creating a datamodule for prediction where we need the scalers from the datamodule we used for fitting. 
     - Also useful to create the class "without data" which arrives at `forecaster.fit()` while we accept the dm class in `__init__` of the `forecaster`. So, the class is actually just empty at this point without data.  